### PR TITLE
Codex - Promote dev to master for 2026-04-27.1 Developer Preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,24 @@ Do not start coding for an issue-driven conversation until I explicitly ask you 
 
 GitHub project workflow uses the `Starforged Atlas Task Board`.
 
+GitHub release workflow:
+1. Create releases from `master` only.
+2. Pull the latest `origin/master` before building release artifacts.
+3. Build the portable desktop package with `scripts/New-PortableDesktopPackage.ps1`.
+4. Upload `Starforged-Atlas-Portable.zip` as the primary release asset.
+5. Do not re-upload the Delcora sector import zip if it has not changed. In release notes, direct users to download `Delcora.Sector.zip` from the previous release instead. Only upload it again when the file changes or when a fully self-contained onboarding release is explicitly requested.
+6. Release notes must include a changelog covering what changed since the previous release.
+7. Follow the same release note format used by `2026-04-26.2 Developer Preview`, with these sections in this order:
+   - `Developer Preview release for {date}.`
+   - `Included assets`
+   - `Built from`
+   - `Changelog since {previous release}`
+   - `Highlights`
+   - `Issues included`
+   - `Commit summary`
+   - `Notes`
+8. In the `Included assets` section, list the portable desktop package zip and note that `Delcora.Sector.zip` should be downloaded from the previous release when it is not re-uploaded for the current release.
+
 When an assigned issue is in `Backlog`, move it to `Ready` after research is complete.
 
 When I explicitly tell you to implement the changes, move the issue from `Ready` to `In progress`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ GitHub release workflow:
    - `Commit summary`
    - `Notes`
 8. In the `Included assets` section, list the portable desktop package zip and note that `Delcora.Sector.zip` should be downloaded from the previous release when it is not re-uploaded for the current release.
+9. When promoting `dev` to `master`, update the desktop application version before the pull request is merged so the version change is included in the `dev` -> `master` pull request.
+10. The desktop application version format is `{year}-{two-digit-month}-{two-digit-day}.{release-index}-developer-preview` for the informational release tag, where the first release of a day uses release index `0`, the second uses `1`, and so on.
+11. For the corresponding assembly/file/package numeric version, use `{year}.{month}.{day}.{release-index}`.
+12. Until explicitly changed, the release name suffix is `Developer Preview`.
+13. Include the release name in the `dev` -> `master` pull request title/body when preparing the promotion.
+14. After the `dev` -> `master` pull request is fully merged, create the GitHub release from `master` using that version.
 
 When an assigned issue is in `Backlog`, move it to `Ready` after research is complete.
 

--- a/Slipstream Map.sln
+++ b/Slipstream Map.sln
@@ -38,6 +38,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWin.Infrastructure.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWin.Desktop.Tests", "StarWin.Desktop.Tests\StarWin.Desktop.Tests.csproj", "{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarforgedAtlas.PortableLauncher.Tests", "StarforgedAtlas.PortableLauncher.Tests\StarforgedAtlas.PortableLauncher.Tests.csproj", "{18B7FCB4-437C-4806-965A-8115B4763A6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -204,6 +206,18 @@ Global
 		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x64.Build.0 = Release|Any CPU
 		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x86.ActiveCfg = Release|Any CPU
 		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x86.Build.0 = Release|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Debug|x86.Build.0 = Debug|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Release|x64.ActiveCfg = Release|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Release|x64.Build.0 = Release|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Release|x86.ActiveCfg = Release|Any CPU
+		{18B7FCB4-437C-4806-965A-8115B4763A6F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Slipstream Map.sln
+++ b/Slipstream Map.sln
@@ -36,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarforgedAtlas.PortableLau
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWin.Infrastructure.Tests", "StarWin.Infrastructure.Tests\StarWin.Infrastructure.Tests.csproj", "{F365516D-075C-4F87-A15E-B22663C35FAC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWin.Desktop.Tests", "StarWin.Desktop.Tests\StarWin.Desktop.Tests.csproj", "{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -190,6 +192,18 @@ Global
 		{F365516D-075C-4F87-A15E-B22663C35FAC}.Release|x64.Build.0 = Release|Any CPU
 		{F365516D-075C-4F87-A15E-B22663C35FAC}.Release|x86.ActiveCfg = Release|Any CPU
 		{F365516D-075C-4F87-A15E-B22663C35FAC}.Release|x86.Build.0 = Release|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Debug|x64.Build.0 = Debug|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Debug|x86.Build.0 = Debug|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x64.ActiveCfg = Release|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x64.Build.0 = Release|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x86.ActiveCfg = Release|Any CPU
+		{C087EDE1-42A8-4287-A9E0-DFB9BB3DEE04}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StarWin.Desktop.Tests/GlobalUsings.cs
+++ b/StarWin.Desktop.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/StarWin.Desktop.Tests/StarWin.Desktop.Tests.csproj
+++ b/StarWin.Desktop.Tests/StarWin.Desktop.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StarWin.Desktop\StarWin.Desktop.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/StarWin.Desktop.Tests/Updates/DesktopReleaseUpdateEvaluatorTests.cs
+++ b/StarWin.Desktop.Tests/Updates/DesktopReleaseUpdateEvaluatorTests.cs
@@ -30,10 +30,12 @@ public sealed class DesktopReleaseUpdateEvaluatorTests
             new GitHubReleaseInfo(
                 "2026-04-26.2-developer-preview",
                 "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-26.2-developer-preview",
-                "Developer Preview"));
+                "Developer Preview",
+                "- Fixed updater flow"));
 
         Assert.NotNull(prompt);
         Assert.Equal("2026-04-26.2-developer-preview", prompt!.LatestReleaseTag);
+        Assert.Equal("- Fixed updater flow", prompt.ReleaseNotes);
     }
 
     [Fact]
@@ -46,7 +48,8 @@ public sealed class DesktopReleaseUpdateEvaluatorTests
             new GitHubReleaseInfo(
                 "2026-04-26.2-developer-preview",
                 "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-26.2-developer-preview",
-                "Developer Preview"));
+                "Developer Preview",
+                "- Fixed updater flow"));
 
         Assert.Null(prompt);
     }
@@ -61,8 +64,24 @@ public sealed class DesktopReleaseUpdateEvaluatorTests
             new GitHubReleaseInfo(
                 "2026-04-26.2-developer-preview",
                 "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-26.2-developer-preview",
-                "Developer Preview"));
+                "Developer Preview",
+                "- Fixed updater flow"));
 
         Assert.Null(prompt);
+    }
+
+    [Fact]
+    public void BuildMessage_includes_release_notes()
+    {
+        var message = DesktopReleaseUpdatePromptFormatter.BuildMessage(
+            new DesktopReleaseUpdatePrompt(
+                "2026-04-26.2-developer-preview",
+                "2026-04-27.0-developer-preview",
+                "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-27.0-developer-preview",
+                "Developer Preview",
+                "- Added portable updater progress"));
+
+        Assert.Contains("Release notes:", message, StringComparison.Ordinal);
+        Assert.Contains("- Added portable updater progress", message, StringComparison.Ordinal);
     }
 }

--- a/StarWin.Desktop.Tests/Updates/DesktopReleaseUpdateEvaluatorTests.cs
+++ b/StarWin.Desktop.Tests/Updates/DesktopReleaseUpdateEvaluatorTests.cs
@@ -1,0 +1,68 @@
+namespace StarWin.Desktop.Tests.Updates;
+
+public sealed class DesktopReleaseUpdateEvaluatorTests
+{
+    [Fact]
+    public void TryParse_accepts_developer_preview_tag_without_revision()
+    {
+        var parsed = StarforgedReleaseVersion.TryParse("2026-04-26-developer-preview", out var version);
+
+        Assert.True(parsed);
+        Assert.Equal(new StarforgedReleaseVersion(2026, 4, 26, 0), version);
+    }
+
+    [Fact]
+    public void TryParse_accepts_revisioned_developer_preview_tag()
+    {
+        var parsed = StarforgedReleaseVersion.TryParse("2026-04-26.2-developer-preview", out var version);
+
+        Assert.True(parsed);
+        Assert.Equal(new StarforgedReleaseVersion(2026, 4, 26, 2), version);
+    }
+
+    [Fact]
+    public void Evaluate_returns_prompt_when_latest_release_is_newer()
+    {
+        var prompt = DesktopReleaseUpdateEvaluator.Evaluate(
+            new StarforgedReleaseVersion(2026, 4, 26, 0),
+            "2026-04-26-developer-preview",
+            skippedReleaseTag: null,
+            new GitHubReleaseInfo(
+                "2026-04-26.2-developer-preview",
+                "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-26.2-developer-preview",
+                "Developer Preview"));
+
+        Assert.NotNull(prompt);
+        Assert.Equal("2026-04-26.2-developer-preview", prompt!.LatestReleaseTag);
+    }
+
+    [Fact]
+    public void Evaluate_returns_null_when_latest_release_matches_skipped_tag()
+    {
+        var prompt = DesktopReleaseUpdateEvaluator.Evaluate(
+            new StarforgedReleaseVersion(2026, 4, 26, 0),
+            "2026-04-26-developer-preview",
+            skippedReleaseTag: "2026-04-26.2-developer-preview",
+            new GitHubReleaseInfo(
+                "2026-04-26.2-developer-preview",
+                "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-26.2-developer-preview",
+                "Developer Preview"));
+
+        Assert.Null(prompt);
+    }
+
+    [Fact]
+    public void Evaluate_returns_null_when_latest_release_is_not_newer()
+    {
+        var prompt = DesktopReleaseUpdateEvaluator.Evaluate(
+            new StarforgedReleaseVersion(2026, 4, 26, 2),
+            "2026-04-26.2-developer-preview",
+            skippedReleaseTag: null,
+            new GitHubReleaseInfo(
+                "2026-04-26.2-developer-preview",
+                "https://github.com/darkdhamon/Slip-Map-Tool/releases/tag/2026-04-26.2-developer-preview",
+                "Developer Preview"));
+
+        Assert.Null(prompt);
+    }
+}

--- a/StarWin.Desktop/Program.cs
+++ b/StarWin.Desktop/Program.cs
@@ -28,6 +28,7 @@ internal static class Program
     private const string BackendServerArgument = "--backend-server";
     private const string BackendPortArgument = "--backend-port";
     private const string SmokeTestArgument = "--smoke-test";
+    private const string SkipUpdateCheckArgument = "--skip-update-check";
 
     [STAThread]
     public static async Task Main(string[] args)
@@ -56,7 +57,13 @@ internal static class Program
             }
 
             startupReporter.Report("Opening main window", "Starting the embedded browser shell.");
-            RunDesktopShell(backendLease.LocalUrl, StarWinDesktopPaths.GetWebViewDataPath(), StarWinDesktopPaths.GetIconPath(), startupReporter);
+            var skipUpdateCheck = args.Contains(SkipUpdateCheckArgument, StringComparer.OrdinalIgnoreCase);
+            RunDesktopShell(
+                backendLease.LocalUrl,
+                StarWinDesktopPaths.GetWebViewDataPath(),
+                StarWinDesktopPaths.GetIconPath(),
+                startupReporter,
+                skipUpdateCheck);
         }
         catch (Exception ex)
         {
@@ -134,14 +141,14 @@ internal static class Program
 #endif
 
 #if WINDOWS
-    private static void RunDesktopShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter)
+    private static void RunDesktopShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter, bool skipUpdateCheck)
     {
         Exception? shellException = null;
         var shellThread = new Thread(() =>
         {
             try
             {
-                RunWindowsFormsShell(localUrl, webViewDataPath, iconPath, startupReporter);
+                RunWindowsFormsShell(localUrl, webViewDataPath, iconPath, startupReporter, skipUpdateCheck);
             }
             catch (Exception ex)
             {
@@ -159,7 +166,7 @@ internal static class Program
         }
     }
 
-    private static void RunWindowsFormsShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter)
+    private static void RunWindowsFormsShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter, bool skipUpdateCheck)
     {
         Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", WebView2Arguments);
         var releaseUpdateService = new DesktopReleaseUpdateService();
@@ -218,7 +225,7 @@ internal static class Program
                     if (navigationArgs.IsSuccess)
                     {
                         CloseSplash();
-                        if (!checkedForUpdates)
+                        if (!skipUpdateCheck && !checkedForUpdates)
                         {
                             checkedForUpdates = true;
                             _ = CheckForDesktopReleaseUpdateAsync(form, releaseUpdateService);
@@ -304,7 +311,7 @@ internal static class Program
         releaseUpdateService.RememberSkippedRelease(prompt.LatestReleaseTag);
     }
 #else
-    private static void RunDesktopShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter)
+    private static void RunDesktopShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter, bool skipUpdateCheck)
     {
         var window = new PhotinoWindow()
             .SetTitle("Starforged Atlas")

--- a/StarWin.Desktop/Program.cs
+++ b/StarWin.Desktop/Program.cs
@@ -162,6 +162,7 @@ internal static class Program
     private static void RunWindowsFormsShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter)
     {
         Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", WebView2Arguments);
+        var releaseUpdateService = new DesktopReleaseUpdateService();
 
         ApplicationConfiguration.Initialize();
 
@@ -184,6 +185,7 @@ internal static class Program
             Dock = DockStyle.Fill,
             DefaultBackgroundColor = Color.FromArgb(3, 7, 18)
         };
+        var checkedForUpdates = false;
 
         var splashClosed = false;
         void CloseSplash()
@@ -216,6 +218,11 @@ internal static class Program
                     if (navigationArgs.IsSuccess)
                     {
                         CloseSplash();
+                        if (!checkedForUpdates)
+                        {
+                            checkedForUpdates = true;
+                            _ = CheckForDesktopReleaseUpdateAsync(form, releaseUpdateService);
+                        }
                     }
                 };
                 webView.CoreWebView2.Navigate(localUrl);
@@ -236,6 +243,65 @@ internal static class Program
 
         form.FormClosed += (_, _) => CloseSplash();
         Application.Run(form);
+    }
+
+    private static async Task CheckForDesktopReleaseUpdateAsync(Form form, DesktopReleaseUpdateService releaseUpdateService)
+    {
+        var prompt = await releaseUpdateService.CheckForUpdateAsync(CancellationToken.None);
+        if (prompt is null || form.IsDisposed)
+        {
+            return;
+        }
+
+        if (form.InvokeRequired)
+        {
+            form.BeginInvoke(new Action(() => ShowDesktopReleaseUpdatePrompt(form, releaseUpdateService, prompt)));
+            return;
+        }
+
+        ShowDesktopReleaseUpdatePrompt(form, releaseUpdateService, prompt);
+    }
+
+    private static void ShowDesktopReleaseUpdatePrompt(
+        Form form,
+        DesktopReleaseUpdateService releaseUpdateService,
+        DesktopReleaseUpdatePrompt prompt)
+    {
+        if (form.IsDisposed)
+        {
+            return;
+        }
+
+        var releaseLabel = string.IsNullOrWhiteSpace(prompt.ReleaseName)
+            ? prompt.LatestReleaseTag
+            : $"{prompt.ReleaseName} ({prompt.LatestReleaseTag})";
+
+        var message = $"A newer version of Starforged Atlas is available.\r\n\r\nCurrent version: {prompt.CurrentReleaseTag}\r\nLatest version: {releaseLabel}\r\n\r\nOpen the latest GitHub release page so you can upgrade?";
+        var result = MessageBox.Show(
+            form,
+            message,
+            "Starforged Atlas update available",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Information);
+
+        if (result == DialogResult.Yes)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = prompt.ReleaseUrl,
+                    UseShellExecute = true
+                });
+            }
+            catch
+            {
+            }
+
+            return;
+        }
+
+        releaseUpdateService.RememberSkippedRelease(prompt.LatestReleaseTag);
     }
 #else
     private static void RunDesktopShell(string localUrl, string webViewDataPath, string iconPath, IDesktopStartupReporter startupReporter)
@@ -1163,6 +1229,11 @@ internal static class StarWinDesktopPaths
     public static string GetBackendStatePath()
     {
         return Path.Combine(GetApplicationDataRoot(), "desktop-backend-state.json");
+    }
+
+    public static string GetUpdatePromptStatePath()
+    {
+        return Path.Combine(GetApplicationDataRoot(), "desktop-update-state.json");
     }
 
     private static string? FindWebContentRoot(string startDirectory)

--- a/StarWin.Desktop/Program.cs
+++ b/StarWin.Desktop/Program.cs
@@ -279,11 +279,7 @@ internal static class Program
             return;
         }
 
-        var releaseLabel = string.IsNullOrWhiteSpace(prompt.ReleaseName)
-            ? prompt.LatestReleaseTag
-            : $"{prompt.ReleaseName} ({prompt.LatestReleaseTag})";
-
-        var message = $"A newer version of Starforged Atlas is available.\r\n\r\nCurrent version: {prompt.CurrentReleaseTag}\r\nLatest version: {releaseLabel}\r\n\r\nOpen the latest GitHub release page so you can upgrade?";
+        var message = DesktopReleaseUpdatePromptFormatter.BuildMessage(prompt);
         var result = MessageBox.Show(
             form,
             message,

--- a/StarWin.Desktop/Properties/AssemblyInfo.cs
+++ b/StarWin.Desktop/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("StarWin.Desktop.Tests")]

--- a/StarWin.Desktop/StarWin.Desktop.csproj
+++ b/StarWin.Desktop/StarWin.Desktop.csproj
@@ -31,10 +31,10 @@
     <AssemblyTitle>Starforged Atlas Desktop</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
-    <AssemblyVersion>2026.4.27.0</AssemblyVersion>
-    <FileVersion>2026.4.27.0</FileVersion>
-    <Version>2026.4.27.0</Version>
-    <InformationalVersion>2026-04-27-developer-preview</InformationalVersion>
+    <AssemblyVersion>2026.4.26.2</AssemblyVersion>
+    <FileVersion>2026.4.26.2</FileVersion>
+    <Version>2026.4.26.2</Version>
+    <InformationalVersion>2026-04-26.2-developer-preview</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/StarWin.Desktop/StarWin.Desktop.csproj
+++ b/StarWin.Desktop/StarWin.Desktop.csproj
@@ -31,6 +31,11 @@
     <AssemblyTitle>Starforged Atlas Desktop</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
+    <AssemblyVersion>2026.4.27.0</AssemblyVersion>
+    <FileVersion>2026.4.27.0</FileVersion>
+    <Version>2026.4.27.0</Version>
+    <InformationalVersion>2026-04-27-developer-preview</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">

--- a/StarWin.Desktop/StarWin.Desktop.csproj
+++ b/StarWin.Desktop/StarWin.Desktop.csproj
@@ -31,10 +31,10 @@
     <AssemblyTitle>Starforged Atlas Desktop</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
-    <AssemblyVersion>2026.4.26.2</AssemblyVersion>
-    <FileVersion>2026.4.26.2</FileVersion>
-    <Version>2026.4.26.2</Version>
-    <InformationalVersion>2026-04-26.2-developer-preview</InformationalVersion>
+    <AssemblyVersion>2026.4.27.1</AssemblyVersion>
+    <FileVersion>2026.4.27.1</FileVersion>
+    <Version>2026.4.27.1</Version>
+    <InformationalVersion>2026-04-27.1-developer-preview</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/StarWin.Desktop/Updates/DesktopReleaseUpdateService.cs
+++ b/StarWin.Desktop/Updates/DesktopReleaseUpdateService.cs
@@ -62,7 +62,8 @@ internal sealed class DesktopReleaseUpdateService
             return new GitHubReleaseInfo(
                 payload.TagName,
                 string.IsNullOrWhiteSpace(payload.HtmlUrl) ? LatestReleasePageUri.AbsoluteUri : payload.HtmlUrl,
-                payload.Name);
+                payload.Name,
+                payload.Body);
         }
         catch
         {
@@ -84,13 +85,14 @@ internal static class DesktopAppVersion
     }
 }
 
-internal sealed record GitHubReleaseInfo(string TagName, string HtmlUrl, string? Name);
+internal sealed record GitHubReleaseInfo(string TagName, string HtmlUrl, string? Name, string? Body);
 
 internal sealed record DesktopReleaseUpdatePrompt(
     string CurrentReleaseTag,
     string LatestReleaseTag,
     string ReleaseUrl,
-    string? ReleaseName);
+    string? ReleaseName,
+    string? ReleaseNotes);
 
 internal static class DesktopReleaseUpdateEvaluator
 {
@@ -119,7 +121,63 @@ internal static class DesktopReleaseUpdateEvaluator
             currentReleaseTag,
             latestRelease.TagName,
             latestRelease.HtmlUrl,
-            latestRelease.Name);
+            latestRelease.Name,
+            latestRelease.Body);
+    }
+}
+
+internal static class DesktopReleaseUpdatePromptFormatter
+{
+    private const int MaxReleaseNotesLines = 12;
+    private const int MaxReleaseNotesCharacters = 1200;
+
+    public static string BuildMessage(DesktopReleaseUpdatePrompt prompt)
+    {
+        var releaseLabel = string.IsNullOrWhiteSpace(prompt.ReleaseName)
+            ? prompt.LatestReleaseTag
+            : $"{prompt.ReleaseName} ({prompt.LatestReleaseTag})";
+        var releaseNotes = FormatReleaseNotes(prompt.ReleaseNotes);
+
+        return
+            $"A newer version of Starforged Atlas is available.{Environment.NewLine}{Environment.NewLine}" +
+            $"Current version: {prompt.CurrentReleaseTag}{Environment.NewLine}" +
+            $"Latest version: {releaseLabel}{Environment.NewLine}{Environment.NewLine}" +
+            $"Release notes:{Environment.NewLine}{releaseNotes}{Environment.NewLine}{Environment.NewLine}" +
+            "Open the latest GitHub release page so you can upgrade?";
+    }
+
+    public static string FormatReleaseNotes(string? releaseNotes)
+    {
+        if (string.IsNullOrWhiteSpace(releaseNotes))
+        {
+            return "No release notes were provided for this release.";
+        }
+
+        var normalized = releaseNotes.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Trim();
+        var lines = normalized.Split('\n');
+        for (var index = 0; index < lines.Length; index++)
+        {
+            lines[index] = lines[index].TrimEnd();
+        }
+
+        var includedLineCount = Math.Min(lines.Length, MaxReleaseNotesLines);
+        var limited = string.Join(Environment.NewLine, lines, 0, includedLineCount);
+        var truncated = lines.Length > MaxReleaseNotesLines;
+
+        if (limited.Length > MaxReleaseNotesCharacters)
+        {
+            limited = limited[..MaxReleaseNotesCharacters].TrimEnd();
+            truncated = true;
+        }
+
+        if (truncated)
+        {
+            limited = $"{limited}{Environment.NewLine}...{Environment.NewLine}See GitHub for the full release notes.";
+        }
+
+        return limited;
     }
 }
 
@@ -243,4 +301,7 @@ internal sealed class GitHubLatestReleaseResponse
 
     [JsonPropertyName("name")]
     public string? Name { get; set; }
+
+    [JsonPropertyName("body")]
+    public string? Body { get; set; }
 }

--- a/StarWin.Desktop/Updates/DesktopReleaseUpdateService.cs
+++ b/StarWin.Desktop/Updates/DesktopReleaseUpdateService.cs
@@ -1,0 +1,246 @@
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+internal sealed class DesktopReleaseUpdateService
+{
+    private static readonly Uri LatestReleaseApiUri = new("https://api.github.com/repos/darkdhamon/Slip-Map-Tool/releases/latest");
+    private static readonly Uri LatestReleasePageUri = new("https://github.com/darkdhamon/Slip-Map-Tool/releases/latest");
+
+    public async Task<DesktopReleaseUpdatePrompt?> CheckForUpdateAsync(CancellationToken cancellationToken)
+    {
+        var currentReleaseTag = DesktopAppVersion.GetCurrentReleaseTag();
+        if (!StarforgedReleaseVersion.TryParse(currentReleaseTag, out var currentVersion))
+        {
+            return null;
+        }
+
+        var latestRelease = await TryGetLatestReleaseAsync(cancellationToken);
+        if (latestRelease is null)
+        {
+            return null;
+        }
+
+        var skippedReleaseTag = DesktopUpdatePromptStateStore.Load().SkippedReleaseTag;
+        return DesktopReleaseUpdateEvaluator.Evaluate(currentVersion, currentReleaseTag, skippedReleaseTag, latestRelease);
+    }
+
+    public void RememberSkippedRelease(string releaseTag)
+    {
+        DesktopUpdatePromptStateStore.Save(new DesktopUpdatePromptState
+        {
+            SkippedReleaseTag = releaseTag
+        });
+    }
+
+    private static async Task<GitHubReleaseInfo?> TryGetLatestReleaseAsync(CancellationToken cancellationToken)
+    {
+        using var client = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("StarforgedAtlasDesktop", "1.0"));
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+        try
+        {
+            using var response = await client.GetAsync(LatestReleaseApiUri, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            var payload = await JsonSerializer.DeserializeAsync<GitHubLatestReleaseResponse>(stream, cancellationToken: cancellationToken);
+            if (payload is null || string.IsNullOrWhiteSpace(payload.TagName))
+            {
+                return null;
+            }
+
+            return new GitHubReleaseInfo(
+                payload.TagName,
+                string.IsNullOrWhiteSpace(payload.HtmlUrl) ? LatestReleasePageUri.AbsoluteUri : payload.HtmlUrl,
+                payload.Name);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+internal static class DesktopAppVersion
+{
+    public static string GetCurrentReleaseTag()
+    {
+        var assembly = typeof(DesktopAppVersion).Assembly;
+        return assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
+    }
+}
+
+internal sealed record GitHubReleaseInfo(string TagName, string HtmlUrl, string? Name);
+
+internal sealed record DesktopReleaseUpdatePrompt(
+    string CurrentReleaseTag,
+    string LatestReleaseTag,
+    string ReleaseUrl,
+    string? ReleaseName);
+
+internal static class DesktopReleaseUpdateEvaluator
+{
+    public static DesktopReleaseUpdatePrompt? Evaluate(
+        StarforgedReleaseVersion currentVersion,
+        string currentReleaseTag,
+        string? skippedReleaseTag,
+        GitHubReleaseInfo latestRelease)
+    {
+        if (!StarforgedReleaseVersion.TryParse(latestRelease.TagName, out var latestVersion))
+        {
+            return null;
+        }
+
+        if (latestVersion.CompareTo(currentVersion) <= 0)
+        {
+            return null;
+        }
+
+        if (string.Equals(skippedReleaseTag, latestRelease.TagName, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return new DesktopReleaseUpdatePrompt(
+            currentReleaseTag,
+            latestRelease.TagName,
+            latestRelease.HtmlUrl,
+            latestRelease.Name);
+    }
+}
+
+internal readonly record struct StarforgedReleaseVersion(int Year, int Month, int Day, int Revision) : IComparable<StarforgedReleaseVersion>
+{
+    public int CompareTo(StarforgedReleaseVersion other)
+    {
+        var yearComparison = Year.CompareTo(other.Year);
+        if (yearComparison != 0)
+        {
+            return yearComparison;
+        }
+
+        var monthComparison = Month.CompareTo(other.Month);
+        if (monthComparison != 0)
+        {
+            return monthComparison;
+        }
+
+        var dayComparison = Day.CompareTo(other.Day);
+        if (dayComparison != 0)
+        {
+            return dayComparison;
+        }
+
+        return Revision.CompareTo(other.Revision);
+    }
+
+    public static bool TryParse(string? value, out StarforgedReleaseVersion version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmedValue = value.Trim();
+        const string developerPreviewSuffix = "-developer-preview";
+        if (trimmedValue.EndsWith(developerPreviewSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            trimmedValue = trimmedValue[..^developerPreviewSuffix.Length];
+        }
+
+        if (trimmedValue.StartsWith('v') || trimmedValue.StartsWith('V'))
+        {
+            trimmedValue = trimmedValue[1..];
+        }
+
+        var segments = trimmedValue.Split('.', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var datePortion = segments[0];
+        var revisionPortion = segments.Length == 2 ? segments[1] : "0";
+
+        var dateSegments = datePortion.Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (dateSegments.Length != 3
+            || !int.TryParse(dateSegments[0], out var year)
+            || !int.TryParse(dateSegments[1], out var month)
+            || !int.TryParse(dateSegments[2], out var day)
+            || !int.TryParse(revisionPortion, out var revision))
+        {
+            return false;
+        }
+
+        try
+        {
+            _ = new DateOnly(year, month, day);
+        }
+        catch
+        {
+            return false;
+        }
+
+        version = new StarforgedReleaseVersion(year, month, day, revision);
+        return true;
+    }
+}
+
+internal sealed class DesktopUpdatePromptState
+{
+    public string? SkippedReleaseTag { get; set; }
+}
+
+internal static class DesktopUpdatePromptStateStore
+{
+    public static DesktopUpdatePromptState Load()
+    {
+        var path = StarWinDesktopPaths.GetUpdatePromptStatePath();
+        if (!File.Exists(path))
+        {
+            return new DesktopUpdatePromptState();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<DesktopUpdatePromptState>(json) ?? new DesktopUpdatePromptState();
+        }
+        catch
+        {
+            return new DesktopUpdatePromptState();
+        }
+    }
+
+    public static void Save(DesktopUpdatePromptState state)
+    {
+        var path = StarWinDesktopPaths.GetUpdatePromptStatePath();
+        var json = JsonSerializer.Serialize(state, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+        File.WriteAllText(path, json);
+    }
+}
+
+internal sealed class GitHubLatestReleaseResponse
+{
+    [JsonPropertyName("tag_name")]
+    public string? TagName { get; set; }
+
+    [JsonPropertyName("html_url")]
+    public string? HtmlUrl { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/StarWin.Infrastructure.Tests/AppConfiguration/StarWinDatabaseMigrationTests.cs
+++ b/StarWin.Infrastructure.Tests/AppConfiguration/StarWinDatabaseMigrationTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using StarWin.Infrastructure.Data;
+using Xunit;
+
+namespace StarWin.Infrastructure.Tests.AppConfiguration;
+
+public sealed class StarWinDatabaseMigrationTests
+{
+    [Fact]
+    public async Task MigrateStarWinDatabaseAsync_creates_fresh_sqlite_schema_without_sqlserver_migration_failures()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var serviceProvider = BuildServiceProvider(databasePath);
+
+            await serviceProvider.MigrateStarWinDatabaseAsync();
+
+            await using var verificationContext = serviceProvider.GetRequiredService<IDbContextFactory<StarWinDbContext>>().CreateDbContext();
+            Assert.True(await verificationContext.Database.CanConnectAsync());
+            Assert.True(await verificationContext.Database.EnsureCreatedAsync() is false);
+            Assert.True(await TableExistsAsync(verificationContext, "Sectors"));
+            Assert.True(await TableExistsAsync(verificationContext, "StarSystems"));
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task MigrateStarWinDatabaseAsync_recovers_from_partial_sqlite_migration_artifacts()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await CreatePartialMigrationHistoryAsync(databasePath);
+            await using var serviceProvider = BuildServiceProvider(databasePath);
+
+            await serviceProvider.MigrateStarWinDatabaseAsync();
+
+            await using var verificationContext = serviceProvider.GetRequiredService<IDbContextFactory<StarWinDbContext>>().CreateDbContext();
+            Assert.True(await TableExistsAsync(verificationContext, "Sectors"));
+            Assert.True(await TableExistsAsync(verificationContext, "StarSystems"));
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    private static ServiceProvider BuildServiceProvider(string databasePath)
+    {
+        var services = new ServiceCollection();
+        void ConfigureDatabase(DbContextOptionsBuilder options)
+        {
+            options.ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning));
+            options.UseSqlite($"Data Source={databasePath}");
+        }
+
+        services.AddDbContext<StarWinDbContext>(
+            ConfigureDatabase,
+            contextLifetime: ServiceLifetime.Scoped,
+            optionsLifetime: ServiceLifetime.Singleton);
+        services.AddDbContextFactory<StarWinDbContext>(ConfigureDatabase);
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<bool> TableExistsAsync(StarWinDbContext dbContext, string tableName)
+    {
+        var connection = dbContext.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = $name;";
+
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = tableName;
+        command.Parameters.Add(parameter);
+
+        var result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result) > 0;
+    }
+
+    private static string CreateTempFilePath(string extension)
+    {
+        return Path.Combine(Path.GetTempPath(), $"starwin-migrate-{Guid.NewGuid():N}{extension}");
+    }
+
+    private static async Task CreatePartialMigrationHistoryAsync(string databasePath)
+    {
+        await using var connection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={databasePath}");
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            CREATE TABLE "__EFMigrationsHistory" (
+                "MigrationId" TEXT NOT NULL CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY,
+                "ProductVersion" TEXT NOT NULL
+            );
+
+            CREATE TABLE "__EFMigrationsLock" (
+                "Id" INTEGER NOT NULL CONSTRAINT "PK___EFMigrationsLock" PRIMARY KEY,
+                "Timestamp" TEXT NOT NULL
+            );
+            """;
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/StarWin.Infrastructure/DependencyInjection.cs
+++ b/StarWin.Infrastructure/DependencyInjection.cs
@@ -78,14 +78,50 @@ public static class DependencyInjection
 
         if (dbContext.Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true)
         {
+            if (!await HasRequiredSqliteApplicationSchemaAsync(dbContext))
+            {
+                await dbContext.Database.EnsureDeletedAsync();
+                await dbContext.Database.EnsureCreatedAsync();
+                await StarSystemNameUniqueness.EnsureUniquePersistedNamesAsync(dbContext);
+                return;
+            }
+
             await UpgradeSqliteDatabaseAsync(dbContext);
-            await StarSystemNameUniqueness.EnsureUniquePersistedNamesAsync(dbContext);
             await dbContext.Database.MigrateAsync();
+            await StarSystemNameUniqueness.EnsureUniquePersistedNamesAsync(dbContext);
             return;
         }
 
-        await StarSystemNameUniqueness.EnsureUniquePersistedNamesAsync(dbContext);
         await dbContext.Database.MigrateAsync();
+        await StarSystemNameUniqueness.EnsureUniquePersistedNamesAsync(dbContext);
+    }
+
+    private static async Task<bool> HasRequiredSqliteApplicationSchemaAsync(StarWinDbContext dbContext)
+    {
+        var connectionString = dbContext.Database.GetConnectionString();
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return false;
+        }
+
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        var databasePath = builder.DataSource;
+        if (string.IsNullOrWhiteSpace(databasePath) || databasePath.Equals(":memory:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        databasePath = Path.GetFullPath(databasePath);
+        if (!File.Exists(databasePath))
+        {
+            return false;
+        }
+
+        await using var connection = new SqliteConnection(builder.ConnectionString);
+        await connection.OpenAsync();
+
+        return await TableExistsAsync(connection, "Sectors")
+            && await TableExistsAsync(connection, "StarSystems");
     }
 
     private static async Task UpgradeSqliteDatabaseAsync(StarWinDbContext dbContext)

--- a/StarforgedAtlas.PortableLauncher.Tests/GlobalUsings.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -290,6 +290,75 @@ public sealed class PortableLauncherVersionTests
     }
 
     [Fact]
+    public void LocalUpdateSource_round_trips_through_override_store()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-override-test-{Guid.NewGuid():N}");
+        var packagePath = Path.Combine(root, "updates", "Starforged-Atlas-Portable.zip");
+        Directory.CreateDirectory(Path.Combine(root, "app", "data"));
+        Directory.CreateDirectory(Path.GetDirectoryName(packagePath)!);
+        File.WriteAllText(packagePath, "zip");
+
+        try
+        {
+            PortableUpdateSourceOverrideStore.Save(
+                root,
+                new PortableUpdateSourceOverride(
+                    "2026-04-27.0-developer-preview",
+                    "Developer Preview",
+                    packagePath,
+                    "- Broken test package"));
+
+            var updateOverride = PortableUpdateSourceOverrideStore.Load(root);
+
+            Assert.NotNull(updateOverride);
+            Assert.Equal("2026-04-27.0-developer-preview", updateOverride!.ReleaseTag);
+            Assert.Equal(packagePath, updateOverride.PackagePath);
+            Assert.Equal("- Broken test package", updateOverride.ReleaseNotes);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void TryCreateLocalOverrideUpdate_returns_local_package_when_newer_release_exists()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-local-update-test-{Guid.NewGuid():N}");
+        var packagePath = Path.Combine(root, "Starforged-Atlas-Portable.zip");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(packagePath, "zip");
+
+        try
+        {
+            var update = global::PortableLauncher.TryCreateLocalOverrideUpdate(
+                new PortableUpdateSourceOverride(
+                    "2026-04-27.0-developer-preview",
+                    "Developer Preview",
+                    packagePath,
+                    "- Broken test package"),
+                "2026-04-26.2-developer-preview",
+                new StarforgedReleaseVersion(2026, 4, 26, 2),
+                new PortableUpdateState([], null));
+
+            Assert.NotNull(update);
+            Assert.True(update!.IsLocalPackage);
+            Assert.Equal(packagePath, update.DownloadUrl);
+            Assert.Equal("2026-04-27.0-developer-preview", update.ReleaseTag);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void BuildIssueDraftUri_contains_release_context()
     {
         var body = PortableUpdateFailureReporter.BuildIssueBody(

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -54,4 +54,49 @@ public sealed class PortableLauncherVersionTests
             }
         }
     }
+
+    [Fact]
+    public void InstallPackage_reports_progress_for_each_install_stage()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-progress-test-{Guid.NewGuid():N}");
+        var targetRoot = Path.Combine(root, "target");
+        var stagingRoot = Path.Combine(root, "staging");
+        var preservedDataRoot = Path.Combine(root, "preserved-data");
+        var reportedProgress = new List<UpdateProgressInfo>();
+
+        Directory.CreateDirectory(Path.Combine(targetRoot, "app", "data"));
+        Directory.CreateDirectory(Path.Combine(stagingRoot, "app"));
+
+        File.WriteAllText(Path.Combine(targetRoot, "app", "data", "settings.json"), "{ \"theme\": \"legacy\" }");
+        File.WriteAllText(Path.Combine(stagingRoot, "app", "new.txt"), "new");
+        File.WriteAllText(Path.Combine(stagingRoot, "Starforged Atlas.exe"), "launcher");
+
+        try
+        {
+            PortablePackageInstaller.InstallPackage(
+                stagingRoot,
+                targetRoot,
+                preservedDataRoot,
+                new CollectingProgress<UpdateProgressInfo>(reportedProgress));
+
+            Assert.Collection(
+                reportedProgress,
+                update => Assert.Equal("Preserving your portable data...", update.Message),
+                update => Assert.Equal("Replacing application files...", update.Message),
+                update => Assert.Equal("Restoring your portable data...", update.Message),
+                update => Assert.Equal("Finishing the update...", update.Message));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    private sealed class CollectingProgress<T>(List<T> values) : IProgress<T>
+    {
+        public void Report(T value) => values.Add(value);
+    }
 }

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -234,6 +234,29 @@ public sealed class PortableLauncherVersionTests
         Assert.Contains("2026-04-27.0-developer-preview", Uri.UnescapeDataString(issueUri.Query), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BuildAvailableUpdatePromptMessage_includes_release_notes()
+    {
+        var message = global::PortableLauncher.BuildAvailableUpdatePromptMessage(
+            new PortableReleaseUpdate(
+                "2026-04-26.2-developer-preview",
+                "2026-04-27.0-developer-preview",
+                "Developer Preview",
+                "https://github.com/darkdhamon/Slip-Map-Tool/releases/download/2026-04-27.0-developer-preview/Starforged-Atlas-Portable.zip",
+                "- Added desktop update notes"));
+
+        Assert.Contains("Release notes:", message, StringComparison.Ordinal);
+        Assert.Contains("- Added desktop update notes", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatReleaseNotesForPrompt_returns_fallback_when_notes_missing()
+    {
+        var notes = global::PortableLauncher.FormatReleaseNotesForPrompt(null);
+
+        Assert.Equal("No release notes were provided for this release.", notes);
+    }
+
     private sealed class CollectingProgress<T>(List<T> values) : IProgress<T>
     {
         public void Report(T value) => values.Add(value);

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -221,6 +221,75 @@ public sealed class PortableLauncherVersionTests
     }
 
     [Fact]
+    public void PendingValidation_round_trips_through_portable_state_store()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-validation-state-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(root, "app", "data"));
+
+        try
+        {
+            PortableUpdateStateStore.SavePendingValidation(
+                root,
+                new PortableUpdateValidationContext(
+                    root,
+                    "2026-04-27.0-developer-preview",
+                    "2026-04-26.2-developer-preview",
+                    @"C:\temp\backup"));
+
+            var pending = PortableUpdateStateStore.LoadPendingValidation(root);
+
+            Assert.NotNull(pending);
+            Assert.Equal("2026-04-27.0-developer-preview", pending!.ReleaseTag);
+            Assert.Equal("2026-04-26.2-developer-preview", pending.PreviousVersion);
+            Assert.Equal(@"C:\temp\backup", pending.BackupRoot);
+
+            PortableUpdateStateStore.ClearPendingValidation(root);
+
+            Assert.Null(PortableUpdateStateStore.LoadPendingValidation(root));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void IgnoreRelease_preserves_pending_validation_state()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-combined-state-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(root, "app", "data"));
+
+        try
+        {
+            PortableUpdateStateStore.SavePendingValidation(
+                root,
+                new PortableUpdateValidationContext(
+                    root,
+                    "2026-04-27.0-developer-preview",
+                    "2026-04-26.2-developer-preview",
+                    @"C:\temp\backup"));
+
+            PortableUpdateStateStore.IgnoreRelease(root, "2026-04-27.0-developer-preview");
+
+            var state = PortableUpdateStateStore.Load(root);
+
+            Assert.True(state.ShouldIgnore("2026-04-27.0-developer-preview"));
+            Assert.NotNull(state.PendingValidation);
+            Assert.Equal("2026-04-27.0-developer-preview", state.PendingValidation!.ReleaseTag);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void BuildIssueDraftUri_contains_release_context()
     {
         var body = PortableUpdateFailureReporter.BuildIssueBody(

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -1,0 +1,57 @@
+namespace StarforgedAtlas.PortableLauncher.Tests;
+
+public sealed class PortableLauncherVersionTests
+{
+    [Fact]
+    public void TryParse_accepts_revisioned_developer_preview_tag()
+    {
+        var parsed = StarforgedReleaseVersion.TryParse("2026-04-27.0-developer-preview", out var version);
+
+        Assert.True(parsed);
+        Assert.Equal(new StarforgedReleaseVersion(2026, 4, 27, 0), version);
+    }
+
+    [Fact]
+    public void CompareTo_orders_newer_release_higher()
+    {
+        var older = new StarforgedReleaseVersion(2026, 4, 27, 0);
+        var newer = new StarforgedReleaseVersion(2026, 4, 27, 1);
+
+        Assert.True(newer.CompareTo(older) > 0);
+    }
+
+    [Fact]
+    public void InstallPackage_replaces_app_files_and_preserves_existing_data()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-test-{Guid.NewGuid():N}");
+        var targetRoot = Path.Combine(root, "target");
+        var stagingRoot = Path.Combine(root, "staging");
+        var preservedDataRoot = Path.Combine(root, "preserved-data");
+
+        Directory.CreateDirectory(Path.Combine(targetRoot, "app", "data"));
+        Directory.CreateDirectory(Path.Combine(stagingRoot, "app"));
+
+        File.WriteAllText(Path.Combine(targetRoot, "app", "old.txt"), "old");
+        File.WriteAllText(Path.Combine(targetRoot, "app", "data", "settings.json"), "{ \"theme\": \"legacy\" }");
+        File.WriteAllText(Path.Combine(stagingRoot, "app", "new.txt"), "new");
+        File.WriteAllText(Path.Combine(stagingRoot, "Starforged Atlas.exe"), "launcher");
+
+        try
+        {
+            PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataRoot);
+
+            Assert.False(File.Exists(Path.Combine(targetRoot, "app", "old.txt")));
+            Assert.True(File.Exists(Path.Combine(targetRoot, "app", "new.txt")));
+            Assert.Equal(
+                "{ \"theme\": \"legacy\" }",
+                File.ReadAllText(Path.Combine(targetRoot, "app", "data", "settings.json")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -95,6 +95,26 @@ public sealed class PortableLauncherVersionTests
         }
     }
 
+    [Fact]
+    public void CreateUpdateHelperStartInfo_preserves_trailing_backslash_arguments()
+    {
+        var startInfo = global::PortableLauncher.CreateUpdateHelperStartInfo(
+            @"C:\temp\StarforgedAtlas.UpdateHelper.exe",
+            @"C:\temp",
+            @"C:\temp\package",
+            @"C:\portable\Starforged-Atlas-Portable\",
+            4321);
+
+        Assert.Equal(7, startInfo.ArgumentList.Count);
+        Assert.Equal("--apply-update", startInfo.ArgumentList[0]);
+        Assert.Equal("--staging-root", startInfo.ArgumentList[1]);
+        Assert.Equal(@"C:\temp\package", startInfo.ArgumentList[2]);
+        Assert.Equal("--target-root", startInfo.ArgumentList[3]);
+        Assert.Equal(@"C:\portable\Starforged-Atlas-Portable\", startInfo.ArgumentList[4]);
+        Assert.Equal("--wait-for-pid", startInfo.ArgumentList[5]);
+        Assert.Equal("4321", startInfo.ArgumentList[6]);
+    }
+
     private sealed class CollectingProgress<T>(List<T> values) : IProgress<T>
     {
         public void Report(T value) => values.Add(value);

--- a/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
+++ b/StarforgedAtlas.PortableLauncher.Tests/PortableLauncherVersionTests.cs
@@ -38,7 +38,11 @@ public sealed class PortableLauncherVersionTests
 
         try
         {
-            PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataRoot);
+            PortablePackageInstaller.InstallPackage(
+                stagingRoot,
+                targetRoot,
+                preservedDataRoot,
+                Path.Combine(root, "backup"));
 
             Assert.False(File.Exists(Path.Combine(targetRoot, "app", "old.txt")));
             Assert.True(File.Exists(Path.Combine(targetRoot, "app", "new.txt")));
@@ -77,10 +81,12 @@ public sealed class PortableLauncherVersionTests
                 stagingRoot,
                 targetRoot,
                 preservedDataRoot,
+                Path.Combine(root, "backup"),
                 new CollectingProgress<UpdateProgressInfo>(reportedProgress));
 
             Assert.Collection(
                 reportedProgress,
+                update => Assert.Equal("Creating a rollback backup...", update.Message),
                 update => Assert.Equal("Preserving your portable data...", update.Message),
                 update => Assert.Equal("Replacing application files...", update.Message),
                 update => Assert.Equal("Restoring your portable data...", update.Message),
@@ -103,16 +109,129 @@ public sealed class PortableLauncherVersionTests
             @"C:\temp",
             @"C:\temp\package",
             @"C:\portable\Starforged-Atlas-Portable\",
+            @"C:\temp\backup",
+            "2026-04-27.0-developer-preview",
+            "2026-04-26.2-developer-preview",
             4321);
 
-        Assert.Equal(7, startInfo.ArgumentList.Count);
+        Assert.Equal(13, startInfo.ArgumentList.Count);
         Assert.Equal("--apply-update", startInfo.ArgumentList[0]);
         Assert.Equal("--staging-root", startInfo.ArgumentList[1]);
         Assert.Equal(@"C:\temp\package", startInfo.ArgumentList[2]);
         Assert.Equal("--target-root", startInfo.ArgumentList[3]);
         Assert.Equal(@"C:\portable\Starforged-Atlas-Portable\", startInfo.ArgumentList[4]);
-        Assert.Equal("--wait-for-pid", startInfo.ArgumentList[5]);
-        Assert.Equal("4321", startInfo.ArgumentList[6]);
+        Assert.Equal("--backup-root", startInfo.ArgumentList[5]);
+        Assert.Equal(@"C:\temp\backup", startInfo.ArgumentList[6]);
+        Assert.Equal("--release-tag", startInfo.ArgumentList[7]);
+        Assert.Equal("2026-04-27.0-developer-preview", startInfo.ArgumentList[8]);
+        Assert.Equal("--previous-version", startInfo.ArgumentList[9]);
+        Assert.Equal("2026-04-26.2-developer-preview", startInfo.ArgumentList[10]);
+        Assert.Equal("--wait-for-pid", startInfo.ArgumentList[11]);
+        Assert.Equal("4321", startInfo.ArgumentList[12]);
+    }
+
+    [Fact]
+    public void CreateRestoreBackupHelperStartInfo_preserves_restore_arguments()
+    {
+        var startInfo = global::PortableLauncher.CreateRestoreBackupHelperStartInfo(
+            @"C:\temp\StarforgedAtlas.UpdateHelper.exe",
+            @"C:\temp",
+            @"C:\temp\backup",
+            @"C:\portable\Starforged-Atlas-Portable\",
+            "2026-04-27.0-developer-preview",
+            "2026-04-26.2-developer-preview",
+            4321);
+
+        Assert.Equal(11, startInfo.ArgumentList.Count);
+        Assert.Equal("--restore-backup", startInfo.ArgumentList[0]);
+        Assert.Equal("--backup-root", startInfo.ArgumentList[1]);
+        Assert.Equal(@"C:\temp\backup", startInfo.ArgumentList[2]);
+        Assert.Equal("--target-root", startInfo.ArgumentList[3]);
+        Assert.Equal(@"C:\portable\Starforged-Atlas-Portable\", startInfo.ArgumentList[4]);
+        Assert.Equal("--release-tag", startInfo.ArgumentList[5]);
+        Assert.Equal("2026-04-27.0-developer-preview", startInfo.ArgumentList[6]);
+        Assert.Equal("--previous-version", startInfo.ArgumentList[7]);
+        Assert.Equal("2026-04-26.2-developer-preview", startInfo.ArgumentList[8]);
+        Assert.Equal("--wait-for-pid", startInfo.ArgumentList[9]);
+        Assert.Equal("4321", startInfo.ArgumentList[10]);
+    }
+
+    [Fact]
+    public void RestoreBackup_restores_original_portable_files()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-restore-test-{Guid.NewGuid():N}");
+        var targetRoot = Path.Combine(root, "target");
+        var stagingRoot = Path.Combine(root, "staging");
+        var preservedDataRoot = Path.Combine(root, "preserved-data");
+        var backupRoot = Path.Combine(root, "backup");
+
+        Directory.CreateDirectory(Path.Combine(targetRoot, "app", "data"));
+        Directory.CreateDirectory(Path.Combine(stagingRoot, "app"));
+
+        File.WriteAllText(Path.Combine(targetRoot, "app", "old.txt"), "old");
+        File.WriteAllText(Path.Combine(targetRoot, "app", "data", "settings.json"), "{ \"theme\": \"legacy\" }");
+        File.WriteAllText(Path.Combine(stagingRoot, "app", "new.txt"), "new");
+        File.WriteAllText(Path.Combine(stagingRoot, "Starforged Atlas.exe"), "launcher");
+
+        try
+        {
+            PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataRoot, backupRoot);
+
+            File.WriteAllText(Path.Combine(targetRoot, "app", "new.txt"), "modified");
+            File.WriteAllText(Path.Combine(targetRoot, "app", "data", "settings.json"), "{ \"theme\": \"updated\" }");
+
+            PortablePackageInstaller.RestoreBackup(backupRoot, targetRoot);
+
+            Assert.True(File.Exists(Path.Combine(targetRoot, "app", "old.txt")));
+            Assert.False(File.Exists(Path.Combine(targetRoot, "app", "new.txt")));
+            Assert.Equal(
+                "{ \"theme\": \"legacy\" }",
+                File.ReadAllText(Path.Combine(targetRoot, "app", "data", "settings.json")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void IgnoreRelease_persists_release_tag_for_future_checks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"portable-launcher-state-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(root, "app", "data"));
+
+        try
+        {
+            PortableUpdateStateStore.IgnoreRelease(root, "2026-04-27.0-developer-preview");
+
+            var state = PortableUpdateStateStore.Load(root);
+
+            Assert.True(state.ShouldIgnore("2026-04-27.0-developer-preview"));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void BuildIssueDraftUri_contains_release_context()
+    {
+        var body = PortableUpdateFailureReporter.BuildIssueBody(
+            "2026-04-27.0-developer-preview",
+            "2026-04-26.2-developer-preview");
+        var issueUri = PortableUpdateFailureReporter.BuildIssueDraftUri(
+            "Bugfix: portable update rollback for 2026-04-27.0-developer-preview",
+            body);
+
+        Assert.Contains("issues/new", issueUri.ToString(), StringComparison.Ordinal);
+        Assert.Contains("2026-04-27.0-developer-preview", Uri.UnescapeDataString(issueUri.Query), StringComparison.Ordinal);
     }
 
     private sealed class CollectingProgress<T>(List<T> values) : IProgress<T>

--- a/StarforgedAtlas.PortableLauncher.Tests/StarforgedAtlas.PortableLauncher.Tests.csproj
+++ b/StarforgedAtlas.PortableLauncher.Tests/StarforgedAtlas.PortableLauncher.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StarforgedAtlas.PortableLauncher\StarforgedAtlas.PortableLauncher.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
 using System.Net.Http.Headers;
+using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -15,6 +16,7 @@ internal sealed class PortableLauncher
     private const string StagingRootArgument = "--staging-root";
     private const string TargetRootArgument = "--target-root";
     private const string WaitForPidArgument = "--wait-for-pid";
+    private const string HelperExecutableName = "StarforgedAtlas.UpdateHelper.exe";
     private static readonly Uri LatestReleaseApiUri = new("https://api.github.com/repos/darkdhamon/Slip-Map-Tool/releases/latest");
 
     public async Task RunAsync(string[] args)
@@ -139,46 +141,118 @@ internal sealed class PortableLauncher
 
         try
         {
-            using var client = new HttpClient
-            {
-                Timeout = TimeSpan.FromMinutes(5)
-            };
+            await LauncherProgressDialog.RunAsync(
+                "Starforged Atlas update",
+                "Downloading the latest portable release...",
+                async progress =>
+                {
+                    using var client = new HttpClient
+                    {
+                        Timeout = TimeSpan.FromMinutes(5)
+                    };
 
-            await using (var responseStream = await client.GetStreamAsync(update.DownloadUrl))
-            await using (var fileStream = File.Create(zipPath))
-            {
-                await responseStream.CopyToAsync(fileStream);
-            }
+                    client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("StarforgedAtlasPortableLauncher", "1.0"));
 
-            ZipFile.ExtractToDirectory(zipPath, extractRoot);
+                    progress.Report(new UpdateProgressInfo("Connecting to GitHub...", update.ReleaseTag, null));
 
-            var extractedLauncherPath = Path.Combine(extractRoot, LauncherExecutableName);
-            var extractedDesktopPath = Path.Combine(extractRoot, "app", DesktopExecutableName);
-            if (!File.Exists(extractedLauncherPath) || !File.Exists(extractedDesktopPath))
-            {
-                throw new InvalidOperationException("The downloaded portable package is missing the launcher or desktop executable.");
-            }
+                    using var response = await client.GetAsync(
+                        update.DownloadUrl,
+                        HttpCompletionOption.ResponseHeadersRead);
 
-            var currentProcessId = Environment.ProcessId;
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = extractedLauncherPath,
-                UseShellExecute = true,
-                WorkingDirectory = extractRoot,
-                Arguments =
-                    $"{ApplyUpdateArgument} " +
-                    $"{StagingRootArgument} \"{extractRoot}\" " +
-                    $"{TargetRootArgument} \"{packageRoot}\" " +
-                    $"{WaitForPidArgument} {currentProcessId}"
-            };
+                    response.EnsureSuccessStatusCode();
 
-            Process.Start(startInfo);
+                    var totalBytes = response.Content.Headers.ContentLength;
+                    await using var responseStream = await response.Content.ReadAsStreamAsync();
+                    await using var fileStream = File.Create(zipPath);
+
+                    await CopyDownloadToFileAsync(responseStream, fileStream, totalBytes, progress);
+
+                    progress.Report(new UpdateProgressInfo("Extracting the portable package...", PortableZipAssetName, null));
+                    ZipFile.ExtractToDirectory(zipPath, extractRoot);
+
+                    var extractedDesktopPath = Path.Combine(extractRoot, "app", DesktopExecutableName);
+                    if (!File.Exists(extractedDesktopPath))
+                    {
+                        throw new InvalidOperationException("The downloaded portable package is missing the desktop executable.");
+                    }
+
+                    progress.Report(new UpdateProgressInfo("Launching the installer...", "The updater will replace the portable files and restart the app.", 100));
+
+                    var currentProcessId = Environment.ProcessId;
+                    var helperExecutablePath = CreateUpdateHelperExecutable(stagingParent);
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = helperExecutablePath,
+                        UseShellExecute = true,
+                        WorkingDirectory = stagingParent,
+                        Arguments =
+                            $"{ApplyUpdateArgument} " +
+                            $"{StagingRootArgument} \"{extractRoot}\" " +
+                            $"{TargetRootArgument} \"{packageRoot}\" " +
+                            $"{WaitForPidArgument} {currentProcessId}"
+                    };
+
+                    Process.Start(startInfo);
+                });
         }
         catch
         {
             TryDeleteDirectory(stagingParent);
             throw;
         }
+    }
+
+    private static async Task CopyDownloadToFileAsync(
+        Stream responseStream,
+        Stream fileStream,
+        long? totalBytes,
+        IProgress<UpdateProgressInfo> progress)
+    {
+        var buffer = new byte[81920];
+        long totalRead = 0;
+        int read;
+
+        while ((read = await responseStream.ReadAsync(buffer)) > 0)
+        {
+            await fileStream.WriteAsync(buffer.AsMemory(0, read));
+            totalRead += read;
+
+            int? percent = totalBytes is > 0
+                ? (int)Math.Clamp((double)totalRead / totalBytes.Value * 100d, 0d, 100d)
+                : null;
+            var detail = totalBytes is > 0
+                ? $"{FormatBytes(totalRead)} of {FormatBytes(totalBytes.Value)}"
+                : $"{FormatBytes(totalRead)} downloaded";
+
+            progress.Report(new UpdateProgressInfo("Downloading update...", detail, percent));
+        }
+    }
+
+    private static string FormatBytes(long byteCount)
+    {
+        string[] suffixes = ["B", "KB", "MB", "GB"];
+        double size = byteCount;
+        var suffixIndex = 0;
+
+        while (size >= 1024d && suffixIndex < suffixes.Length - 1)
+        {
+            size /= 1024d;
+            suffixIndex++;
+        }
+
+        return suffixIndex == 0
+            ? FormattableString.Invariant($"{size:0} {suffixes[suffixIndex]}")
+            : FormattableString.Invariant($"{size:0.0} {suffixes[suffixIndex]}");
+    }
+
+    private static string CreateUpdateHelperExecutable(string stagingParent)
+    {
+        var currentExecutablePath = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Unable to determine the current launcher executable path.");
+
+        var helperExecutablePath = Path.Combine(stagingParent, HelperExecutableName);
+        File.Copy(currentExecutablePath, helperExecutablePath, overwrite: true);
+        return helperExecutablePath;
     }
 
     private async Task ApplyUpdateAsync(string[] args)
@@ -192,24 +266,33 @@ internal sealed class PortableLauncher
             throw new InvalidOperationException("The update helper did not receive a valid process id to wait for.");
         }
 
-        await WaitForProcessExitAsync(waitForPid);
-
         var preservedDataPath = Path.Combine(Path.GetTempPath(), "StarforgedAtlasUpdate", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture), "data");
         Directory.CreateDirectory(Path.GetDirectoryName(preservedDataPath)!);
 
         try
         {
-            PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataPath);
+            await LauncherProgressDialog.RunAsync(
+                "Installing Starforged Atlas update",
+                "Preparing the portable update...",
+                async progress =>
+                {
+                    progress.Report(new UpdateProgressInfo("Waiting for the launcher to close...", null, null));
+                    await WaitForProcessExitAsync(waitForPid);
 
-            var launcherPath = Path.Combine(targetRoot, LauncherExecutableName);
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = launcherPath,
-                WorkingDirectory = targetRoot,
-                UseShellExecute = true
-            };
+                    PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataPath, progress);
 
-            Process.Start(startInfo);
+                    progress.Report(new UpdateProgressInfo("Restarting Starforged Atlas...", null, 100));
+
+                    var launcherPath = Path.Combine(targetRoot, LauncherExecutableName);
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = launcherPath,
+                        WorkingDirectory = targetRoot,
+                        UseShellExecute = true
+                    };
+
+                    Process.Start(startInfo);
+                });
         }
         catch (Exception ex)
         {
@@ -300,11 +383,19 @@ internal sealed class PortableLauncher
 
 internal static class PortablePackageInstaller
 {
-    public static void InstallPackage(string stagingRoot, string targetRoot, string preservedDataPath)
+    public static void InstallPackage(
+        string stagingRoot,
+        string targetRoot,
+        string preservedDataPath,
+        IProgress<UpdateProgressInfo>? progress = null)
     {
+        progress?.Report(new UpdateProgressInfo("Preserving your portable data...", null, 15));
         PreservePortableData(targetRoot, preservedDataPath);
+        progress?.Report(new UpdateProgressInfo("Replacing application files...", null, 55));
         ReplacePackageContents(stagingRoot, targetRoot);
+        progress?.Report(new UpdateProgressInfo("Restoring your portable data...", null, 85));
         RestorePortableData(targetRoot, preservedDataPath);
+        progress?.Report(new UpdateProgressInfo("Finishing the update...", null, 95));
     }
 
     private static void PreservePortableData(string targetRoot, string preservedDataPath)
@@ -351,6 +442,8 @@ internal sealed record PortableReleaseUpdate(
     string ReleaseTag,
     string? ReleaseName,
     string DownloadUrl);
+
+internal readonly record struct UpdateProgressInfo(string Message, string? Detail, int? Percent);
 
 internal readonly record struct StarforgedReleaseVersion(int Year, int Month, int Day, int Revision) : IComparable<StarforgedReleaseVersion>
 {
@@ -444,4 +537,47 @@ internal sealed class GitHubReleaseAsset
 
     [JsonPropertyName("browser_download_url")]
     public string? BrowserDownloadUrl { get; set; }
+}
+
+internal static class LauncherProgressDialog
+{
+    public static Task RunAsync(
+        string title,
+        string initialMessage,
+        Func<IProgress<UpdateProgressInfo>, Task> operation)
+    {
+        using var form = new UpdateProgressForm(title);
+        Exception? failure = null;
+
+        form.UpdateProgress(new UpdateProgressInfo(initialMessage, null, null));
+        form.Shown += async (_, _) =>
+        {
+            var progress = new Progress<UpdateProgressInfo>(form.UpdateProgress);
+
+            try
+            {
+                await operation(progress);
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                if (!form.IsDisposed)
+                {
+                    form.BeginInvoke(form.Close);
+                }
+            }
+        };
+
+        form.ShowDialog();
+
+        if (failure is not null)
+        {
+            ExceptionDispatchInfo.Capture(failure).Throw();
+        }
+
+        return Task.CompletedTask;
+    }
 }

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -1,0 +1,447 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+internal sealed class PortableLauncher
+{
+    private const string DesktopExecutableName = "StarWin.Desktop.exe";
+    private const string LauncherExecutableName = "Starforged Atlas.exe";
+    private const string PortableZipAssetName = "Starforged-Atlas-Portable.zip";
+    private const string SkipUpdateCheckArgument = "--skip-update-check";
+    private const string ApplyUpdateArgument = "--apply-update";
+    private const string StagingRootArgument = "--staging-root";
+    private const string TargetRootArgument = "--target-root";
+    private const string WaitForPidArgument = "--wait-for-pid";
+    private static readonly Uri LatestReleaseApiUri = new("https://api.github.com/repos/darkdhamon/Slip-Map-Tool/releases/latest");
+
+    public async Task RunAsync(string[] args)
+    {
+        if (args.Contains(ApplyUpdateArgument, StringComparer.OrdinalIgnoreCase))
+        {
+            await ApplyUpdateAsync(args);
+            return;
+        }
+
+        var packageRoot = AppContext.BaseDirectory;
+        var appRoot = Path.Combine(packageRoot, "app");
+        var targetPath = Path.Combine(appRoot, DesktopExecutableName);
+
+        if (!File.Exists(targetPath))
+        {
+            ShowError(
+                "Starforged Atlas could not find the packaged desktop application.",
+                $"Expected to find:{Environment.NewLine}{targetPath}");
+            return;
+        }
+
+        try
+        {
+            var update = await TryGetAvailableUpdateAsync(targetPath);
+            if (update is not null)
+            {
+                var releaseLabel = string.IsNullOrWhiteSpace(update.ReleaseName)
+                    ? update.ReleaseTag
+                    : $"{update.ReleaseName} ({update.ReleaseTag})";
+
+                var prompt = $"A newer version of Starforged Atlas is available.{Environment.NewLine}{Environment.NewLine}Current version: {update.CurrentTag}{Environment.NewLine}Latest version: {releaseLabel}{Environment.NewLine}{Environment.NewLine}Download and install the update now?";
+                var result = MessageBox.Show(
+                    prompt,
+                    "Starforged Atlas update available",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Information);
+
+                if (result == DialogResult.Yes)
+                {
+                    await DownloadAndApplyUpdateAsync(packageRoot, update);
+                    return;
+                }
+            }
+
+            StartDesktopApplication(targetPath, appRoot);
+        }
+        catch (Exception ex)
+        {
+            ShowError(
+                "Starforged Atlas could not be started.",
+                ex.GetBaseException().Message);
+        }
+    }
+
+    private static void StartDesktopApplication(string targetPath, string appRoot)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = targetPath,
+            WorkingDirectory = appRoot,
+            UseShellExecute = true,
+            Arguments = SkipUpdateCheckArgument
+        };
+
+        Process.Start(startInfo);
+    }
+
+    private async Task<PortableReleaseUpdate?> TryGetAvailableUpdateAsync(string desktopExecutablePath)
+    {
+        var currentTag = FileVersionInfo.GetVersionInfo(desktopExecutablePath).ProductVersion;
+        if (!StarforgedReleaseVersion.TryParse(currentTag, out var currentVersion))
+        {
+            return null;
+        }
+
+        using var client = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(15)
+        };
+
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("StarforgedAtlasPortableLauncher", "1.0"));
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+        using var response = await client.GetAsync(LatestReleaseApiUri);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        var release = await JsonSerializer.DeserializeAsync<GitHubLatestReleaseResponse>(stream);
+        if (release is null
+            || string.IsNullOrWhiteSpace(release.TagName)
+            || !StarforgedReleaseVersion.TryParse(release.TagName, out var latestVersion)
+            || latestVersion.CompareTo(currentVersion) <= 0)
+        {
+            return null;
+        }
+
+        var asset = release.Assets.FirstOrDefault(candidate =>
+            string.Equals(candidate.Name, PortableZipAssetName, StringComparison.OrdinalIgnoreCase));
+        if (asset is null || string.IsNullOrWhiteSpace(asset.BrowserDownloadUrl))
+        {
+            return null;
+        }
+
+        return new PortableReleaseUpdate(
+            currentTag ?? "0.0.0",
+            release.TagName,
+            release.Name,
+            asset.BrowserDownloadUrl);
+    }
+
+    private async Task DownloadAndApplyUpdateAsync(string packageRoot, PortableReleaseUpdate update)
+    {
+        var stagingParent = Path.Combine(Path.GetTempPath(), "StarforgedAtlasUpdate", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        var zipPath = Path.Combine(stagingParent, PortableZipAssetName);
+        var extractRoot = Path.Combine(stagingParent, "package");
+
+        Directory.CreateDirectory(stagingParent);
+
+        try
+        {
+            using var client = new HttpClient
+            {
+                Timeout = TimeSpan.FromMinutes(5)
+            };
+
+            await using (var responseStream = await client.GetStreamAsync(update.DownloadUrl))
+            await using (var fileStream = File.Create(zipPath))
+            {
+                await responseStream.CopyToAsync(fileStream);
+            }
+
+            ZipFile.ExtractToDirectory(zipPath, extractRoot);
+
+            var extractedLauncherPath = Path.Combine(extractRoot, LauncherExecutableName);
+            var extractedDesktopPath = Path.Combine(extractRoot, "app", DesktopExecutableName);
+            if (!File.Exists(extractedLauncherPath) || !File.Exists(extractedDesktopPath))
+            {
+                throw new InvalidOperationException("The downloaded portable package is missing the launcher or desktop executable.");
+            }
+
+            var currentProcessId = Environment.ProcessId;
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = extractedLauncherPath,
+                UseShellExecute = true,
+                WorkingDirectory = extractRoot,
+                Arguments =
+                    $"{ApplyUpdateArgument} " +
+                    $"{StagingRootArgument} \"{extractRoot}\" " +
+                    $"{TargetRootArgument} \"{packageRoot}\" " +
+                    $"{WaitForPidArgument} {currentProcessId}"
+            };
+
+            Process.Start(startInfo);
+        }
+        catch
+        {
+            TryDeleteDirectory(stagingParent);
+            throw;
+        }
+    }
+
+    private async Task ApplyUpdateAsync(string[] args)
+    {
+        var stagingRoot = GetRequiredArgumentValue(args, StagingRootArgument);
+        var targetRoot = GetRequiredArgumentValue(args, TargetRootArgument);
+        var waitForPidValue = GetRequiredArgumentValue(args, WaitForPidArgument);
+
+        if (!int.TryParse(waitForPidValue, NumberStyles.None, CultureInfo.InvariantCulture, out var waitForPid))
+        {
+            throw new InvalidOperationException("The update helper did not receive a valid process id to wait for.");
+        }
+
+        await WaitForProcessExitAsync(waitForPid);
+
+        var preservedDataPath = Path.Combine(Path.GetTempPath(), "StarforgedAtlasUpdate", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture), "data");
+        Directory.CreateDirectory(Path.GetDirectoryName(preservedDataPath)!);
+
+        try
+        {
+            PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataPath);
+
+            var launcherPath = Path.Combine(targetRoot, LauncherExecutableName);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = launcherPath,
+                WorkingDirectory = targetRoot,
+                UseShellExecute = true
+            };
+
+            Process.Start(startInfo);
+        }
+        catch (Exception ex)
+        {
+            ShowError(
+                "Starforged Atlas could not apply the downloaded update.",
+                ex.GetBaseException().Message);
+        }
+        finally
+        {
+            TryDeleteDirectory(Path.GetDirectoryName(preservedDataPath)!);
+            TryDeleteDirectory(Path.GetDirectoryName(stagingRoot)!);
+        }
+    }
+
+    private static async Task WaitForProcessExitAsync(int processId)
+    {
+        if (processId <= 0)
+        {
+            return;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            await process.WaitForExitAsync();
+        }
+        catch
+        {
+        }
+    }
+
+    private static string GetRequiredArgumentValue(string[] args, string argumentName)
+    {
+        for (var index = 0; index < args.Length - 1; index++)
+        {
+            if (string.Equals(args[index], argumentName, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[index + 1];
+            }
+        }
+
+        throw new InvalidOperationException($"Missing required argument '{argumentName}'.");
+    }
+
+    internal static void CopyDirectory(string sourceRoot, string targetRoot, bool overwrite)
+    {
+        Directory.CreateDirectory(targetRoot);
+
+        foreach (var directory in Directory.GetDirectories(sourceRoot, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceRoot, directory);
+            Directory.CreateDirectory(Path.Combine(targetRoot, relativePath));
+        }
+
+        foreach (var file in Directory.GetFiles(sourceRoot, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceRoot, file);
+            var destinationPath = Path.Combine(targetRoot, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            File.Copy(file, destinationPath, overwrite);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static void ShowError(string message, string detail)
+    {
+        var fullMessage = $"{message}{Environment.NewLine}{Environment.NewLine}{detail}";
+        MessageBox.Show(
+            fullMessage,
+            "Starforged Atlas",
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Error);
+    }
+}
+
+internal static class PortablePackageInstaller
+{
+    public static void InstallPackage(string stagingRoot, string targetRoot, string preservedDataPath)
+    {
+        PreservePortableData(targetRoot, preservedDataPath);
+        ReplacePackageContents(stagingRoot, targetRoot);
+        RestorePortableData(targetRoot, preservedDataPath);
+    }
+
+    private static void PreservePortableData(string targetRoot, string preservedDataPath)
+    {
+        var currentDataPath = Path.Combine(targetRoot, "app", "data");
+        if (!Directory.Exists(currentDataPath))
+        {
+            return;
+        }
+
+        PortableLauncher.CopyDirectory(currentDataPath, preservedDataPath, overwrite: true);
+    }
+
+    private static void ReplacePackageContents(string stagingRoot, string targetRoot)
+    {
+        foreach (var directory in Directory.GetDirectories(targetRoot))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+
+        foreach (var file in Directory.GetFiles(targetRoot))
+        {
+            File.Delete(file);
+        }
+
+        PortableLauncher.CopyDirectory(stagingRoot, targetRoot, overwrite: true);
+    }
+
+    private static void RestorePortableData(string targetRoot, string preservedDataPath)
+    {
+        if (!Directory.Exists(preservedDataPath))
+        {
+            return;
+        }
+
+        var newDataPath = Path.Combine(targetRoot, "app", "data");
+        Directory.CreateDirectory(newDataPath);
+        PortableLauncher.CopyDirectory(preservedDataPath, newDataPath, overwrite: true);
+    }
+}
+
+internal sealed record PortableReleaseUpdate(
+    string CurrentTag,
+    string ReleaseTag,
+    string? ReleaseName,
+    string DownloadUrl);
+
+internal readonly record struct StarforgedReleaseVersion(int Year, int Month, int Day, int Revision) : IComparable<StarforgedReleaseVersion>
+{
+    public int CompareTo(StarforgedReleaseVersion other)
+    {
+        var yearComparison = Year.CompareTo(other.Year);
+        if (yearComparison != 0)
+        {
+            return yearComparison;
+        }
+
+        var monthComparison = Month.CompareTo(other.Month);
+        if (monthComparison != 0)
+        {
+            return monthComparison;
+        }
+
+        var dayComparison = Day.CompareTo(other.Day);
+        if (dayComparison != 0)
+        {
+            return dayComparison;
+        }
+
+        return Revision.CompareTo(other.Revision);
+    }
+
+    public static bool TryParse(string? value, out StarforgedReleaseVersion version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmedValue = value.Trim();
+        const string developerPreviewSuffix = "-developer-preview";
+        if (trimmedValue.EndsWith(developerPreviewSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            trimmedValue = trimmedValue[..^developerPreviewSuffix.Length];
+        }
+
+        if (trimmedValue.StartsWith('v') || trimmedValue.StartsWith('V'))
+        {
+            trimmedValue = trimmedValue[1..];
+        }
+
+        var segments = trimmedValue.Split('.', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var datePortion = segments[0];
+        var revisionPortion = segments.Length == 2 ? segments[1] : "0";
+
+        var dateSegments = datePortion.Split('-', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (dateSegments.Length != 3
+            || !int.TryParse(dateSegments[0], out var year)
+            || !int.TryParse(dateSegments[1], out var month)
+            || !int.TryParse(dateSegments[2], out var day)
+            || !int.TryParse(revisionPortion, out var revision))
+        {
+            return false;
+        }
+
+        try
+        {
+            _ = new DateOnly(year, month, day);
+        }
+        catch
+        {
+            return false;
+        }
+
+        version = new StarforgedReleaseVersion(year, month, day, revision);
+        return true;
+    }
+}
+
+internal sealed class GitHubLatestReleaseResponse
+{
+    [JsonPropertyName("tag_name")]
+    public string? TagName { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("assets")]
+    public List<GitHubReleaseAsset> Assets { get; set; } = [];
+}
+
+internal sealed class GitHubReleaseAsset
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("browser_download_url")]
+    public string? BrowserDownloadUrl { get; set; }
+}

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -181,17 +181,12 @@ internal sealed class PortableLauncher
 
                     var currentProcessId = Environment.ProcessId;
                     var helperExecutablePath = CreateUpdateHelperExecutable(stagingParent);
-                    var startInfo = new ProcessStartInfo
-                    {
-                        FileName = helperExecutablePath,
-                        UseShellExecute = true,
-                        WorkingDirectory = stagingParent,
-                        Arguments =
-                            $"{ApplyUpdateArgument} " +
-                            $"{StagingRootArgument} \"{extractRoot}\" " +
-                            $"{TargetRootArgument} \"{packageRoot}\" " +
-                            $"{WaitForPidArgument} {currentProcessId}"
-                    };
+                    var startInfo = CreateUpdateHelperStartInfo(
+                        helperExecutablePath,
+                        stagingParent,
+                        extractRoot,
+                        packageRoot,
+                        currentProcessId);
 
                     Process.Start(startInfo);
                 });
@@ -254,6 +249,31 @@ internal sealed class PortableLauncher
         var helperExecutablePath = Path.Combine(stagingParent, HelperExecutableName);
         File.Copy(currentExecutablePath, helperExecutablePath, overwrite: true);
         return helperExecutablePath;
+    }
+
+    internal static ProcessStartInfo CreateUpdateHelperStartInfo(
+        string helperExecutablePath,
+        string workingDirectory,
+        string stagingRoot,
+        string targetRoot,
+        int waitForPid)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = helperExecutablePath,
+            UseShellExecute = true,
+            WorkingDirectory = workingDirectory
+        };
+
+        startInfo.ArgumentList.Add(ApplyUpdateArgument);
+        startInfo.ArgumentList.Add(StagingRootArgument);
+        startInfo.ArgumentList.Add(stagingRoot);
+        startInfo.ArgumentList.Add(TargetRootArgument);
+        startInfo.ArgumentList.Add(targetRoot);
+        startInfo.ArgumentList.Add(WaitForPidArgument);
+        startInfo.ArgumentList.Add(waitForPid.ToString(CultureInfo.InvariantCulture));
+
+        return startInfo;
     }
 
     private async Task ApplyUpdateAsync(string[] args)

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -13,14 +13,25 @@ internal sealed class PortableLauncher
     private const string PortableZipAssetName = "Starforged-Atlas-Portable.zip";
     private const string SkipUpdateCheckArgument = "--skip-update-check";
     private const string ApplyUpdateArgument = "--apply-update";
+    private const string RestoreBackupArgument = "--restore-backup";
     private const string StagingRootArgument = "--staging-root";
     private const string TargetRootArgument = "--target-root";
     private const string WaitForPidArgument = "--wait-for-pid";
+    private const string BackupRootArgument = "--backup-root";
+    private const string ReleaseTagArgument = "--release-tag";
+    private const string PreviousVersionArgument = "--previous-version";
+    private const string PostUpdateValidationArgument = "--post-update-validation";
     private const string HelperExecutableName = "StarforgedAtlas.UpdateHelper.exe";
     private static readonly Uri LatestReleaseApiUri = new("https://api.github.com/repos/darkdhamon/Slip-Map-Tool/releases/latest");
 
     public async Task RunAsync(string[] args)
     {
+        if (args.Contains(RestoreBackupArgument, StringComparer.OrdinalIgnoreCase))
+        {
+            await RestoreBackupAsync(args);
+            return;
+        }
+
         if (args.Contains(ApplyUpdateArgument, StringComparer.OrdinalIgnoreCase))
         {
             await ApplyUpdateAsync(args);
@@ -39,30 +50,35 @@ internal sealed class PortableLauncher
             return;
         }
 
+        var postUpdateValidation = TryGetPostUpdateValidation(args, packageRoot);
+
         try
         {
-            var update = await TryGetAvailableUpdateAsync(targetPath);
-            if (update is not null)
+            if (postUpdateValidation is null)
             {
-                var releaseLabel = string.IsNullOrWhiteSpace(update.ReleaseName)
-                    ? update.ReleaseTag
-                    : $"{update.ReleaseName} ({update.ReleaseTag})";
-
-                var prompt = $"A newer version of Starforged Atlas is available.{Environment.NewLine}{Environment.NewLine}Current version: {update.CurrentTag}{Environment.NewLine}Latest version: {releaseLabel}{Environment.NewLine}{Environment.NewLine}Download and install the update now?";
-                var result = MessageBox.Show(
-                    prompt,
-                    "Starforged Atlas update available",
-                    MessageBoxButtons.YesNo,
-                    MessageBoxIcon.Information);
-
-                if (result == DialogResult.Yes)
+                var update = await TryGetAvailableUpdateAsync(packageRoot, targetPath);
+                if (update is not null)
                 {
-                    await DownloadAndApplyUpdateAsync(packageRoot, update);
-                    return;
+                    var releaseLabel = string.IsNullOrWhiteSpace(update.ReleaseName)
+                        ? update.ReleaseTag
+                        : $"{update.ReleaseName} ({update.ReleaseTag})";
+
+                    var prompt = $"A newer version of Starforged Atlas is available.{Environment.NewLine}{Environment.NewLine}Current version: {update.CurrentTag}{Environment.NewLine}Latest version: {releaseLabel}{Environment.NewLine}{Environment.NewLine}Download and install the update now?";
+                    var result = MessageBox.Show(
+                        prompt,
+                        "Starforged Atlas update available",
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Information);
+
+                    if (result == DialogResult.Yes)
+                    {
+                        await DownloadAndApplyUpdateAsync(packageRoot, update);
+                        return;
+                    }
                 }
             }
 
-            StartDesktopApplication(targetPath, appRoot);
+            await RunDesktopApplicationAsync(packageRoot, targetPath, appRoot, postUpdateValidation);
         }
         catch (Exception ex)
         {
@@ -72,20 +88,53 @@ internal sealed class PortableLauncher
         }
     }
 
-    private static void StartDesktopApplication(string targetPath, string appRoot)
+    private async Task RunDesktopApplicationAsync(
+        string packageRoot,
+        string targetPath,
+        string appRoot,
+        PortableUpdateValidationContext? postUpdateValidation)
     {
         var startInfo = new ProcessStartInfo
         {
             FileName = targetPath,
             WorkingDirectory = appRoot,
-            UseShellExecute = true,
-            Arguments = SkipUpdateCheckArgument
+            UseShellExecute = false
         };
+        startInfo.ArgumentList.Add(SkipUpdateCheckArgument);
 
-        Process.Start(startInfo);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Starforged Atlas could not start the desktop application.");
+        await process.WaitForExitAsync();
+
+        if (postUpdateValidation is not null)
+        {
+            await HandlePostUpdateExitAsync(packageRoot, postUpdateValidation);
+        }
     }
 
-    private async Task<PortableReleaseUpdate?> TryGetAvailableUpdateAsync(string desktopExecutablePath)
+    private async Task HandlePostUpdateExitAsync(string packageRoot, PortableUpdateValidationContext validationContext)
+    {
+        if (!Directory.Exists(validationContext.BackupRoot))
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            $"The updated Starforged Atlas app has exited.{Environment.NewLine}{Environment.NewLine}Did the update work okay?{Environment.NewLine}{Environment.NewLine}Choose Yes to keep the new version.{Environment.NewLine}Choose No to restore the previous portable backup and ignore release {validationContext.ReleaseTag} in future update checks.",
+            "Starforged Atlas update check-in",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+
+        if (result == DialogResult.Yes)
+        {
+            TryDeleteDirectory(Path.GetDirectoryName(validationContext.BackupRoot)!);
+            return;
+        }
+
+        await StartRestoreBackupHelperAsync(packageRoot, validationContext);
+    }
+
+    private async Task<PortableReleaseUpdate?> TryGetAvailableUpdateAsync(string packageRoot, string desktopExecutablePath)
     {
         var currentTag = FileVersionInfo.GetVersionInfo(desktopExecutablePath).ProductVersion;
         if (!StarforgedReleaseVersion.TryParse(currentTag, out var currentVersion))
@@ -124,6 +173,12 @@ internal sealed class PortableLauncher
             return null;
         }
 
+        var updateState = PortableUpdateStateStore.Load(packageRoot);
+        if (updateState.ShouldIgnore(release.TagName))
+        {
+            return null;
+        }
+
         return new PortableReleaseUpdate(
             currentTag ?? "0.0.0",
             release.TagName,
@@ -136,8 +191,10 @@ internal sealed class PortableLauncher
         var stagingParent = Path.Combine(Path.GetTempPath(), "StarforgedAtlasUpdate", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
         var zipPath = Path.Combine(stagingParent, PortableZipAssetName);
         var extractRoot = Path.Combine(stagingParent, "package");
+        var backupRoot = Path.Combine(Path.GetTempPath(), "StarforgedAtlasBackup", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture), "package");
 
         Directory.CreateDirectory(stagingParent);
+        Directory.CreateDirectory(Path.GetDirectoryName(backupRoot)!);
 
         try
         {
@@ -186,6 +243,9 @@ internal sealed class PortableLauncher
                         stagingParent,
                         extractRoot,
                         packageRoot,
+                        backupRoot,
+                        update.ReleaseTag,
+                        update.CurrentTag,
                         currentProcessId);
 
                     Process.Start(startInfo);
@@ -194,6 +254,7 @@ internal sealed class PortableLauncher
         catch
         {
             TryDeleteDirectory(stagingParent);
+            TryDeleteDirectory(Path.GetDirectoryName(backupRoot)!);
             throw;
         }
     }
@@ -256,6 +317,9 @@ internal sealed class PortableLauncher
         string workingDirectory,
         string stagingRoot,
         string targetRoot,
+        string backupRoot,
+        string releaseTag,
+        string previousVersion,
         int waitForPid)
     {
         var startInfo = new ProcessStartInfo
@@ -270,6 +334,12 @@ internal sealed class PortableLauncher
         startInfo.ArgumentList.Add(stagingRoot);
         startInfo.ArgumentList.Add(TargetRootArgument);
         startInfo.ArgumentList.Add(targetRoot);
+        startInfo.ArgumentList.Add(BackupRootArgument);
+        startInfo.ArgumentList.Add(backupRoot);
+        startInfo.ArgumentList.Add(ReleaseTagArgument);
+        startInfo.ArgumentList.Add(releaseTag);
+        startInfo.ArgumentList.Add(PreviousVersionArgument);
+        startInfo.ArgumentList.Add(previousVersion);
         startInfo.ArgumentList.Add(WaitForPidArgument);
         startInfo.ArgumentList.Add(waitForPid.ToString(CultureInfo.InvariantCulture));
 
@@ -280,6 +350,9 @@ internal sealed class PortableLauncher
     {
         var stagingRoot = GetRequiredArgumentValue(args, StagingRootArgument);
         var targetRoot = GetRequiredArgumentValue(args, TargetRootArgument);
+        var backupRoot = GetRequiredArgumentValue(args, BackupRootArgument);
+        var releaseTag = GetRequiredArgumentValue(args, ReleaseTagArgument);
+        var previousVersion = GetRequiredArgumentValue(args, PreviousVersionArgument);
         var waitForPidValue = GetRequiredArgumentValue(args, WaitForPidArgument);
 
         if (!int.TryParse(waitForPidValue, NumberStyles.None, CultureInfo.InvariantCulture, out var waitForPid))
@@ -300,9 +373,126 @@ internal sealed class PortableLauncher
                     progress.Report(new UpdateProgressInfo("Waiting for the launcher to close...", null, null));
                     await WaitForProcessExitAsync(waitForPid);
 
-                    PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataPath, progress);
+                    PortablePackageInstaller.InstallPackage(stagingRoot, targetRoot, preservedDataPath, backupRoot, progress);
 
-                    progress.Report(new UpdateProgressInfo("Restarting Starforged Atlas...", null, 100));
+                    progress.Report(new UpdateProgressInfo("Restarting Starforged Atlas...", "The launcher will check whether the update worked when the app exits.", 100));
+
+                    var launcherPath = Path.Combine(targetRoot, LauncherExecutableName);
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = launcherPath,
+                        WorkingDirectory = targetRoot,
+                        UseShellExecute = true
+                    };
+                    startInfo.ArgumentList.Add(PostUpdateValidationArgument);
+                    startInfo.ArgumentList.Add(ReleaseTagArgument);
+                    startInfo.ArgumentList.Add(releaseTag);
+                    startInfo.ArgumentList.Add(PreviousVersionArgument);
+                    startInfo.ArgumentList.Add(previousVersion);
+                    startInfo.ArgumentList.Add(BackupRootArgument);
+                    startInfo.ArgumentList.Add(backupRoot);
+
+                    Process.Start(startInfo);
+                });
+        }
+        catch (Exception ex)
+        {
+            ShowError(
+                "Starforged Atlas could not apply the downloaded update.",
+                ex.GetBaseException().Message);
+        }
+        finally
+        {
+            TryDeleteDirectory(Path.GetDirectoryName(preservedDataPath)!);
+            TryDeleteDirectory(Path.GetDirectoryName(stagingRoot)!);
+        }
+    }
+
+    private async Task StartRestoreBackupHelperAsync(string packageRoot, PortableUpdateValidationContext validationContext)
+    {
+        var helperParent = Path.Combine(Path.GetTempPath(), "StarforgedAtlasRollback", Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(helperParent);
+
+        try
+        {
+            var helperExecutablePath = CreateUpdateHelperExecutable(helperParent);
+            var startInfo = CreateRestoreBackupHelperStartInfo(
+                helperExecutablePath,
+                helperParent,
+                validationContext.BackupRoot,
+                packageRoot,
+                validationContext.ReleaseTag,
+                validationContext.PreviousVersion,
+                Environment.ProcessId);
+
+            Process.Start(startInfo);
+        }
+        catch
+        {
+            TryDeleteDirectory(helperParent);
+            throw;
+        }
+    }
+
+    internal static ProcessStartInfo CreateRestoreBackupHelperStartInfo(
+        string helperExecutablePath,
+        string workingDirectory,
+        string backupRoot,
+        string targetRoot,
+        string releaseTag,
+        string previousVersion,
+        int waitForPid)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = helperExecutablePath,
+            UseShellExecute = true,
+            WorkingDirectory = workingDirectory
+        };
+
+        startInfo.ArgumentList.Add(RestoreBackupArgument);
+        startInfo.ArgumentList.Add(BackupRootArgument);
+        startInfo.ArgumentList.Add(backupRoot);
+        startInfo.ArgumentList.Add(TargetRootArgument);
+        startInfo.ArgumentList.Add(targetRoot);
+        startInfo.ArgumentList.Add(ReleaseTagArgument);
+        startInfo.ArgumentList.Add(releaseTag);
+        startInfo.ArgumentList.Add(PreviousVersionArgument);
+        startInfo.ArgumentList.Add(previousVersion);
+        startInfo.ArgumentList.Add(WaitForPidArgument);
+        startInfo.ArgumentList.Add(waitForPid.ToString(CultureInfo.InvariantCulture));
+
+        return startInfo;
+    }
+
+    private async Task RestoreBackupAsync(string[] args)
+    {
+        var backupRoot = GetRequiredArgumentValue(args, BackupRootArgument);
+        var targetRoot = GetRequiredArgumentValue(args, TargetRootArgument);
+        var releaseTag = GetRequiredArgumentValue(args, ReleaseTagArgument);
+        var previousVersion = GetRequiredArgumentValue(args, PreviousVersionArgument);
+        var waitForPidValue = GetRequiredArgumentValue(args, WaitForPidArgument);
+
+        if (!int.TryParse(waitForPidValue, NumberStyles.None, CultureInfo.InvariantCulture, out var waitForPid))
+        {
+            throw new InvalidOperationException("The rollback helper did not receive a valid process id to wait for.");
+        }
+
+        try
+        {
+            await LauncherProgressDialog.RunAsync(
+                "Restoring Starforged Atlas backup",
+                "Preparing the rollback...",
+                async progress =>
+                {
+                    progress.Report(new UpdateProgressInfo("Waiting for the launcher to close...", null, null));
+                    await WaitForProcessExitAsync(waitForPid);
+
+                    PortablePackageInstaller.RestoreBackup(backupRoot, targetRoot, progress);
+                    PortableUpdateStateStore.IgnoreRelease(targetRoot, releaseTag);
+                    PortableUpdateFailureReporter.ReportFailedUpdate(releaseTag, previousVersion);
+
+                    progress.Report(new UpdateProgressInfo("Restarting the previous version...", null, 100));
 
                     var launcherPath = Path.Combine(targetRoot, LauncherExecutableName);
                     var startInfo = new ProcessStartInfo
@@ -318,13 +508,12 @@ internal sealed class PortableLauncher
         catch (Exception ex)
         {
             ShowError(
-                "Starforged Atlas could not apply the downloaded update.",
+                "Starforged Atlas could not restore the previous backup.",
                 ex.GetBaseException().Message);
         }
         finally
         {
-            TryDeleteDirectory(Path.GetDirectoryName(preservedDataPath)!);
-            TryDeleteDirectory(Path.GetDirectoryName(stagingRoot)!);
+            TryDeleteDirectory(Path.GetDirectoryName(backupRoot)!);
         }
     }
 
@@ -400,6 +589,40 @@ internal sealed class PortableLauncher
             MessageBoxButtons.OK,
             MessageBoxIcon.Error);
     }
+
+    private static PortableUpdateValidationContext? TryGetPostUpdateValidation(string[] args, string packageRoot)
+    {
+        if (!args.Contains(PostUpdateValidationArgument, StringComparer.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var releaseTag = TryGetOptionalArgumentValue(args, ReleaseTagArgument);
+        var previousVersion = TryGetOptionalArgumentValue(args, PreviousVersionArgument);
+        var backupRoot = TryGetOptionalArgumentValue(args, BackupRootArgument);
+
+        if (string.IsNullOrWhiteSpace(releaseTag)
+            || string.IsNullOrWhiteSpace(previousVersion)
+            || string.IsNullOrWhiteSpace(backupRoot))
+        {
+            return null;
+        }
+
+        return new PortableUpdateValidationContext(packageRoot, releaseTag, previousVersion, backupRoot);
+    }
+
+    private static string? TryGetOptionalArgumentValue(string[] args, string argumentName)
+    {
+        for (var index = 0; index < args.Length - 1; index++)
+        {
+            if (string.Equals(args[index], argumentName, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[index + 1];
+            }
+        }
+
+        return null;
+    }
 }
 
 internal static class PortablePackageInstaller
@@ -408,8 +631,11 @@ internal static class PortablePackageInstaller
         string stagingRoot,
         string targetRoot,
         string preservedDataPath,
+        string backupRoot,
         IProgress<UpdateProgressInfo>? progress = null)
     {
+        progress?.Report(new UpdateProgressInfo("Creating a rollback backup...", null, 5));
+        CreateBackup(targetRoot, backupRoot);
         progress?.Report(new UpdateProgressInfo("Preserving your portable data...", null, 15));
         PreservePortableData(targetRoot, preservedDataPath);
         progress?.Report(new UpdateProgressInfo("Replacing application files...", null, 55));
@@ -417,6 +643,26 @@ internal static class PortablePackageInstaller
         progress?.Report(new UpdateProgressInfo("Restoring your portable data...", null, 85));
         RestorePortableData(targetRoot, preservedDataPath);
         progress?.Report(new UpdateProgressInfo("Finishing the update...", null, 95));
+    }
+
+    public static void RestoreBackup(
+        string backupRoot,
+        string targetRoot,
+        IProgress<UpdateProgressInfo>? progress = null)
+    {
+        progress?.Report(new UpdateProgressInfo("Restoring the previous portable package...", null, 45));
+        ReplacePackageContents(backupRoot, targetRoot);
+        progress?.Report(new UpdateProgressInfo("Finishing the rollback...", null, 90));
+    }
+
+    private static void CreateBackup(string targetRoot, string backupRoot)
+    {
+        if (!Directory.Exists(targetRoot))
+        {
+            return;
+        }
+
+        PortableLauncher.CopyDirectory(targetRoot, backupRoot, overwrite: true);
     }
 
     private static void PreservePortableData(string targetRoot, string preservedDataPath)
@@ -463,6 +709,12 @@ internal sealed record PortableReleaseUpdate(
     string ReleaseTag,
     string? ReleaseName,
     string DownloadUrl);
+
+internal sealed record PortableUpdateValidationContext(
+    string PackageRoot,
+    string ReleaseTag,
+    string PreviousVersion,
+    string BackupRoot);
 
 internal readonly record struct UpdateProgressInfo(string Message, string? Detail, int? Percent);
 
@@ -601,4 +853,240 @@ internal static class LauncherProgressDialog
 
         return Task.CompletedTask;
     }
+}
+
+internal static class PortableUpdateStateStore
+{
+    private const string StateFileName = "portable-launcher-state.json";
+
+    public static PortableUpdateState Load(string packageRoot)
+    {
+        var path = GetStatePath(packageRoot);
+        if (!File.Exists(path))
+        {
+            return new PortableUpdateState([]);
+        }
+
+        try
+        {
+            var state = JsonSerializer.Deserialize<PortableUpdateState>(File.ReadAllText(path));
+            return state ?? new PortableUpdateState([]);
+        }
+        catch
+        {
+            return new PortableUpdateState([]);
+        }
+    }
+
+    public static void IgnoreRelease(string packageRoot, string releaseTag)
+    {
+        var state = Load(packageRoot);
+        if (state.ShouldIgnore(releaseTag))
+        {
+            return;
+        }
+
+        var ignoredReleases = state.IgnoredReleases
+            .Concat([releaseTag])
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Save(packageRoot, new PortableUpdateState(ignoredReleases));
+    }
+
+    public static void Save(string packageRoot, PortableUpdateState state)
+    {
+        var path = GetStatePath(packageRoot);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(state, PortableJsonContext.Default.PortableUpdateState));
+    }
+
+    private static string GetStatePath(string packageRoot)
+    {
+        return Path.Combine(packageRoot, "app", "data", StateFileName);
+    }
+}
+
+internal sealed record PortableUpdateState(string[] IgnoredReleases)
+{
+    public bool ShouldIgnore(string releaseTag)
+        => IgnoredReleases.Any(candidate => string.Equals(candidate, releaseTag, StringComparison.OrdinalIgnoreCase));
+}
+
+internal static class PortableUpdateFailureReporter
+{
+    private const string GitHubOwner = "darkdhamon";
+    private const string GitHubRepo = "Slip-Map-Tool";
+    private const string GitHubProjectTitle = "Starforged Atlas Task Board";
+
+    public static void ReportFailedUpdate(string releaseTag, string previousVersion)
+    {
+        var title = $"Bugfix: portable update rollback for {releaseTag}";
+        var body = BuildIssueBody(releaseTag, previousVersion);
+
+        if (TryCreateIssueWithGh(title, body, out var issueUrl))
+        {
+            TryAddIssueToProject(issueUrl!);
+            return;
+        }
+
+        OpenIssueDraftInBrowser(title, body);
+    }
+
+    internal static string BuildIssueBody(string releaseTag, string previousVersion)
+    {
+        return
+            $"A user restored the portable backup after testing release `{releaseTag}`.{Environment.NewLine}{Environment.NewLine}" +
+            $"Previous version: `{previousVersion}`{Environment.NewLine}" +
+            $"Rolled back at: `{DateTimeOffset.Now:O}`{Environment.NewLine}{Environment.NewLine}" +
+            "The updated app exited and the user indicated that the update did not work correctly, so the launcher restored the backup and will ignore this release for future portable update checks.";
+    }
+
+    internal static Uri BuildIssueDraftUri(string title, string body)
+    {
+        var builder = new UriBuilder($"https://github.com/{GitHubOwner}/{GitHubRepo}/issues/new");
+        builder.Query =
+            $"title={Uri.EscapeDataString(title)}&labels={Uri.EscapeDataString("bug")}&body={Uri.EscapeDataString(body)}";
+        return builder.Uri;
+    }
+
+    private static bool TryCreateIssueWithGh(string title, string body, out string? issueUrl)
+    {
+        issueUrl = null;
+
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "gh",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                ArgumentList =
+                {
+                    "issue",
+                    "create",
+                    "--repo",
+                    $"{GitHubOwner}/{GitHubRepo}",
+                    "--label",
+                    "bug",
+                    "--title",
+                    title,
+                    "--body",
+                    body
+                }
+            });
+
+            if (process is null)
+            {
+                return false;
+            }
+
+            issueUrl = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit();
+            return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(issueUrl);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void TryAddIssueToProject(string issueUrl)
+    {
+        try
+        {
+            using var listProcess = Process.Start(new ProcessStartInfo
+            {
+                FileName = "gh",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                ArgumentList =
+                {
+                    "project",
+                    "list",
+                    "--owner",
+                    GitHubOwner,
+                    "--format",
+                    "json"
+                }
+            });
+
+            if (listProcess is null)
+            {
+                return;
+            }
+
+            var json = listProcess.StandardOutput.ReadToEnd();
+            listProcess.WaitForExit();
+            if (listProcess.ExitCode != 0)
+            {
+                return;
+            }
+
+            var projects = JsonSerializer.Deserialize(json, PortableJsonContext.Default.GitHubProjectSummaryArray);
+            var project = projects?.FirstOrDefault(candidate =>
+                string.Equals(candidate.Title, GitHubProjectTitle, StringComparison.OrdinalIgnoreCase));
+            if (project is null)
+            {
+                return;
+            }
+
+            using var addProcess = Process.Start(new ProcessStartInfo
+            {
+                FileName = "gh",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                ArgumentList =
+                {
+                    "project",
+                    "item-add",
+                    project.Number.ToString(CultureInfo.InvariantCulture),
+                    "--owner",
+                    GitHubOwner,
+                    "--url",
+                    issueUrl
+                }
+            });
+
+            addProcess?.WaitForExit();
+        }
+        catch
+        {
+        }
+    }
+
+    private static void OpenIssueDraftInBrowser(string title, string body)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = BuildIssueDraftUri(title, body).ToString(),
+                UseShellExecute = true
+            });
+        }
+        catch
+        {
+        }
+    }
+}
+
+[JsonSerializable(typeof(PortableUpdateState))]
+[JsonSerializable(typeof(GitHubProjectSummary[]))]
+internal partial class PortableJsonContext : JsonSerializerContext
+{
+}
+
+internal sealed class GitHubProjectSummary
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("number")]
+    public int Number { get; set; }
 }

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -59,13 +59,8 @@ internal sealed class PortableLauncher
                 var update = await TryGetAvailableUpdateAsync(packageRoot, targetPath);
                 if (update is not null)
                 {
-                    var releaseLabel = string.IsNullOrWhiteSpace(update.ReleaseName)
-                        ? update.ReleaseTag
-                        : $"{update.ReleaseName} ({update.ReleaseTag})";
-
-                    var prompt = $"A newer version of Starforged Atlas is available.{Environment.NewLine}{Environment.NewLine}Current version: {update.CurrentTag}{Environment.NewLine}Latest version: {releaseLabel}{Environment.NewLine}{Environment.NewLine}Download and install the update now?";
                     var result = MessageBox.Show(
-                        prompt,
+                        BuildAvailableUpdatePromptMessage(update),
                         "Starforged Atlas update available",
                         MessageBoxButtons.YesNo,
                         MessageBoxIcon.Information);
@@ -183,7 +178,8 @@ internal sealed class PortableLauncher
             currentTag ?? "0.0.0",
             release.TagName,
             release.Name,
-            asset.BrowserDownloadUrl);
+            asset.BrowserDownloadUrl,
+            release.Body);
     }
 
     private async Task DownloadAndApplyUpdateAsync(string packageRoot, PortableReleaseUpdate update)
@@ -300,6 +296,58 @@ internal sealed class PortableLauncher
         return suffixIndex == 0
             ? FormattableString.Invariant($"{size:0} {suffixes[suffixIndex]}")
             : FormattableString.Invariant($"{size:0.0} {suffixes[suffixIndex]}");
+    }
+
+    internal static string BuildAvailableUpdatePromptMessage(PortableReleaseUpdate update)
+    {
+        var releaseLabel = string.IsNullOrWhiteSpace(update.ReleaseName)
+            ? update.ReleaseTag
+            : $"{update.ReleaseName} ({update.ReleaseTag})";
+        var releaseNotes = FormatReleaseNotesForPrompt(update.ReleaseNotes);
+
+        return
+            $"A newer version of Starforged Atlas is available.{Environment.NewLine}{Environment.NewLine}" +
+            $"Current version: {update.CurrentTag}{Environment.NewLine}" +
+            $"Latest version: {releaseLabel}{Environment.NewLine}{Environment.NewLine}" +
+            $"Release notes:{Environment.NewLine}{releaseNotes}{Environment.NewLine}{Environment.NewLine}" +
+            "Download and install the update now?";
+    }
+
+    internal static string FormatReleaseNotesForPrompt(string? releaseNotes)
+    {
+        const int maxLines = 12;
+        const int maxCharacters = 1200;
+
+        if (string.IsNullOrWhiteSpace(releaseNotes))
+        {
+            return "No release notes were provided for this release.";
+        }
+
+        var normalized = releaseNotes.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Trim();
+        var lines = normalized.Split('\n');
+        for (var index = 0; index < lines.Length; index++)
+        {
+            lines[index] = lines[index].TrimEnd();
+        }
+
+        var includedLineCount = Math.Min(lines.Length, maxLines);
+        var limited = string.Join(Environment.NewLine, lines, 0, includedLineCount);
+        var truncated = lines.Length > maxLines;
+
+        if (limited.Length > maxCharacters)
+        {
+            limited = limited[..maxCharacters].TrimEnd();
+            truncated = true;
+        }
+
+        if (truncated)
+        {
+            limited = $"{limited}{Environment.NewLine}...{Environment.NewLine}See GitHub for the full release notes.";
+        }
+
+        return limited;
     }
 
     private static string CreateUpdateHelperExecutable(string stagingParent)
@@ -708,7 +756,8 @@ internal sealed record PortableReleaseUpdate(
     string CurrentTag,
     string ReleaseTag,
     string? ReleaseName,
-    string DownloadUrl);
+    string DownloadUrl,
+    string? ReleaseNotes);
 
 internal sealed record PortableUpdateValidationContext(
     string PackageRoot,
@@ -798,6 +847,9 @@ internal sealed class GitHubLatestReleaseResponse
 
     [JsonPropertyName("name")]
     public string? Name { get; set; }
+
+    [JsonPropertyName("body")]
+    public string? Body { get; set; }
 
     [JsonPropertyName("assets")]
     public List<GitHubReleaseAsset> Assets { get; set; } = [];

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -144,6 +144,13 @@ internal sealed class PortableLauncher
             return null;
         }
 
+        var updateState = PortableUpdateStateStore.Load(packageRoot);
+        var updateOverride = PortableUpdateSourceOverrideStore.Load(packageRoot);
+        if (updateOverride is not null)
+        {
+            return TryCreateLocalOverrideUpdate(updateOverride, currentTag ?? "0.0.0", currentVersion, updateState);
+        }
+
         using var client = new HttpClient
         {
             Timeout = TimeSpan.FromSeconds(15)
@@ -175,7 +182,6 @@ internal sealed class PortableLauncher
             return null;
         }
 
-        var updateState = PortableUpdateStateStore.Load(packageRoot);
         if (updateState.ShouldIgnore(release.TagName))
         {
             return null;
@@ -186,7 +192,33 @@ internal sealed class PortableLauncher
             release.TagName,
             release.Name,
             asset.BrowserDownloadUrl,
-            release.Body);
+            release.Body,
+            IsLocalPackage: false);
+    }
+
+    internal static PortableReleaseUpdate? TryCreateLocalOverrideUpdate(
+        PortableUpdateSourceOverride updateOverride,
+        string currentTag,
+        StarforgedReleaseVersion currentVersion,
+        PortableUpdateState updateState)
+    {
+        if (string.IsNullOrWhiteSpace(updateOverride.ReleaseTag)
+            || string.IsNullOrWhiteSpace(updateOverride.PackagePath)
+            || !File.Exists(updateOverride.PackagePath)
+            || !StarforgedReleaseVersion.TryParse(updateOverride.ReleaseTag, out var overrideVersion)
+            || overrideVersion.CompareTo(currentVersion) <= 0
+            || updateState.ShouldIgnore(updateOverride.ReleaseTag))
+        {
+            return null;
+        }
+
+        return new PortableReleaseUpdate(
+            currentTag,
+            updateOverride.ReleaseTag,
+            updateOverride.ReleaseName,
+            updateOverride.PackagePath,
+            updateOverride.ReleaseNotes,
+            IsLocalPackage: true);
     }
 
     private async Task DownloadAndApplyUpdateAsync(string packageRoot, PortableReleaseUpdate update)
@@ -206,26 +238,33 @@ internal sealed class PortableLauncher
                 "Downloading the latest portable release...",
                 async progress =>
                 {
-                    using var client = new HttpClient
+                    if (update.IsLocalPackage)
                     {
-                        Timeout = TimeSpan.FromMinutes(5)
-                    };
-
-                    client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("StarforgedAtlasPortableLauncher", "1.0"));
-
-                    progress.Report(new UpdateProgressInfo("Connecting to GitHub...", update.ReleaseTag, null));
-
-                    using var response = await client.GetAsync(
-                        update.DownloadUrl,
-                        HttpCompletionOption.ResponseHeadersRead);
-
-                    response.EnsureSuccessStatusCode();
-
-                    var totalBytes = response.Content.Headers.ContentLength;
-                    await using (var responseStream = await response.Content.ReadAsStreamAsync())
-                    await using (var fileStream = File.Create(zipPath))
+                        await CopyLocalPackageToFileAsync(update.DownloadUrl, zipPath, progress);
+                    }
+                    else
                     {
-                        await CopyDownloadToFileAsync(responseStream, fileStream, totalBytes, progress);
+                        using var client = new HttpClient
+                        {
+                            Timeout = TimeSpan.FromMinutes(5)
+                        };
+
+                        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("StarforgedAtlasPortableLauncher", "1.0"));
+
+                        progress.Report(new UpdateProgressInfo("Connecting to GitHub...", update.ReleaseTag, null));
+
+                        using var response = await client.GetAsync(
+                            update.DownloadUrl,
+                            HttpCompletionOption.ResponseHeadersRead);
+
+                        response.EnsureSuccessStatusCode();
+
+                        var totalBytes = response.Content.Headers.ContentLength;
+                        await using (var responseStream = await response.Content.ReadAsStreamAsync())
+                        await using (var fileStream = File.Create(zipPath))
+                        {
+                            await CopyDownloadToFileAsync(responseStream, fileStream, totalBytes, progress);
+                        }
                     }
 
                     progress.Report(new UpdateProgressInfo("Extracting the portable package...", PortableZipAssetName, null));
@@ -262,19 +301,59 @@ internal sealed class PortableLauncher
         }
     }
 
-    private static async Task CopyDownloadToFileAsync(
+    private static Task CopyDownloadToFileAsync(
         Stream responseStream,
         Stream fileStream,
         long? totalBytes,
         IProgress<UpdateProgressInfo> progress)
     {
+        return CopyStreamToFileAsync(
+            responseStream,
+            fileStream,
+            totalBytes,
+            progress,
+            "Downloading update...",
+            "downloaded");
+    }
+
+    private static async Task CopyLocalPackageToFileAsync(
+        string sourcePath,
+        string destinationPath,
+        IProgress<UpdateProgressInfo> progress)
+    {
+        if (!File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException("The configured local update package could not be found.", sourcePath);
+        }
+
+        progress.Report(new UpdateProgressInfo("Copying local update package...", sourcePath, null));
+
+        await using var sourceStream = File.OpenRead(sourcePath);
+        await using var destinationStream = File.Create(destinationPath);
+        await CopyStreamToFileAsync(
+            sourceStream,
+            destinationStream,
+            sourceStream.Length,
+            progress,
+            "Copying update package...",
+            "copied");
+    }
+
+    private static async Task CopyStreamToFileAsync(
+        Stream sourceStream,
+        Stream destinationStream,
+        long? totalBytes,
+        IProgress<UpdateProgressInfo> progress,
+        string message,
+        string fallbackVerb)
+    {
         var buffer = new byte[81920];
         long totalRead = 0;
         int read;
 
-        while ((read = await responseStream.ReadAsync(buffer)) > 0)
+        while ((read = await sourceStream.ReadAsync(buffer)) > 0)
         {
-            await fileStream.WriteAsync(buffer.AsMemory(0, read));
+            await destinationStream.WriteAsync(buffer.AsMemory(0, read));
             totalRead += read;
 
             int? percent = totalBytes is > 0
@@ -282,9 +361,9 @@ internal sealed class PortableLauncher
                 : null;
             var detail = totalBytes is > 0
                 ? $"{FormatBytes(totalRead)} of {FormatBytes(totalBytes.Value)}"
-                : $"{FormatBytes(totalRead)} downloaded";
+                : $"{FormatBytes(totalRead)} {fallbackVerb}";
 
-            progress.Report(new UpdateProgressInfo("Downloading update...", detail, percent));
+            progress.Report(new UpdateProgressInfo(message, detail, percent));
         }
     }
 
@@ -769,6 +848,13 @@ internal sealed record PortableReleaseUpdate(
     string ReleaseTag,
     string? ReleaseName,
     string DownloadUrl,
+    string? ReleaseNotes,
+    bool IsLocalPackage = false);
+
+internal sealed record PortableUpdateSourceOverride(
+    string? ReleaseTag,
+    string? ReleaseName,
+    string? PackagePath,
     string? ReleaseNotes);
 
 internal sealed record PortableUpdateValidationContext(
@@ -1007,6 +1093,69 @@ internal static class PortableUpdateStateStore
     }
 }
 
+internal static class PortableUpdateSourceOverrideStore
+{
+    private const string OverrideFileName = "portable-update-source.json";
+
+    public static PortableUpdateSourceOverride? Load(string packageRoot)
+    {
+        var path = GetOverridePath(packageRoot);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var updateOverride = JsonSerializer.Deserialize(
+                File.ReadAllText(path),
+                PortableJsonContext.Default.PortableUpdateSourceOverride);
+            if (updateOverride is null
+                || string.IsNullOrWhiteSpace(updateOverride.ReleaseTag)
+                || string.IsNullOrWhiteSpace(updateOverride.PackagePath))
+            {
+                return null;
+            }
+
+            return updateOverride with
+            {
+                PackagePath = ResolvePackagePath(path, updateOverride.PackagePath)
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static void Save(string packageRoot, PortableUpdateSourceOverride updateOverride)
+    {
+        var path = GetOverridePath(packageRoot);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(updateOverride, PortableJsonContext.Default.PortableUpdateSourceOverride));
+    }
+
+    private static string GetOverridePath(string packageRoot)
+    {
+        return Path.Combine(packageRoot, "app", "data", OverrideFileName);
+    }
+
+    private static string ResolvePackagePath(string overridePath, string configuredPackagePath)
+    {
+        var expandedPath = Environment.ExpandEnvironmentVariables(configuredPackagePath.Trim());
+        if (Path.IsPathFullyQualified(expandedPath))
+        {
+            return expandedPath;
+        }
+
+        var configDirectory = Path.GetDirectoryName(overridePath)
+            ?? throw new InvalidOperationException("Unable to determine the portable update override directory.");
+        return Path.GetFullPath(Path.Combine(configDirectory, expandedPath));
+    }
+}
+
 internal sealed record PortableUpdateState(
     string[] IgnoredReleases,
     PortablePendingUpdateValidation? PendingValidation)
@@ -1186,6 +1335,7 @@ internal static class PortableUpdateFailureReporter
 
 [JsonSerializable(typeof(PortableUpdateState))]
 [JsonSerializable(typeof(PortablePendingUpdateValidation))]
+[JsonSerializable(typeof(PortableUpdateSourceOverride))]
 [JsonSerializable(typeof(GitHubProjectSummary[]))]
 internal partial class PortableJsonContext : JsonSerializerContext
 {

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -50,7 +50,12 @@ internal sealed class PortableLauncher
             return;
         }
 
-        var postUpdateValidation = TryGetPostUpdateValidation(args, packageRoot);
+        var postUpdateValidation = PortableUpdateStateStore.LoadPendingValidation(packageRoot)
+            ?? TryGetPostUpdateValidation(args, packageRoot);
+        if (postUpdateValidation is not null)
+        {
+            PortableUpdateStateStore.SavePendingValidation(packageRoot, postUpdateValidation);
+        }
 
         try
         {
@@ -111,6 +116,7 @@ internal sealed class PortableLauncher
     {
         if (!Directory.Exists(validationContext.BackupRoot))
         {
+            PortableUpdateStateStore.ClearPendingValidation(packageRoot);
             return;
         }
 
@@ -122,6 +128,7 @@ internal sealed class PortableLauncher
 
         if (result == DialogResult.Yes)
         {
+            PortableUpdateStateStore.ClearPendingValidation(packageRoot);
             TryDeleteDirectory(Path.GetDirectoryName(validationContext.BackupRoot)!);
             return;
         }
@@ -425,6 +432,10 @@ internal sealed class PortableLauncher
 
                     progress.Report(new UpdateProgressInfo("Restarting Starforged Atlas...", "The launcher will check whether the update worked when the app exits.", 100));
 
+                    PortableUpdateStateStore.SavePendingValidation(
+                        targetRoot,
+                        new PortableUpdateValidationContext(targetRoot, releaseTag, previousVersion, backupRoot));
+
                     var launcherPath = Path.Combine(targetRoot, LauncherExecutableName);
                     var startInfo = new ProcessStartInfo
                     {
@@ -538,6 +549,7 @@ internal sealed class PortableLauncher
 
                     PortablePackageInstaller.RestoreBackup(backupRoot, targetRoot, progress);
                     PortableUpdateStateStore.IgnoreRelease(targetRoot, releaseTag);
+                    PortableUpdateStateStore.ClearPendingValidation(targetRoot);
                     PortableUpdateFailureReporter.ReportFailedUpdate(releaseTag, previousVersion);
 
                     progress.Report(new UpdateProgressInfo("Restarting the previous version...", null, 100));
@@ -916,17 +928,17 @@ internal static class PortableUpdateStateStore
         var path = GetStatePath(packageRoot);
         if (!File.Exists(path))
         {
-            return new PortableUpdateState([]);
+            return new PortableUpdateState([], null);
         }
 
         try
         {
             var state = JsonSerializer.Deserialize<PortableUpdateState>(File.ReadAllText(path));
-            return state ?? new PortableUpdateState([]);
+            return state ?? new PortableUpdateState([], null);
         }
         catch
         {
-            return new PortableUpdateState([]);
+            return new PortableUpdateState([], null);
         }
     }
 
@@ -942,7 +954,7 @@ internal static class PortableUpdateStateStore
             .Concat([releaseTag])
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        Save(packageRoot, new PortableUpdateState(ignoredReleases));
+        Save(packageRoot, state with { IgnoredReleases = ignoredReleases });
     }
 
     public static void Save(string packageRoot, PortableUpdateState state)
@@ -956,13 +968,57 @@ internal static class PortableUpdateStateStore
     {
         return Path.Combine(packageRoot, "app", "data", StateFileName);
     }
+
+    public static PortableUpdateValidationContext? LoadPendingValidation(string packageRoot)
+    {
+        var pendingValidation = Load(packageRoot).PendingValidation;
+        return pendingValidation is null
+            ? null
+            : new PortableUpdateValidationContext(
+                packageRoot,
+                pendingValidation.ReleaseTag,
+                pendingValidation.PreviousVersion,
+                pendingValidation.BackupRoot);
+    }
+
+    public static void SavePendingValidation(string packageRoot, PortableUpdateValidationContext validationContext)
+    {
+        var state = Load(packageRoot);
+        Save(
+            packageRoot,
+            state with
+            {
+                PendingValidation = new PortablePendingUpdateValidation(
+                    validationContext.ReleaseTag,
+                    validationContext.PreviousVersion,
+                    validationContext.BackupRoot)
+            });
+    }
+
+    public static void ClearPendingValidation(string packageRoot)
+    {
+        var state = Load(packageRoot);
+        if (state.PendingValidation is null)
+        {
+            return;
+        }
+
+        Save(packageRoot, state with { PendingValidation = null });
+    }
 }
 
-internal sealed record PortableUpdateState(string[] IgnoredReleases)
+internal sealed record PortableUpdateState(
+    string[] IgnoredReleases,
+    PortablePendingUpdateValidation? PendingValidation)
 {
     public bool ShouldIgnore(string releaseTag)
         => IgnoredReleases.Any(candidate => string.Equals(candidate, releaseTag, StringComparison.OrdinalIgnoreCase));
 }
+
+internal sealed record PortablePendingUpdateValidation(
+    string ReleaseTag,
+    string PreviousVersion,
+    string BackupRoot);
 
 internal static class PortableUpdateFailureReporter
 {
@@ -1129,6 +1185,7 @@ internal static class PortableUpdateFailureReporter
 }
 
 [JsonSerializable(typeof(PortableUpdateState))]
+[JsonSerializable(typeof(PortablePendingUpdateValidation))]
 [JsonSerializable(typeof(GitHubProjectSummary[]))]
 internal partial class PortableJsonContext : JsonSerializerContext
 {

--- a/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
+++ b/StarforgedAtlas.PortableLauncher/PortableLauncher.cs
@@ -162,10 +162,11 @@ internal sealed class PortableLauncher
                     response.EnsureSuccessStatusCode();
 
                     var totalBytes = response.Content.Headers.ContentLength;
-                    await using var responseStream = await response.Content.ReadAsStreamAsync();
-                    await using var fileStream = File.Create(zipPath);
-
-                    await CopyDownloadToFileAsync(responseStream, fileStream, totalBytes, progress);
+                    await using (var responseStream = await response.Content.ReadAsStreamAsync())
+                    await using (var fileStream = File.Create(zipPath))
+                    {
+                        await CopyDownloadToFileAsync(responseStream, fileStream, totalBytes, progress);
+                    }
 
                     progress.Report(new UpdateProgressInfo("Extracting the portable package...", PortableZipAssetName, null));
                     ZipFile.ExtractToDirectory(zipPath, extractRoot);

--- a/StarforgedAtlas.PortableLauncher/Program.cs
+++ b/StarforgedAtlas.PortableLauncher/Program.cs
@@ -1,41 +1,11 @@
 using System.Diagnostics;
+using System.Globalization;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-var packageRoot = AppContext.BaseDirectory;
-var appRoot = Path.Combine(packageRoot, "app");
-var targetPath = Path.Combine(appRoot, "StarWin.Desktop.exe");
+ApplicationConfiguration.Initialize();
 
-if (!File.Exists(targetPath))
-{
-    ShowError(
-        "Starforged Atlas could not find the packaged desktop application.",
-        $"Expected to find:{Environment.NewLine}{targetPath}");
-    return;
-}
-
-try
-{
-    var startInfo = new ProcessStartInfo
-    {
-        FileName = targetPath,
-        WorkingDirectory = appRoot,
-        UseShellExecute = true
-    };
-
-    Process.Start(startInfo);
-}
-catch (Exception ex)
-{
-    ShowError(
-        "Starforged Atlas could not be started.",
-        ex.GetBaseException().Message);
-}
-
-static void ShowError(string message, string detail)
-{
-    var fullMessage = $"{message}{Environment.NewLine}{Environment.NewLine}{detail}";
-    System.Windows.Forms.MessageBox.Show(
-        fullMessage,
-        "Starforged Atlas",
-        System.Windows.Forms.MessageBoxButtons.OK,
-        System.Windows.Forms.MessageBoxIcon.Error);
-}
+var launcher = new PortableLauncher();
+await launcher.RunAsync(args);

--- a/StarforgedAtlas.PortableLauncher/Properties/AssemblyInfo.cs
+++ b/StarforgedAtlas.PortableLauncher/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("StarforgedAtlas.PortableLauncher.Tests")]

--- a/StarforgedAtlas.PortableLauncher/UpdateProgressForm.cs
+++ b/StarforgedAtlas.PortableLauncher/UpdateProgressForm.cs
@@ -1,0 +1,71 @@
+internal sealed class UpdateProgressForm : Form
+{
+    private readonly Label _messageLabel;
+    private readonly Label _detailLabel;
+    private readonly ProgressBar _progressBar;
+
+    public UpdateProgressForm(string title)
+    {
+        Text = title;
+        StartPosition = FormStartPosition.CenterScreen;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        ControlBox = false;
+        ShowInTaskbar = true;
+        ClientSize = new Size(520, 150);
+
+        _messageLabel = new Label
+        {
+            AutoSize = false,
+            Location = new Point(18, 16),
+            Size = new Size(484, 28),
+            Font = new Font(FontFamily.GenericSansSerif, 10f, FontStyle.Bold),
+            TextAlign = ContentAlignment.MiddleLeft
+        };
+
+        _detailLabel = new Label
+        {
+            AutoSize = false,
+            Location = new Point(18, 52),
+            Size = new Size(484, 40),
+            TextAlign = ContentAlignment.TopLeft
+        };
+
+        _progressBar = new ProgressBar
+        {
+            Location = new Point(18, 104),
+            Size = new Size(484, 24),
+            Style = ProgressBarStyle.Marquee,
+            MarqueeAnimationSpeed = 25
+        };
+
+        Controls.Add(_messageLabel);
+        Controls.Add(_detailLabel);
+        Controls.Add(_progressBar);
+    }
+
+    public void UpdateProgress(UpdateProgressInfo progress)
+    {
+        if (InvokeRequired)
+        {
+            BeginInvoke(() => UpdateProgress(progress));
+            return;
+        }
+
+        _messageLabel.Text = progress.Message;
+        _detailLabel.Text = progress.Detail ?? string.Empty;
+
+        if (progress.Percent is int percent)
+        {
+            _progressBar.Style = ProgressBarStyle.Continuous;
+            _progressBar.MarqueeAnimationSpeed = 0;
+            _progressBar.Value = Math.Clamp(percent, _progressBar.Minimum, _progressBar.Maximum);
+        }
+        else
+        {
+            _progressBar.Style = ProgressBarStyle.Marquee;
+            _progressBar.MarqueeAnimationSpeed = 25;
+        }
+    }
+}


### PR DESCRIPTION
## Affected issues
- None specified

## Release
- 2026-04-27.1 Developer Preview
- Release tag: `2026-04-27.1-developer-preview`

## Summary of changes
- promote the current `dev` branch to `master` for the April 27, 2026 Developer Preview release
- include the desktop GitHub release check and prompt flow using embedded app version metadata and release notes
- include the desktop SQLite startup fixes so fresh and partially initialized local databases start cleanly
- include the portable self-update, progress UI, rollback, failed-release ignore, and local override testing support
- stamp the desktop app version metadata on `dev` to `2026-04-27.1-developer-preview` before merge so the release build reports the correct version

## Verification
- dotnet build StarWin.Desktop/StarWin.Desktop.csproj -f net10.0-windows --no-restore