### PR TITLE
Issue #29 - Compact aliens page and web data-source fixes

### DIFF
--- a/StarWin.Infrastructure/DependencyInjection.cs
+++ b/StarWin.Infrastructure/DependencyInjection.cs
@@ -43,6 +43,7 @@ public static class DependencyInjection
 
         services.AddDbContext<StarWinDbContext>(
             ConfigureDatabase,
+            contextLifetime: ServiceLifetime.Scoped,
             optionsLifetime: ServiceLifetime.Singleton);
         services.AddDbContextFactory<StarWinDbContext>(ConfigureDatabase);
 

--- a/StarWin.Infrastructure/Services/StarWinEntityNameService.cs
+++ b/StarWin.Infrastructure/Services/StarWinEntityNameService.cs
@@ -5,7 +5,7 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinEntityNameService(StarWinDbContext dbContext) : IStarWinEntityNameService
+public sealed class StarWinEntityNameService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinEntityNameService
 {
     public async Task<string> SaveNameAsync(
         EntityNoteTargetKind targetKind,
@@ -13,6 +13,7 @@ public sealed class StarWinEntityNameService(StarWinDbContext dbContext) : IStar
         string name,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var normalizedName = name.Trim();
         if (string.IsNullOrWhiteSpace(normalizedName))
         {

--- a/StarWin.Infrastructure/Services/StarWinEntityNoteService.cs
+++ b/StarWin.Infrastructure/Services/StarWinEntityNoteService.cs
@@ -5,13 +5,14 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinEntityNoteService(StarWinDbContext dbContext) : IStarWinEntityNoteService
+public sealed class StarWinEntityNoteService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinEntityNoteService
 {
     public async Task<EntityNote?> GetNoteAsync(
         EntityNoteTargetKind targetKind,
         int targetId,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         return await dbContext.EntityNotes
             .AsNoTracking()
             .FirstOrDefaultAsync(
@@ -25,6 +26,7 @@ public sealed class StarWinEntityNoteService(StarWinDbContext dbContext) : IStar
         string markdown,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var normalizedMarkdown = markdown.Trim();
         var existingNote = await dbContext.EntityNotes
             .FirstOrDefaultAsync(

--- a/StarWin.Infrastructure/Services/StarWinImageService.cs
+++ b/StarWin.Infrastructure/Services/StarWinImageService.cs
@@ -6,7 +6,9 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinImageService(StarWinDbContext dbContext, IHostEnvironment environment) : IStarWinImageService
+public sealed class StarWinImageService(
+    IDbContextFactory<StarWinDbContext> dbContextFactory,
+    IHostEnvironment environment) : IStarWinImageService
 {
     private static readonly HashSet<string> AllowedContentTypes =
     [
@@ -18,6 +20,7 @@ public sealed class StarWinImageService(StarWinDbContext dbContext, IHostEnviron
 
     public async Task<IReadOnlyList<EntityImage>> GetImagesAsync(CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var images = await dbContext.EntityImages
             .AsNoTracking()
             .ToListAsync(cancellationToken);
@@ -40,6 +43,7 @@ public sealed class StarWinImageService(StarWinDbContext dbContext, IHostEnviron
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(content);
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
         if (!AllowedContentTypes.Contains(contentType))
         {

--- a/StarWin.Infrastructure/Services/StarWinIndependentColonyService.cs
+++ b/StarWin.Infrastructure/Services/StarWinIndependentColonyService.cs
@@ -7,7 +7,7 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinIndependentColonyService(StarWinDbContext dbContext) : IStarWinIndependentColonyService
+public sealed class StarWinIndependentColonyService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinIndependentColonyService
 {
     private readonly IndependentColonyEmpireFactory independentColonyEmpireFactory = new();
 
@@ -15,6 +15,7 @@ public sealed class StarWinIndependentColonyService(StarWinDbContext dbContext) 
         int sectorId,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var independentEmpires = await dbContext.Empires
             .Where(empire => empire.Founding.Origin == EmpireOrigin.IndependentColony
                 && empire.Founding.FoundingColonyId != null)

--- a/StarWin.Infrastructure/Services/StarWinSectorConfigurationService.cs
+++ b/StarWin.Infrastructure/Services/StarWinSectorConfigurationService.cs
@@ -5,13 +5,14 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinSectorConfigurationService(StarWinDbContext dbContext) : IStarWinSectorConfigurationService
+public sealed class StarWinSectorConfigurationService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinSectorConfigurationService
 {
     public async Task<string> SaveSectorNameAsync(
         int sectorId,
         string name,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var normalizedName = name.Trim();
         if (string.IsNullOrWhiteSpace(normalizedName))
         {
@@ -41,6 +42,7 @@ public sealed class StarWinSectorConfigurationService(StarWinDbContext dbContext
         SectorConfiguration configuration,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var entity = await dbContext.Set<SectorConfiguration>()
             .FirstOrDefaultAsync(item => item.SectorId == sectorId, cancellationToken);
 

--- a/StarWin.Infrastructure/Services/StarWinSectorRouteService.cs
+++ b/StarWin.Infrastructure/Services/StarWinSectorRouteService.cs
@@ -7,13 +7,14 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinSectorRouteService(StarWinDbContext dbContext) : IStarWinSectorRouteService
+public sealed class StarWinSectorRouteService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinSectorRouteService
 {
     public async Task<SectorRouteSaveResult> SaveCurrentRoutesAsync(
         int sectorId,
         IProgress<SectorRouteSaveProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         progress?.Report(new SectorRouteSaveProgress("Loading sector", "Reading the active sector and travel configuration.", 10));
         await Task.Yield();
 
@@ -110,6 +111,7 @@ public sealed class StarWinSectorRouteService(StarWinDbContext dbContext) : ISta
         SectorManualRouteSaveRequest request,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         if (request.SourceSystemId <= 0 || request.TargetSystemId <= 0)
         {
             throw new InvalidOperationException("Hyperlanes require valid source and target systems.");
@@ -203,6 +205,7 @@ public sealed class StarWinSectorRouteService(StarWinDbContext dbContext) : ISta
         int routeId,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var route = await dbContext.SectorSavedRoutes
             .FirstOrDefaultAsync(item => item.SectorId == sectorId && item.Id == routeId, cancellationToken)
             ?? throw new InvalidOperationException("Saved hyperlane was not found.");

--- a/StarWin.Infrastructure/Services/StarWinSpaceHabitatService.cs
+++ b/StarWin.Infrastructure/Services/StarWinSpaceHabitatService.cs
@@ -5,7 +5,7 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinSpaceHabitatService(StarWinDbContext dbContext) : IStarWinSpaceHabitatService
+public sealed class StarWinSpaceHabitatService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinSpaceHabitatService
 {
     public async Task<SpaceHabitat> CreateOrbitingAstralBodyAsync(
         int starSystemId,
@@ -14,6 +14,7 @@ public sealed class StarWinSpaceHabitatService(StarWinDbContext dbContext) : ISt
         string? name,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var system = await dbContext.StarSystems
             .Include(item => item.AstralBodies)
             .FirstOrDefaultAsync(item => item.Id == starSystemId, cancellationToken)
@@ -29,7 +30,7 @@ public sealed class StarWinSpaceHabitatService(StarWinDbContext dbContext) : ISt
         var body = system.AstralBodies.ElementAt(astralBodySequence);
         var habitat = new SpaceHabitat
         {
-            Id = await GetNextSpaceHabitatIdAsync(cancellationToken),
+            Id = await GetNextSpaceHabitatIdAsync(dbContext, cancellationToken),
             Name = NormalizeHabitatName(name, $"{body.Role} Habitat"),
             OrbitTargetKind = OrbitTargetKind.AstralBody,
             OrbitTargetId = astralBodySequence,
@@ -49,6 +50,7 @@ public sealed class StarWinSpaceHabitatService(StarWinDbContext dbContext) : ISt
         string? name,
         CancellationToken cancellationToken = default)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var world = await dbContext.Worlds.FirstOrDefaultAsync(item => item.Id == worldId, cancellationToken)
             ?? throw new InvalidOperationException("World was not found.");
         if (world.StarSystemId is null)
@@ -60,7 +62,7 @@ public sealed class StarWinSpaceHabitatService(StarWinDbContext dbContext) : ISt
             ?? throw new InvalidOperationException("Empire was not found.");
         var habitat = new SpaceHabitat
         {
-            Id = await GetNextSpaceHabitatIdAsync(cancellationToken),
+            Id = await GetNextSpaceHabitatIdAsync(dbContext, cancellationToken),
             Name = NormalizeHabitatName(name, $"{world.Name} Habitat"),
             OrbitTargetKind = OrbitTargetKind.World,
             OrbitTargetId = world.Id,
@@ -74,7 +76,7 @@ public sealed class StarWinSpaceHabitatService(StarWinDbContext dbContext) : ISt
         return habitat;
     }
 
-    private async Task<int> GetNextSpaceHabitatIdAsync(CancellationToken cancellationToken)
+    private async Task<int> GetNextSpaceHabitatIdAsync(StarWinDbContext dbContext, CancellationToken cancellationToken)
     {
         return (await dbContext.SpaceHabitats
             .Select(habitat => (int?)habitat.Id)

--- a/StarWin.Web/Components/Pages/Home.razor
+++ b/StarWin.Web/Components/Pages/Home.razor
@@ -1351,69 +1351,124 @@
                 @if (selectedRace is not null)
                 {
                     var gurpsTemplate = BuildGurpsTemplate(selectedRace);
-                    <article class="detail-panel">
+                    var homeWorld = FindWorld(selectedRace.HomePlanetId);
+                    var raceMemberships = GetRaceEmpireMemberships(selectedRace, sectorEmpires).ToList();
+                    var raceHighlights = GetRaceHighlights(selectedRace).ToList();
+                    <article class="detail-panel alien-detail-panel">
                         <span class="panel-kicker">Alien biology</span>
                         <EditableEntityName Name="@selectedRace.Name"
                                             Label="Race"
                                             NameSaved="name => SaveEntityNameAsync(EntityNoteTargetKind.AlienRace, selectedRace.Id, name)" />
-                        @RenderImagePanel(EntityImageTargetKind.AlienRace, selectedRace.Id, "Race images", true)
-                        <div class="parent-actions">
-                            @if (FindWorld(selectedRace.HomePlanetId) is World homeWorld)
-                            {
-                                <button type="button" @onclick="() => SelectWorld(homeWorld.Id)">Homeworld: @homeWorld.Name</button>
-                            }
-                        </div>
-                        <dl class="field-grid">
-                            <div><dt>Appearance</dt><dd>@selectedRace.AppearanceType</dd></div>
-                            <div><dt>Biology</dt><dd>@selectedRace.BodyChemistry</dd></div>
-                            <div><dt>Environment</dt><dd>@selectedRace.EnvironmentType</dd></div>
-                            <div><dt>Government</dt><dd>@selectedRace.GovernmentType</dd></div>
-                            <div><dt>Reproduction</dt><dd>@selectedRace.ReproductionMethod</dd></div>
-                            <div><dt>Diet</dt><dd>@selectedRace.Diet</dd></div>
-                            <div><dt>Mass</dt><dd>@selectedRace.MassKg kg</dd></div>
-                            <div><dt>Size</dt><dd>@selectedRace.SizeCm cm</dd></div>
-                            <div><dt>Limb pairs</dt><dd>@selectedRace.LimbPairCount</dd></div>
-                            <div><dt>Body</dt><dd>@selectedRace.BiologyProfile.Body</dd></div>
-                            <div><dt>Mind</dt><dd>@selectedRace.BiologyProfile.Mind</dd></div>
-                            <div><dt>Speed</dt><dd>@selectedRace.BiologyProfile.Speed</dd></div>
-                            <div><dt>Psi</dt><dd>@selectedRace.BiologyProfile.PsiRating</dd></div>
-                            <div><dt>Faith</dt><dd>@selectedRace.Religion</dd></div>
-                        </dl>
-
-                        <EntityNotesPanel TargetKind="EntityNoteTargetKind.AlienRace"
-                                          TargetId="selectedRace.Id"
-                                          Title="Alien notes" />
-
-                        <section class="relationship-section">
-                            <h3>Empire memberships</h3>
-                            <div class="relationship-list">
-                                @foreach (var membership in GetRaceEmpireMemberships(selectedRace, sectorEmpires))
+                        <div class="alien-overview-grid">
+                            <section class="alien-summary-card alien-summary-card-primary">
+                                <div class="parent-actions">
+                                    @if (homeWorld is not null)
+                                    {
+                                        <button type="button" @onclick="() => SelectWorld(homeWorld.Id)">Homeworld: @homeWorld.Name</button>
+                                    }
+                                </div>
+                                <dl class="field-grid alien-field-grid alien-field-grid-primary">
+                                    <div><dt>Appearance</dt><dd>@DisplayText(selectedRace.AppearanceType)</dd></div>
+                                    <div><dt>Environment</dt><dd>@DisplayText(selectedRace.EnvironmentType)</dd></div>
+                                    <div><dt>Biology</dt><dd>@DisplayText(selectedRace.BodyChemistry)</dd></div>
+                                    <div><dt>Body cover</dt><dd>@DisplayText(selectedRace.BodyCoverType)</dd></div>
+                                    <div><dt>Mass</dt><dd>@selectedRace.MassKg kg</dd></div>
+                                    <div><dt>Size</dt><dd>@selectedRace.SizeCm cm</dd></div>
+                                    <div><dt>Limb pairs</dt><dd>@selectedRace.LimbPairCount</dd></div>
+                                    <div><dt>Lifespan</dt><dd>@selectedRace.BiologyProfile.Lifespan</dd></div>
+                                    <div><dt>Body</dt><dd>@selectedRace.BiologyProfile.Body</dd></div>
+                                    <div><dt>Mind</dt><dd>@selectedRace.BiologyProfile.Mind</dd></div>
+                                    <div><dt>Speed</dt><dd>@selectedRace.BiologyProfile.Speed</dd></div>
+                                    <div><dt>Psi</dt><dd>@selectedRace.BiologyProfile.PsiRating</dd></div>
+                                </dl>
+                                @if (raceHighlights.Count > 0)
                                 {
-                                    <button type="button" class="relationship-row" @onclick="() => SelectEmpire(membership.Empire.Id)">
-                                        <strong>@membership.Empire.Name</strong>
-                                        <span>@membership.Membership.Role; @membership.Membership.PopulationMillions million</span>
-                                    </button>
+                                    <div class="tag-group alien-tag-group">
+                                        @foreach (var highlight in raceHighlights)
+                                        {
+                                            <span>@highlight</span>
+                                        }
+                                    </div>
                                 }
-                            </div>
-                        </section>
+                            </section>
 
-                        <section class="relationship-section">
-                            <h3>GURPS template</h3>
-                            <dl class="field-grid">
-                                <div><dt>Edition</dt><dd>@DisplayGurpsEdition(gurpsTemplate.Edition)</dd></div>
-                                <div><dt>Total cost</dt><dd>@DisplayPoints(gurpsTemplate.TotalPointCost)</dd></div>
-                                <div><dt>Source</dt><dd>StarWin conversion</dd></div>
-                            </dl>
-                            <p>@gurpsTemplate.Notes</p>
-                            <div class="gurps-grid">
-                                @RenderGurpsTraitGroup("Attributes", gurpsTemplate.AttributeModifiers)
-                                @RenderGurpsTraitGroup("Secondary", gurpsTemplate.SecondaryCharacteristicModifiers)
-                                @RenderGurpsTraitGroup("Advantages", gurpsTemplate.Advantages)
-                                @RenderGurpsTraitGroup("Disadvantages", gurpsTemplate.Disadvantages)
-                                @RenderGurpsTraitGroup("Features", gurpsTemplate.Features)
-                                @RenderGurpsTraitGroup("Skills", gurpsTemplate.Skills)
+                            @RenderImagePanel(EntityImageTargetKind.AlienRace, selectedRace.Id, "Race images", true, compactWhenEmpty: true, panelClass: "alien-image-panel")
+                        </div>
+
+                        <div class="alien-secondary-grid">
+                            <section class="alien-summary-card">
+                                <h3>Society</h3>
+                                <dl class="field-grid alien-field-grid">
+                                    <div><dt>Government</dt><dd>@DisplayText(selectedRace.GovernmentType)</dd></div>
+                                    <div><dt>Diet</dt><dd>@DisplayText(selectedRace.Diet)</dd></div>
+                                    <div><dt>Faith</dt><dd>@DisplayText(selectedRace.Religion)</dd></div>
+                                    <div><dt>Devotion</dt><dd>@selectedRace.DevotionLevel</dd></div>
+                                    <div><dt>Reproduction</dt><dd>@DisplayText(selectedRace.Reproduction)</dd></div>
+                                    <div><dt>Method</dt><dd>@DisplayText(selectedRace.ReproductionMethod)</dd></div>
+                                </dl>
+                            </section>
+
+                            <section class="alien-summary-card">
+                                <h3>Derived data</h3>
+                                <dl class="field-grid alien-field-grid">
+                                    <div><dt>Edition</dt><dd>@DisplayGurpsEdition(gurpsTemplate.Edition)</dd></div>
+                                    <div><dt>Total cost</dt><dd>@DisplayPoints(gurpsTemplate.TotalPointCost)</dd></div>
+                                    <div><dt>Trait entries</dt><dd>@CountGurpsTraits(gurpsTemplate)</dd></div>
+                                    <div><dt>Memberships</dt><dd>@raceMemberships.Count</dd></div>
+                                    <div><dt>Source</dt><dd>StarWin conversion</dd></div>
+                                </dl>
+                                @if (!string.IsNullOrWhiteSpace(gurpsTemplate.Notes))
+                                {
+                                    <p>@gurpsTemplate.Notes</p>
+                                }
+                            </section>
+                        </div>
+
+                        <details class="alien-disclosure-card" @(raceMemberships.Count > 0 ? null : "open")>
+                            <summary>Empire memberships <span>@raceMemberships.Count</span></summary>
+                            @if (raceMemberships.Count == 0)
+                            {
+                                <p class="alien-empty-state">No empire memberships in this sector.</p>
+                            }
+                            else
+                            {
+                                <div class="relationship-list">
+                                    @foreach (var membership in raceMemberships)
+                                    {
+                                        <button type="button" class="relationship-row" @onclick="() => SelectEmpire(membership.Empire.Id)">
+                                            <strong>@membership.Empire.Name</strong>
+                                            <span>@membership.Membership.Role; @membership.Membership.PopulationMillions million</span>
+                                        </button>
+                                    }
+                                </div>
+                            }
+                        </details>
+
+                        <details class="alien-disclosure-card">
+                            <summary>Notes</summary>
+                            <EntityNotesPanel TargetKind="EntityNoteTargetKind.AlienRace"
+                                              TargetId="selectedRace.Id"
+                                              Title="Alien notes" />
+                        </details>
+
+                        <details class="alien-disclosure-card">
+                            <summary>GURPS template <span>@CountGurpsTraits(gurpsTemplate) entries</span></summary>
+                            <div class="alien-gurps-body">
+                                @if (!string.IsNullOrWhiteSpace(gurpsTemplate.Notes))
+                                {
+                                    <p>@gurpsTemplate.Notes</p>
+                                }
+                                <div class="gurps-grid">
+                                    @RenderGurpsTraitGroup("Attributes", gurpsTemplate.AttributeModifiers)
+                                    @RenderGurpsTraitGroup("Secondary", gurpsTemplate.SecondaryCharacteristicModifiers)
+                                    @RenderGurpsTraitGroup("Advantages", gurpsTemplate.Advantages)
+                                    @RenderGurpsTraitGroup("Disadvantages", gurpsTemplate.Disadvantages)
+                                    @RenderGurpsTraitGroup("Quirks", gurpsTemplate.Quirks)
+                                    @RenderGurpsTraitGroup("Features", gurpsTemplate.Features)
+                                    @RenderGurpsTraitGroup("Skills", gurpsTemplate.Skills)
+                                </div>
                             </div>
-                        </section>
+                        </details>
                     </article>
                 }
             </section>
@@ -3756,10 +3811,27 @@
         }
     }
 
-    private RenderFragment RenderImagePanel(EntityImageTargetKind targetKind, int targetId, string title, bool allowMultiple)
+    private RenderFragment RenderImagePanel(
+        EntityImageTargetKind targetKind,
+        int targetId,
+        string title,
+        bool allowMultiple,
+        bool compactWhenEmpty = false,
+        string? panelClass = null)
     {
         var images = GetEntityImages(targetKind, targetId);
-        return @<section class="entity-image-panel">
+        var panelClasses = new List<string> { "entity-image-panel" };
+        if (compactWhenEmpty && images.Count == 0)
+        {
+            panelClasses.Add("compact-empty");
+        }
+
+        if (!string.IsNullOrWhiteSpace(panelClass))
+        {
+            panelClasses.Add(panelClass);
+        }
+
+        return @<section class="@string.Join(" ", panelClasses)">
             <div class="image-panel-header">
                 <h4>@title</h4>
                 <span>@(allowMultiple ? "Multiple allowed" : "One image")</span>
@@ -3910,6 +3982,45 @@
     private static string DisplayDateTime(DateTime value)
     {
         return value == default ? "Not saved" : value.ToLocalTime().ToString("g");
+    }
+
+    private static string DisplayText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "N/A" : value;
+    }
+
+    private static IEnumerable<string> GetRaceHighlights(AlienRace race)
+    {
+        if (!string.IsNullOrWhiteSpace(race.BodyCoverType))
+        {
+            yield return $"Body cover: {race.BodyCoverType}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(race.Reproduction))
+        {
+            yield return $"Reproduction: {race.Reproduction}";
+        }
+
+        if (race.DevotionLevel != AlienDevotionLevel.None)
+        {
+            yield return $"{race.DevotionLevel} devotion";
+        }
+
+        if (race.BiologyProfile.Lifespan > 0)
+        {
+            yield return $"Lifespan {race.BiologyProfile.Lifespan}";
+        }
+    }
+
+    private static int CountGurpsTraits(GurpsTemplate template)
+    {
+        return template.AttributeModifiers.Count
+            + template.SecondaryCharacteristicModifiers.Count
+            + template.Advantages.Count
+            + template.Disadvantages.Count
+            + template.Quirks.Count
+            + template.Features.Count
+            + template.Skills.Count;
     }
 
     private static string DisplayResultType(StarWinSearchResultType type)

--- a/StarWin.Web/StarWinWebHost.cs
+++ b/StarWin.Web/StarWinWebHost.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.StaticWebAssets;
+using Microsoft.Extensions.Configuration;
 using StarWin.Application.Services;
 using StarWin.Infrastructure;
 using StarWin.Web.Components;
@@ -21,6 +22,7 @@ public static class StarWinWebHost
     public static WebApplication Build(WebApplicationBuilder builder)
     {
         StaticWebAssetsLoader.UseStaticWebAssets(builder.Environment, builder.Configuration);
+        ApplyDevelopmentDatabaseDefaults(builder);
 
         builder.Services.AddRazorComponents()
             .AddInteractiveServerComponents();
@@ -73,4 +75,40 @@ public static class StarWinWebHost
         var provider = configuration["StarWin:DatabaseProvider"] ?? "SqlServer";
         return provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static void ApplyDevelopmentDatabaseDefaults(WebApplicationBuilder builder)
+    {
+        if (!builder.Environment.IsDevelopment())
+        {
+            return;
+        }
+
+        var hostKind = builder.Configuration["StarforgedAtlas:HostKind"];
+        if (string.Equals(hostKind, "Desktop", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var provider = builder.Configuration["StarWin:DatabaseProvider"] ?? "SqlServer";
+        var connectionString = builder.Configuration.GetConnectionString("StarWin");
+        if (!provider.Equals("SqlServer", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(connectionString, DefaultLocalDbConnectionString, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var sharedDesktopDatabasePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Starforged Atlas",
+            "starforged-atlas.db");
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["StarWin:DatabaseProvider"] = "Sqlite",
+            ["ConnectionStrings:StarWin"] = $"Data Source={sharedDesktopDatabasePath}"
+        });
+    }
+
+    private const string DefaultLocalDbConnectionString =
+        "Server=(localdb)\\mssqllocaldb;Database=StarWin;Trusted_Connection=True;MultipleActiveResultSets=true";
 }

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1722,6 +1722,68 @@ dd {
     margin-top: 18px;
 }
 
+.alien-detail-panel {
+    display: grid;
+    gap: 16px;
+}
+
+.alien-overview-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.8fr) minmax(220px, 0.95fr);
+    gap: 14px;
+    align-items: start;
+}
+
+.alien-secondary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.alien-summary-card {
+    display: grid;
+    gap: 12px;
+    border: 1px solid rgba(125, 211, 252, 0.16);
+    border-radius: 8px;
+    background: rgba(3, 10, 24, 0.54);
+    padding: 14px;
+}
+
+.alien-summary-card h3 {
+    margin: 0;
+    color: #dff8ff;
+    font-size: 1rem;
+}
+
+.alien-summary-card p,
+.alien-gurps-body p,
+.alien-empty-state {
+    margin: 0;
+    color: var(--muted);
+}
+
+.alien-field-grid {
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
+    gap: 8px;
+}
+
+.alien-field-grid-primary {
+    grid-template-columns: repeat(4, minmax(120px, 1fr));
+}
+
+.alien-field-grid div {
+    padding: 9px 10px;
+}
+
+.alien-tag-group {
+    margin-top: 0;
+}
+
+.alien-image-panel {
+    margin-bottom: 0;
+    align-content: start;
+}
+
 .parent-actions {
     display: flex;
     flex-wrap: wrap;
@@ -1776,6 +1838,25 @@ dd {
 
 .entity-image-panel p {
     margin: 0;
+}
+
+.entity-image-panel.compact-empty {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 12px;
+    align-items: center;
+}
+
+.entity-image-panel.compact-empty .image-panel-header,
+.entity-image-panel.compact-empty small {
+    grid-column: 1 / -1;
+}
+
+.entity-image-panel.compact-empty p {
+    margin: 0;
+}
+
+.entity-image-panel.compact-empty .image-upload-control {
+    justify-self: end;
 }
 
 .entity-image-grid {
@@ -1924,6 +2005,47 @@ dd {
     font-size: 1.05rem;
 }
 
+.alien-disclosure-card {
+    display: grid;
+    gap: 12px;
+    border: 1px solid rgba(125, 211, 252, 0.16);
+    border-radius: 8px;
+    background: rgba(3, 10, 24, 0.42);
+    padding: 12px 14px;
+}
+
+.alien-disclosure-card summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    cursor: pointer;
+    color: #dff8ff;
+    font-size: 1rem;
+    font-weight: 800;
+    list-style: none;
+}
+
+.alien-disclosure-card summary::-webkit-details-marker {
+    display: none;
+}
+
+.alien-disclosure-card summary span {
+    color: var(--muted);
+    font-size: 0.84rem;
+    font-weight: 700;
+}
+
+.alien-disclosure-card[open] summary {
+    padding-bottom: 10px;
+    border-bottom: 1px solid rgba(125, 211, 252, 0.16);
+}
+
+.alien-gurps-body {
+    display: grid;
+    gap: 12px;
+}
+
 .relationship-section {
     clear: both;
     display: grid;
@@ -2057,6 +2179,32 @@ dd {
 .inline-row {
     border-top: 1px solid rgba(125, 211, 252, 0.16);
     padding: 8px 0;
+}
+
+@media (max-width: 1100px) {
+    .alien-overview-grid,
+    .alien-secondary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .alien-field-grid-primary {
+        grid-template-columns: repeat(3, minmax(120px, 1fr));
+    }
+}
+
+@media (max-width: 720px) {
+    .alien-field-grid,
+    .alien-field-grid-primary {
+        grid-template-columns: repeat(2, minmax(120px, 1fr));
+    }
+
+    .entity-image-panel.compact-empty {
+        grid-template-columns: 1fr;
+    }
+
+    .entity-image-panel.compact-empty .image-upload-control {
+        justify-self: start;
+    }
 }
 
 .form-grid {


### PR DESCRIPTION
## Summary
- redesign the Aliens explorer view to improve density and surface more useful detail
- fix DbContext lifetime usage for long-lived interactive services used by desktop and web
- make local web development default to the shared desktop SQLite database when still on the stock LocalDB config

## Testing
- dotnet build "Slipstream Map.sln"
- verified `/desktop/health` returns `ok` after the web-host DI fix

Closes #29
