### PR TITLE
Codex - Remove starwind.json from the Import page

### DIFF
--- a/StarWin.Web.Tests/Pages/ImportPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ImportPageTests.cs
@@ -1,0 +1,95 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using StarWin.Application.Services;
+using StarWin.Application.Services.LegacyImport;
+using StarWin.Domain.Model.Entity.Civilization;
+using StarWin.Domain.Model.Entity.StarMap;
+using StarWin.Domain.Model.ViewModel;
+using StarWin.Web.Components.Pages;
+
+namespace StarWin.Web.Tests.Pages;
+
+public sealed class ImportPageTests : BunitContext
+{
+    [Fact]
+    public void RendersSupportedImportSourcesWithoutStarWinJson()
+    {
+        ConfigureServices();
+
+        var cut = Render<Import>();
+
+        Assert.Contains("StarWin 2 files", cut.Markup);
+        Assert.Contains("Slip Map JSON", cut.Markup);
+        Assert.DoesNotContain("StarWin JSON", cut.Markup);
+        Assert.DoesNotContain("legacy export packages", cut.Markup, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SelectingSlipMapJsonUpdatesAcceptedFileTypes()
+    {
+        ConfigureServices();
+
+        var cut = Render<Import>();
+        cut.FindAll("button").Single(button => button.TextContent.Trim() == "Slip Map JSON").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("<span>Slip Map JSON</span>", cut.Markup);
+            Assert.Contains("accept=\".json,application/json\"", cut.Markup);
+        });
+    }
+
+    private void ConfigureServices()
+    {
+        Services.AddSingleton<IStarWinLegacyImportService>(new FakeLegacyImportService());
+        Services.AddSingleton<IStarWinWorkspace>(new FakeWorkspace());
+    }
+
+    private sealed class FakeLegacyImportService : IStarWinLegacyImportService
+    {
+        public Task<StarWinLegacyImportPreview> PreviewStarWinZipAsync(
+            Stream zipPackage,
+            string packageName,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new StarWinLegacyImportPreview(packageName, [], [], []));
+        }
+
+        public Task<StarWinLegacyImportResult> ImportStarWinZipAsync(
+            Stream zipPackage,
+            string packageName,
+            string targetSectorName,
+            IProgress<StarWinLegacyImportProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new StarWinLegacyImportResult(
+                false,
+                null,
+                new StarWinLegacyImportPreview(packageName, [], [], []),
+                ["Not implemented in test."]));
+        }
+    }
+
+    private sealed class FakeWorkspace : IStarWinWorkspace
+    {
+        public bool IsLoaded => true;
+
+        public IReadOnlyList<StarWinSector> Sectors => [];
+
+        public StarWinSector CurrentSector { get; } = new();
+
+        public IReadOnlyList<AlienRace> AlienRaces => [];
+
+        public IReadOnlyList<Empire> Empires => [];
+
+        public IReadOnlyList<EmpireContact> EmpireContacts => [];
+
+        public CivilizationGeneratorSettings CivilizationSettings { get; } = new();
+
+        public ArmyGeneratorSettings ArmySettings { get; } = new();
+
+        public GurpsTemplate PreviewGurpsTemplate { get; } = new();
+
+        public Task ReloadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/StarWin.Web.Tests/Pages/ImportPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ImportPageTests.cs
@@ -20,23 +20,23 @@ public sealed class ImportPageTests : BunitContext
 
         Assert.Contains("StarWin 2 files", cut.Markup);
         Assert.Contains("Slip Map JSON", cut.Markup);
+        Assert.Contains("Coming soon", cut.Markup);
         Assert.DoesNotContain("StarWin JSON", cut.Markup);
         Assert.DoesNotContain("legacy export packages", cut.Markup, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void SelectingSlipMapJsonUpdatesAcceptedFileTypes()
+    public void SlipMapJsonSourceIsDisabledUntilImplemented()
     {
         ConfigureServices();
 
         var cut = Render<Import>();
-        cut.FindAll("button").Single(button => button.TextContent.Trim() == "Slip Map JSON").Click();
+        var slipMapButton = cut.FindAll("button").Single(button => button.TextContent.Contains("Slip Map JSON", StringComparison.Ordinal));
 
-        cut.WaitForAssertion(() =>
-        {
-            Assert.Contains("<span>Slip Map JSON</span>", cut.Markup);
-            Assert.Contains("accept=\".json,application/json\"", cut.Markup);
-        });
+        Assert.True(slipMapButton.HasAttribute("disabled"));
+        Assert.Contains("Coming soon", slipMapButton.TextContent);
+        Assert.Contains("<span>StarWin 2 files</span>", cut.Markup);
+        Assert.Contains("accept=\".zip,application/zip,application/x-zip-compressed\"", cut.Markup);
     }
 
     private void ConfigureServices()

--- a/StarWin.Web.Tests/Pages/ImportPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ImportPageTests.cs
@@ -23,6 +23,17 @@ public sealed class ImportPageTests : BunitContext
         Assert.Contains("Coming soon", cut.Markup);
         Assert.DoesNotContain("StarWin JSON", cut.Markup);
         Assert.DoesNotContain("legacy export packages", cut.Markup, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Collect all files for the single StarWin 2 sector you want to import", cut.Markup);
+        Assert.Contains("All files for the sector should use the same base file name", cut.Markup);
+        Assert.Contains(".sun", cut.Markup);
+        Assert.Contains(".pln", cut.Markup);
+        Assert.Contains(".mon", cut.Markup);
+        Assert.Contains(".aln", cut.Markup);
+        Assert.Contains(".col", cut.Markup);
+        Assert.Contains(".con", cut.Markup);
+        Assert.Contains(".emp", cut.Markup);
+        Assert.Contains(".his", cut.Markup);
+        Assert.Contains(".nam", cut.Markup);
     }
 
     [Fact]

--- a/StarWin.Web.Tests/Pages/ImportPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ImportPageTests.cs
@@ -35,7 +35,8 @@ public sealed class ImportPageTests : BunitContext
 
         Assert.True(slipMapButton.HasAttribute("disabled"));
         Assert.Contains("Coming soon", slipMapButton.TextContent);
-        Assert.Contains("<span>StarWin 2 files</span>", cut.Markup);
+        Assert.Contains("class=\"import-source-badge\"", cut.Markup);
+        Assert.Contains("<span class=\"import-source-label\">StarWin 2 files</span>", cut.Markup);
         Assert.Contains("accept=\".zip,application/zip,application/x-zip-compressed\"", cut.Markup);
     }
 

--- a/StarWin.Web/Components/Pages/Import.razor
+++ b/StarWin.Web/Components/Pages/Import.razor
@@ -11,7 +11,7 @@
         <div class="hero-copy">
             <p class="eyebrow">Import</p>
             <h1>Bring legacy sectors and slip maps into the new archive.</h1>
-            <p class="hero-summary">Load StarWin 2 sector data, legacy export packages, and Slip Map JSON into the shared Starforged Atlas workspace.</p>
+            <p class="hero-summary">Load StarWin 2 sector data and Slip Map JSON into the shared Starforged Atlas workspace.</p>
         </div>
     </header>
 
@@ -156,7 +156,6 @@
     private readonly ImportSource[] importSources =
     [
         new("starwin-files", "StarWin 2 files"),
-        new("starwin-json", "StarWin JSON"),
         new("slipmap-json", "Slip Map JSON")
     ];
 
@@ -184,7 +183,7 @@
     private string AcceptedFileTypes => selectedSource switch
     {
         "starwin-files" => ".zip,application/zip,application/x-zip-compressed",
-        "starwin-json" or "slipmap-json" => ".json,application/json",
+        "slipmap-json" => ".json,application/json",
         _ => string.Empty
     };
 

--- a/StarWin.Web/Components/Pages/Import.razor
+++ b/StarWin.Web/Components/Pages/Import.razor
@@ -44,6 +44,19 @@
                 }
             </div>
 
+            <section class="import-instructions">
+                <h3>StarWin 2 zip instructions</h3>
+                <p>Collect all files for the single StarWin 2 sector you want to import, place them together in one `.zip` archive, and upload that zip here.</p>
+                <p>All files for the sector should use the same base file name and only differ by file extension. For example: `SectorName.sun`, `SectorName.pln`, `SectorName.mon`, and so on.</p>
+                <p>The current sector import expects these required file extensions:</p>
+                <div class="tag-group import-extension-tags">
+                    @foreach (var extension in requiredStarWinExtensions)
+                    {
+                        <span>@extension</span>
+                    }
+                </div>
+            </section>
+
             <div class="form-grid">
                 <label>Import name <input @bind="importName" /></label>
                 <label>Target sector <input @bind="targetSectorName" /></label>
@@ -166,6 +179,19 @@
     [
         new("starwin-files", "StarWin 2 files", true),
         new("slipmap-json", "Slip Map JSON", false)
+    ];
+
+    private readonly string[] requiredStarWinExtensions =
+    [
+        ".sun",
+        ".pln",
+        ".mon",
+        ".aln",
+        ".col",
+        ".con",
+        ".emp",
+        ".his",
+        ".nam"
     ];
 
     private string selectedSource = "starwin-files";

--- a/StarWin.Web/Components/Pages/Import.razor
+++ b/StarWin.Web/Components/Pages/Import.razor
@@ -23,13 +23,13 @@
                 @foreach (var source in importSources)
                 {
                     <button type="button"
-                            class="@(selectedSource == source.Key ? "active" : null)"
+                            class="import-source-button @(selectedSource == source.Key ? "active" : null)"
                             @onclick="() => selectedSource = source.Key"
                             disabled="@(importLoadingVisible || !source.IsAvailable)">
-                        @source.Label
+                        <span class="import-source-label">@source.Label</span>
                         @if (!source.IsAvailable)
                         {
-                            <span>Coming soon</span>
+                            <span class="import-source-badge">Coming soon</span>
                         }
                     </button>
                 }

--- a/StarWin.Web/Components/Pages/Import.razor
+++ b/StarWin.Web/Components/Pages/Import.razor
@@ -22,7 +22,16 @@
             <div class="segmented-control" role="group" aria-label="Import source">
                 @foreach (var source in importSources)
                 {
-                    <button type="button" class="@(selectedSource == source.Key ? "active" : null)" @onclick="() => selectedSource = source.Key" disabled="@importLoadingVisible">@source.Label</button>
+                    <button type="button"
+                            class="@(selectedSource == source.Key ? "active" : null)"
+                            @onclick="() => selectedSource = source.Key"
+                            disabled="@(importLoadingVisible || !source.IsAvailable)">
+                        @source.Label
+                        @if (!source.IsAvailable)
+                        {
+                            <span>Coming soon</span>
+                        }
+                    </button>
                 }
             </div>
 
@@ -155,8 +164,8 @@
 @code {
     private readonly ImportSource[] importSources =
     [
-        new("starwin-files", "StarWin 2 files"),
-        new("slipmap-json", "Slip Map JSON")
+        new("starwin-files", "StarWin 2 files", true),
+        new("slipmap-json", "Slip Map JSON", false)
     ];
 
     private string selectedSource = "starwin-files";
@@ -364,5 +373,5 @@
         return allegianceId == ushort.MaxValue ? "Independent" : allegianceId.ToString();
     }
 
-    private sealed record ImportSource(string Key, string Label);
+    private sealed record ImportSource(string Key, string Label, bool IsAvailable);
 }

--- a/StarWin.Web/Properties/launchSettings.json
+++ b/StarWin.Web/Properties/launchSettings.json
@@ -5,7 +5,7 @@
         "commandName": "Project",
         "dotnetRunMessages": true,
         "launchBrowser": true,
-        "applicationUrl": "http://localhost:5186",
+        "applicationUrl": "http://localhost:10008",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -2093,6 +2093,30 @@ dd {
     color: #f8fbff;
 }
 
+.import-instructions {
+    display: grid;
+    gap: 10px;
+    border: 1px solid rgba(125, 211, 252, 0.16);
+    border-radius: 8px;
+    background: rgba(3, 10, 24, 0.54);
+    margin-bottom: 16px;
+    padding: 14px;
+}
+
+.import-instructions h3,
+.import-instructions p {
+    margin: 0;
+}
+
+.import-instructions h3 {
+    color: #dff8ff;
+    font-size: 1rem;
+}
+
+.import-extension-tags {
+    margin-top: 0;
+}
+
 .import-actions {
     margin-top: 18px;
 }

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -476,6 +476,9 @@ dd {
 }
 
 .segmented-control button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     min-height: 40px;
     border: 1px solid rgba(125, 211, 252, 0.28);
     border-radius: 6px;
@@ -491,6 +494,38 @@ dd {
     background: rgba(14, 165, 233, 0.22);
     color: #f8fbff;
     box-shadow: 0 0 18px rgba(56, 189, 248, 0.14);
+}
+
+.import-source-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.9;
+}
+
+.import-source-button:disabled:not(.active) {
+    border-color: rgba(148, 163, 184, 0.28);
+    background: rgba(15, 23, 42, 0.58);
+    color: #cbd5e1;
+    box-shadow: none;
+}
+
+.import-source-label {
+    display: inline-flex;
+    align-items: center;
+}
+
+.import-source-badge {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid rgba(251, 191, 36, 0.38);
+    border-radius: 999px;
+    background: rgba(120, 53, 15, 0.42);
+    color: #fde68a;
+    padding: 3px 8px;
+    font-size: 0.68rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .metrics-band {


### PR DESCRIPTION
Codex - Remove starwind.json from the Import page

Affected issues
- Closes #8

Summary of changes
- Removes the obsolete StarWin JSON import source from the Import page.
- Keeps Slip Map JSON visible as a disabled Coming Soon option instead of presenting it as available.
- Adds StarWin 2 zip upload instructions, including the required same-basename sector file extensions.
- Adds and updates Import page tests covering the visible source options, coming-soon badge, and StarWin 2 guidance copy.

Validation
- dotnet test StarWin.Web.Tests/StarWin.Web.Tests.csproj
