### PR TITLE
Codex - Document GitHub release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,24 @@ Do not start coding for an issue-driven conversation until I explicitly ask you 
 
 GitHub project workflow uses the `Starforged Atlas Task Board`.
 
+GitHub release workflow:
+1. Create releases from `master` only.
+2. Pull the latest `origin/master` before building release artifacts.
+3. Build the portable desktop package with `scripts/New-PortableDesktopPackage.ps1`.
+4. Upload `Starforged-Atlas-Portable.zip` as the primary release asset.
+5. Do not re-upload the Delcora sector import zip if it has not changed. In release notes, direct users to download `Delcora.Sector.zip` from the previous release instead. Only upload it again when the file changes or when a fully self-contained onboarding release is explicitly requested.
+6. Release notes must include a changelog covering what changed since the previous release.
+7. Follow the same release note format used by `2026-04-26.2 Developer Preview`, with these sections in this order:
+   - `Developer Preview release for {date}.`
+   - `Included assets`
+   - `Built from`
+   - `Changelog since {previous release}`
+   - `Highlights`
+   - `Issues included`
+   - `Commit summary`
+   - `Notes`
+8. In the `Included assets` section, list the portable desktop package zip and note that `Delcora.Sector.zip` should be downloaded from the previous release when it is not re-uploaded for the current release.
+
 When an assigned issue is in `Backlog`, move it to `Ready` after research is complete.
 
 When I explicitly tell you to implement the changes, move the issue from `Ready` to `In progress`.


### PR DESCRIPTION
Codex - Document GitHub release workflow

Summary of changes
- Adds a dedicated GitHub release workflow section to `AGENTS.md`.
- Requires future releases to be created from `master`.
- Documents building the portable package with `scripts/New-PortableDesktopPackage.ps1`.
- Specifies that `Starforged-Atlas-Portable.zip` is the primary release asset.
- Specifies that unchanged `Delcora.Sector.zip` data should be referenced from the previous release instead of being re-uploaded.
- Requires release notes to include a changelog since the previous release.
- Captures the exact release note section order from `2026-04-26.2 Developer Preview`.

Notes
- This change was committed locally on top of `master`, but `master` is protected, so it is being proposed through this PR as required.