### PR TITLE
Codex - Promote dev to master for 2026-04-30.0 Developer Preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ When I explicitly tell you to implement the changes, move the issue from `Ready`
 
 When I tell you to promote the work to `dev`, move the issue from `In progress` to `In review`.
 
+All code changes promoted into `dev` must go through a pull request. Do not merge or commit changes directly into `dev`.
+
 When a pull request that promotes work to `main` is completed, move all issues connected to that pull request from `In review` to `Done`.
 
 Use `master` as the protected release branch, `dev` as the shared integration branch, and short-lived feature branches for task work. Do not commit feature work directly to `master` or `dev`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ The first workflow step for an issue-driven conversation is:
 
 If `dev` does not exist yet, create it from `master`, then create the feature or bug-fix branch from `dev`.
 
+When I ask for a fix without giving an issue number, check the `Starforged Atlas Task Board` and the repository issues for an existing issue that matches the requested work. If a likely matching issue exists, confirm with me that it is the correct issue before proceeding. If the matching issue is not the one we are working on, or if no matching issue exists, create a new issue for the work and create the branch from that issue.
+
 Do not start coding for an issue-driven conversation until I explicitly ask you to begin the coding process.
 
 GitHub project workflow uses the `Starforged Atlas Task Board`.

--- a/StarWin.Application/Services/IStarWinExplorerContextService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerContextService.cs
@@ -25,6 +25,18 @@ public interface IStarWinExplorerContextService
         int? detailedSectorId = null,
         ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
         CancellationToken cancellationToken = default);
+
+    Task<StarWinExplorerContext> LoadShellAsync(
+        int? preferredSectorId = null,
+        bool includeSavedRoutes = false,
+        bool includeReferenceData = false,
+        CancellationToken cancellationToken = default)
+        => LoadShellAsync(
+            includeSavedRoutes,
+            includeReferenceData,
+            preferredSectorId,
+            ExplorerSectorLoadSections.None,
+            cancellationToken);
 }
 
 public sealed record StarWinExplorerContext(

--- a/StarWin.Application/Services/IStarWinExplorerContextService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerContextService.cs
@@ -3,53 +3,23 @@ using StarWin.Domain.Model.Entity.StarMap;
 
 namespace StarWin.Application.Services;
 
-[Flags]
-public enum ExplorerSectorLoadSections
-{
-    None = 0,
-    AstralBodies = 1 << 0,
-    Worlds = 1 << 1,
-    WorldCharacteristics = 1 << 2,
-    Colonies = 1 << 3,
-    ColonyDemographics = 1 << 4,
-    SpaceHabitats = 1 << 5,
-    SavedRoutes = 1 << 6,
-    History = 1 << 7
-}
-
 public interface IStarWinExplorerContextService
 {
     Task<StarWinExplorerContext> LoadShellAsync(
-        bool includeSavedRoutes = true,
-        bool includeReferenceData = true,
-        int? detailedSectorId = null,
-        ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
-        CancellationToken cancellationToken = default);
-
-    Task<StarWinExplorerContext> LoadShellAsync(
         int? preferredSectorId = null,
-        bool includeSavedRoutes = false,
         bool includeReferenceData = false,
-        CancellationToken cancellationToken = default)
-        => LoadShellAsync(
-            includeSavedRoutes,
-            includeReferenceData,
-            preferredSectorId,
-            ExplorerSectorLoadSections.None,
-            cancellationToken);
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record StarWinExplorerContext(
     IReadOnlyList<StarWinSector> Sectors,
     StarWinSector CurrentSector,
     IReadOnlyList<AlienRace> AlienRaces,
-    IReadOnlyList<Empire> Empires,
-    IReadOnlyList<EmpireContact> EmpireContacts)
+    IReadOnlyList<Empire> Empires)
 {
     public static StarWinExplorerContext Empty { get; } = new(
         [],
         new StarWinSector { Id = 0, Name = "No sectors loaded" },
-        [],
         [],
         []);
 }

--- a/StarWin.Application/Services/IStarWinExplorerContextService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerContextService.cs
@@ -22,10 +22,8 @@ public interface IStarWinExplorerContextService
     Task<StarWinExplorerContext> LoadShellAsync(
         bool includeSavedRoutes = true,
         bool includeReferenceData = true,
-        CancellationToken cancellationToken = default);
-    Task<StarWinSector?> LoadSectorAsync(
-        int sectorId,
-        ExplorerSectorLoadSections loadSections,
+        int? detailedSectorId = null,
+        ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
         CancellationToken cancellationToken = default);
 }
 

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -4,10 +4,41 @@ public interface IStarWinExplorerQueryService
 {
     Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default);
     Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<StarWinSearchResult>> SearchSectorAsync(int sectorId, string query, int maxResults = 30, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<StarWinSearchResult>>([]);
+    Task<int?> ResolveSystemIdAsync(
+        int sectorId,
+        int? worldId = null,
+        int? colonyId = null,
+        int? habitatId = null,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+    Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ExplorerLookupOption>>([]);
     Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default);
     Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default);
     Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default);
     Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default);
+    Task<ExplorerSystemFilterOptions> LoadSystemFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+        => Task.FromResult(new ExplorerSystemFilterOptions([]));
+    Task<ExplorerSystemListPage> LoadSystemListPageAsync(ExplorerSystemListPageRequest request, CancellationToken cancellationToken = default)
+        => Task.FromResult(new ExplorerSystemListPage([], false));
+    Task<ExplorerSystemListItem?> LoadSystemListItemAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerSystemListItem?>(null);
+    Task<ExplorerSystemDetail?> LoadSystemDetailAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerSystemDetail?>(null);
+    Task<ExplorerWorldsWorkspace?> LoadWorldsWorkspaceAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerWorldsWorkspace?>(null);
+    Task<ExplorerColonyFilterOptions> LoadColonyFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+        => Task.FromResult(new ExplorerColonyFilterOptions([], [], []));
+    Task<ExplorerColonyListPage> LoadColonyListPageAsync(ExplorerColonyListPageRequest request, CancellationToken cancellationToken = default)
+        => Task.FromResult(new ExplorerColonyListPage([], false));
+    Task<ExplorerColonyListItem?> LoadColonyListItemAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerColonyListItem?>(null);
+    Task<ExplorerColonyDetail?> LoadColonyDetailAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerColonyDetail?>(null);
+    Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerHyperlaneWorkspace?>(null);
     Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default);
     Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default);
     Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default);
@@ -37,6 +68,86 @@ public sealed record ExplorerSectorEntityUsage(
     int SectorId,
     IReadOnlyList<int> RaceIds,
     IReadOnlyList<int> EmpireIds);
+
+public sealed record ExplorerSystemFilterOptions(
+    IReadOnlyList<ExplorerLookupOption> Empires);
+
+public sealed record ExplorerSystemListPageRequest(
+    int SectorId,
+    int Offset,
+    int Limit,
+    string? Query = null,
+    int? EmpireId = null);
+
+public sealed record ExplorerSystemListPage(
+    IReadOnlyList<ExplorerSystemListItem> Items,
+    bool HasMore);
+
+public sealed record ExplorerSystemListItem(
+    int SystemId,
+    int? LegacySystemId,
+    string Name,
+    StarWin.Domain.Model.Entity.StarMap.Coordinates Coordinates,
+    ushort AllegianceId,
+    string AllegianceName);
+
+public sealed record ExplorerSystemDetail(
+    int SectorId,
+    StarWin.Domain.Model.Entity.StarMap.StarSystem System);
+
+public sealed record ExplorerWorldsWorkspace(
+    int SectorId,
+    StarWin.Domain.Model.Entity.StarMap.StarSystem System,
+    IReadOnlyList<ExplorerLookupOption> Empires);
+
+public sealed record ExplorerColonyFilterOptions(
+    IReadOnlyList<ExplorerLookupOption> Races,
+    IReadOnlyList<ExplorerLookupOption> Empires,
+    IReadOnlyList<string> Classes);
+
+public sealed record ExplorerColonyListPageRequest(
+    int SectorId,
+    int Offset,
+    int Limit,
+    string? Query = null,
+    int? RaceId = null,
+    int? EmpireId = null,
+    string? Status = null,
+    string? ColonyClass = null);
+
+public sealed record ExplorerColonyListPage(
+    IReadOnlyList<ExplorerColonyListItem> Items,
+    bool HasMore);
+
+public sealed record ExplorerColonyListItem(
+    int ColonyId,
+    int WorldId,
+    int SystemId,
+    string ColonyName,
+    string WorldName,
+    string AllegianceName,
+    long EstimatedPopulation);
+
+public sealed record ExplorerColonyDetail(
+    int SectorId,
+    StarWin.Domain.Model.Entity.Civilization.Colony Colony,
+    StarWin.Domain.Model.Entity.StarMap.World World);
+
+public sealed record ExplorerHyperlaneWorkspace(
+    int SectorId,
+    string SectorName,
+    StarWin.Domain.Model.Entity.StarMap.SectorConfiguration Configuration,
+    IReadOnlyList<ExplorerHyperlaneSystem> Systems,
+    IReadOnlyList<StarWin.Domain.Model.Entity.StarMap.SectorSavedRoute> SavedRoutes,
+    IReadOnlyList<int> EligibleSystemIds,
+    IReadOnlyList<ExplorerLookupOption> Empires);
+
+public sealed record ExplorerHyperlaneSystem(
+    int SystemId,
+    int? LegacySystemId,
+    string Name,
+    StarWin.Domain.Model.Entity.StarMap.Coordinates Coordinates,
+    ushort AllegianceId);
 
 public sealed record ExplorerAlienRaceFilterOptions(
     IReadOnlyList<string> EnvironmentTypes,

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -60,9 +60,7 @@ public sealed record ExplorerSectorOverviewData(
     int WorldCount,
     int ColonyCount,
     int EmpireCount,
-    int RaceCount,
-    IReadOnlyList<ExplorerLookupOption> Systems,
-    IReadOnlyList<ExplorerLookupOption> Empires);
+    int RaceCount);
 
 public sealed record ExplorerSectorEntityUsage(
     int SectorId,

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -3,6 +3,7 @@ namespace StarWin.Application.Services;
 public interface IStarWinExplorerQueryService
 {
     Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default);
+    Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default);
     Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default);
     Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default);
     Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default);
@@ -31,6 +32,11 @@ public sealed record ExplorerSectorOverviewData(
     int RaceCount,
     IReadOnlyList<ExplorerLookupOption> Systems,
     IReadOnlyList<ExplorerLookupOption> Empires);
+
+public sealed record ExplorerSectorEntityUsage(
+    int SectorId,
+    IReadOnlyList<int> RaceIds,
+    IReadOnlyList<int> EmpireIds);
 
 public sealed record ExplorerAlienRaceFilterOptions(
     IReadOnlyList<string> EnvironmentTypes,

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -37,6 +37,8 @@ public interface IStarWinExplorerQueryService
         => Task.FromResult<ExplorerColonyListItem?>(null);
     Task<ExplorerColonyDetail?> LoadColonyDetailAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
         => Task.FromResult<ExplorerColonyDetail?>(null);
+    Task<ExplorerHyperlaneSetupState?> LoadHyperlaneSetupAsync(int sectorId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerHyperlaneSetupState?>(null);
     Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
         => Task.FromResult<ExplorerHyperlaneWorkspace?>(null);
     Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default);
@@ -130,6 +132,12 @@ public sealed record ExplorerColonyDetail(
     int SectorId,
     StarWin.Domain.Model.Entity.Civilization.Colony Colony,
     StarWin.Domain.Model.Entity.StarMap.World World);
+
+public sealed record ExplorerHyperlaneSetupState(
+    int SectorId,
+    string SectorName,
+    StarWin.Domain.Model.Entity.StarMap.SectorConfiguration Configuration,
+    int SavedRouteCount);
 
 public sealed record ExplorerHyperlaneWorkspace(
     int SectorId,

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -41,8 +41,8 @@ public interface IStarWinExplorerQueryService
         => Task.FromResult<ExplorerHyperlaneSetupState?>(null);
     Task<ExplorerSectorConfigurationState?> LoadSectorConfigurationStateAsync(int sectorId, int? systemId = null, CancellationToken cancellationToken = default)
         => Task.FromResult<ExplorerSectorConfigurationState?>(null);
-    Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
-        => Task.FromResult<ExplorerHyperlaneWorkspace?>(null);
+    Task<ExplorerHyperlanePageState?> LoadHyperlanePageStateAsync(int sectorId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerHyperlanePageState?>(null);
     Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default);
     Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default);
     Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default);
@@ -149,13 +149,13 @@ public sealed record ExplorerSectorConfigurationState(
     StarWin.Domain.Services.SectorHyperlaneNetworkReport SavedRouteReport,
     int SelectedSystemRouteCount);
 
-public sealed record ExplorerHyperlaneWorkspace(
+public sealed record ExplorerHyperlanePageState(
     int SectorId,
     string SectorName,
     StarWin.Domain.Model.Entity.StarMap.SectorConfiguration Configuration,
     IReadOnlyList<ExplorerHyperlaneSystem> Systems,
     IReadOnlyList<StarWin.Domain.Model.Entity.StarMap.SectorSavedRoute> SavedRoutes,
-    IReadOnlyList<int> EligibleSystemIds,
+    StarWin.Domain.Services.SectorHyperlaneNetworkReport SavedRouteReport,
     IReadOnlyList<ExplorerLookupOption> Empires);
 
 public sealed record ExplorerHyperlaneSystem(

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -39,6 +39,8 @@ public interface IStarWinExplorerQueryService
         => Task.FromResult<ExplorerColonyDetail?>(null);
     Task<ExplorerHyperlaneSetupState?> LoadHyperlaneSetupAsync(int sectorId, CancellationToken cancellationToken = default)
         => Task.FromResult<ExplorerHyperlaneSetupState?>(null);
+    Task<ExplorerSectorConfigurationState?> LoadSectorConfigurationStateAsync(int sectorId, int? systemId = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<ExplorerSectorConfigurationState?>(null);
     Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
         => Task.FromResult<ExplorerHyperlaneWorkspace?>(null);
     Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default);
@@ -138,6 +140,14 @@ public sealed record ExplorerHyperlaneSetupState(
     string SectorName,
     StarWin.Domain.Model.Entity.StarMap.SectorConfiguration Configuration,
     int SavedRouteCount);
+
+public sealed record ExplorerSectorConfigurationState(
+    int SectorId,
+    string SectorName,
+    StarWin.Domain.Model.Entity.StarMap.SectorConfiguration Configuration,
+    int SavedRouteCount,
+    StarWin.Domain.Services.SectorHyperlaneNetworkReport SavedRouteReport,
+    int SelectedSystemRouteCount);
 
 public sealed record ExplorerHyperlaneWorkspace(
     int SectorId,

--- a/StarWin.Application/Services/IStarWinImageService.cs
+++ b/StarWin.Application/Services/IStarWinImageService.cs
@@ -2,9 +2,18 @@ using StarWin.Domain.Model.Entity.Media;
 
 namespace StarWin.Application.Services;
 
+public sealed record EntityImageTarget(EntityImageTargetKind TargetKind, int TargetId);
+
 public interface IStarWinImageService
 {
     Task<IReadOnlyList<EntityImage>> GetImagesAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<EntityImage>> GetImagesAsync(
+        IReadOnlyCollection<EntityImageTarget> targets,
+        CancellationToken cancellationToken = default)
+        => targets.Count == 0
+            ? Task.FromResult<IReadOnlyList<EntityImage>>([])
+            : GetImagesAsync(cancellationToken);
 
     Task<EntityImage> UploadImageAsync(
         EntityImageTargetKind targetKind,

--- a/StarWin.Application/Services/IStarWinWorkspace.cs
+++ b/StarWin.Application/Services/IStarWinWorkspace.cs
@@ -16,8 +16,6 @@ public interface IStarWinWorkspace
 
     IReadOnlyList<Empire> Empires { get; }
 
-    IReadOnlyList<EmpireContact> EmpireContacts { get; }
-
     CivilizationGeneratorSettings CivilizationSettings { get; }
 
     ArmyGeneratorSettings ArmySettings { get; }

--- a/StarWin.Application/Services/StarWinSearchResult.cs
+++ b/StarWin.Application/Services/StarWinSearchResult.cs
@@ -16,6 +16,8 @@ public sealed class StarWinSearchResult
 
     public int? WorldId { get; init; }
 
+    public int? ColonyId { get; init; }
+
     public int? SpaceHabitatId { get; init; }
 
     public int? RaceId { get; init; }

--- a/StarWin.Application/Services/StarWinSearchService.cs
+++ b/StarWin.Application/Services/StarWinSearchService.cs
@@ -71,6 +71,7 @@ public sealed class StarWinSearchService(IStarWinWorkspace workspace) : IStarWin
                             SectorId = sector.Id,
                             SystemId = system.Id,
                             WorldId = world.Id,
+                            ColonyId = world.Colony.Id,
                             RaceId = world.Colony.RaceId,
                             EmpireId = world.Colony.ControllingEmpireId
                         });

--- a/StarWin.Desktop/Program.cs
+++ b/StarWin.Desktop/Program.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Text.Json;
 using System.ComponentModel;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -76,6 +77,7 @@ internal static class Program
     {
         var localUrl = $"http://127.0.0.1:{port}";
         var databasePath = StarWinDesktopPaths.GetDatabasePath();
+        StarWinDesktopLog.Write("desktop-backend", $"Starting backend server on {localUrl} using database '{databasePath}'.");
 
         var builder = StarWinWebHost.CreateBuilder(new WebApplicationOptions
         {
@@ -219,9 +221,20 @@ internal static class Program
                     options);
 
                 await webView.EnsureCoreWebView2Async(environment);
+                webView.CoreWebView2.WebMessageReceived += (_, messageArgs) =>
+                {
+                    StarWinDesktopLog.Write("webview-message", messageArgs.WebMessageAsJson);
+                };
+                webView.CoreWebView2.NavigationStarting += (_, navigationArgs) =>
+                {
+                    StarWinDesktopLog.Write("webview-nav", $"Navigation starting: {navigationArgs.Uri}");
+                };
                 startupReporter.Report("Loading Starforged Atlas", "Navigating to the shared local backend.");
                 webView.CoreWebView2.NavigationCompleted += (_, navigationArgs) =>
                 {
+                    StarWinDesktopLog.Write(
+                        "webview-nav",
+                        $"Navigation completed: success={navigationArgs.IsSuccess} status={navigationArgs.HttpStatusCode} uri={webView.Source}");
                     if (navigationArgs.IsSuccess)
                     {
                         CloseSplash();
@@ -497,19 +510,49 @@ internal static class DesktopBackendCoordinator
     {
         var executablePath = Environment.ProcessPath
             ?? throw new InvalidOperationException("Unable to determine the current desktop executable path.");
+        var backendLogPath = StarWinDesktopPaths.GetBackendLogPath();
+        StarWinDesktopLog.Write("desktop-shell", $"Launching backend process on port {port}. Backend log path: {backendLogPath}");
 
         var startInfo = new ProcessStartInfo
         {
             FileName = executablePath,
             Arguments = $"{BackendServerArgument} {BackendPortArgument} {port}",
             UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
             CreateNoWindow = true,
             WindowStyle = ProcessWindowStyle.Hidden,
             WorkingDirectory = AppContext.BaseDirectory
         };
 
-        return Process.Start(startInfo)
+        startInfo.StandardOutputEncoding = Encoding.UTF8;
+        startInfo.StandardErrorEncoding = Encoding.UTF8;
+
+        var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to launch the shared desktop backend process.");
+        process.EnableRaisingEvents = true;
+        process.Exited += (_, _) =>
+        {
+            StarWinDesktopLog.Write("desktop-shell", $"Backend process exited. pid={process.Id} exitCode={process.ExitCode}");
+        };
+
+        _ = PumpProcessStreamAsync(process.StandardOutput, "backend-stdout");
+        _ = PumpProcessStreamAsync(process.StandardError, "backend-stderr");
+        return process;
+    }
+
+    private static async Task PumpProcessStreamAsync(StreamReader reader, string source)
+    {
+        while (true)
+        {
+            var line = await reader.ReadLineAsync();
+            if (line is null)
+            {
+                break;
+            }
+
+            StarWinDesktopLog.Write(source, line);
+        }
     }
 
     private static int SelectBackendPort(int preferredPort)
@@ -1234,6 +1277,23 @@ internal static class StarWinDesktopPaths
         return Path.Combine(GetApplicationDataRoot(), "desktop-backend-state.json");
     }
 
+    public static string GetLogsRoot()
+    {
+        var logsRoot = Path.Combine(GetApplicationDataRoot(), "logs");
+        Directory.CreateDirectory(logsRoot);
+        return logsRoot;
+    }
+
+    public static string GetBackendLogPath()
+    {
+        return Path.Combine(GetLogsRoot(), "desktop-backend.log");
+    }
+
+    public static string GetDesktopShellLogPath()
+    {
+        return Path.Combine(GetLogsRoot(), "desktop-shell.log");
+    }
+
     public static string GetUpdatePromptStatePath()
     {
         return Path.Combine(GetApplicationDataRoot(), "desktop-update-state.json");
@@ -1270,5 +1330,24 @@ internal static class StarWinDesktopPaths
         Directory.CreateDirectory(atlasRoot);
 
         return atlasRoot;
+    }
+}
+
+internal static class StarWinDesktopLog
+{
+    private static readonly object Sync = new();
+
+    public static void Write(string source, string message)
+    {
+        var line = $"[{DateTimeOffset.Now:O}] [{source}] {message}{Environment.NewLine}";
+        var logPath = source.StartsWith("backend", StringComparison.Ordinal)
+            || source.Equals("desktop-backend", StringComparison.Ordinal)
+            ? StarWinDesktopPaths.GetBackendLogPath()
+            : StarWinDesktopPaths.GetDesktopShellLogPath();
+
+        lock (Sync)
+        {
+            File.AppendAllText(logPath, line);
+        }
     }
 }

--- a/StarWin.Desktop/StarWin.Desktop.csproj
+++ b/StarWin.Desktop/StarWin.Desktop.csproj
@@ -31,10 +31,10 @@
     <AssemblyTitle>Starforged Atlas Desktop</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
-    <AssemblyVersion>2026.4.28.0</AssemblyVersion>
-    <FileVersion>2026.4.28.0</FileVersion>
-    <Version>2026.4.28.0</Version>
-    <InformationalVersion>2026-04-28.0-developer-preview</InformationalVersion>
+    <AssemblyVersion>2026.4.30.0</AssemblyVersion>
+    <FileVersion>2026.4.30.0</FileVersion>
+    <Version>2026.4.30.0</Version>
+    <InformationalVersion>2026-04-30.0-developer-preview</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -111,6 +111,63 @@ public sealed class StarWinExplorerQueryServiceTests
     }
 
     [Fact]
+    public async Task LoadAlienRaceDetailAsync_returns_homeworld_memberships_religions_and_civilization_traits()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var seedContext = CreateDbContext(databasePath);
+            await seedContext.Database.EnsureCreatedAsync();
+            await SeedExplorerDataAsync(seedContext);
+
+            var service = new StarWinExplorerQueryService(CreateFactory(databasePath));
+
+            var detail = await service.LoadAlienRaceDetailAsync(1, 1);
+
+            Assert.NotNull(detail);
+            Assert.Equal("Aurelian", detail!.Race.Name);
+            Assert.Equal("Aurel Prime", detail.HomeWorld?.Name);
+            Assert.Collection(
+                detail.Empires,
+                empire =>
+                {
+                    Assert.Equal(201, empire.Id);
+                    Assert.Equal("Aurelian Concord", empire.Name);
+                    Assert.Equal("Council", empire.GovernmentType);
+                    Assert.Equal((byte)6, empire.CivilizationProfile.TechLevel);
+                    Assert.Equal(2, empire.CivilizationModifiers.Militancy);
+                    var membership = Assert.Single(empire.RaceMemberships);
+                    Assert.Equal(1, membership.RaceId);
+                    Assert.True(membership.IsPrimary);
+                    Assert.Equal(1200, membership.PopulationMillions);
+                    var religion = Assert.Single(empire.Religions);
+                    Assert.Equal("Solar Doctrine", religion.ReligionName);
+                    Assert.Equal(100m, religion.PopulationPercent);
+                },
+                empire =>
+                {
+                    Assert.Equal(203, empire.Id);
+                    Assert.Equal("Watcher Remnant", empire.Name);
+                    Assert.Equal("Council", empire.GovernmentType);
+                    Assert.Equal((byte)7, empire.CivilizationProfile.TechLevel);
+                    Assert.Equal(0, empire.CivilizationModifiers.Militancy);
+                    var membership = Assert.Single(empire.RaceMemberships);
+                    Assert.Equal(1, membership.RaceId);
+                    Assert.False(membership.IsPrimary);
+                    Assert.Equal(30, membership.PopulationMillions);
+                    var religion = Assert.Single(empire.Religions);
+                    Assert.Equal("Solar Doctrine", religion.ReligionName);
+                    Assert.Equal(40m, religion.PopulationPercent);
+                });
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
     public async Task LoadEmpireFilterOptionsAsync_returns_distinct_race_options_for_sector_empires()
     {
         var databasePath = CreateTempFilePath(".db");

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -14,6 +14,34 @@ namespace StarWin.Infrastructure.Tests.Explorer;
 public sealed class StarWinExplorerQueryServiceTests
 {
     [Fact]
+    public async Task LoadSectorOverviewAsync_returns_expected_sector_counts()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var seedContext = CreateDbContext(databasePath);
+            await seedContext.Database.EnsureCreatedAsync();
+            await SeedExplorerDataAsync(seedContext);
+
+            var service = new StarWinExplorerQueryService(CreateFactory(databasePath));
+
+            var overview = await service.LoadSectorOverviewAsync(1);
+
+            Assert.Equal(1, overview.SectorId);
+            Assert.Equal(2, overview.SystemCount);
+            Assert.Equal(4, overview.WorldCount);
+            Assert.Equal(3, overview.ColonyCount);
+            Assert.Equal(3, overview.EmpireCount);
+            Assert.Equal(2, overview.RaceCount);
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
     public async Task LoadAlienRaceFilterOptionsAsync_returns_distinct_database_backed_filter_values()
     {
         var databasePath = CreateTempFilePath(".db");

--- a/StarWin.Infrastructure/Services/StarWinDatabaseWorkspace.cs
+++ b/StarWin.Infrastructure/Services/StarWinDatabaseWorkspace.cs
@@ -28,8 +28,6 @@ public sealed class StarWinDatabaseWorkspace : IStarWinWorkspace
 
     public IReadOnlyList<Empire> Empires { get; private set; } = [];
 
-    public IReadOnlyList<EmpireContact> EmpireContacts { get; private set; } = [];
-
     public CivilizationGeneratorSettings CivilizationSettings { get; private set; } = BuildCivilizationSettings(EmptySector);
 
     public ArmyGeneratorSettings ArmySettings { get; private set; } = new();
@@ -47,7 +45,6 @@ public sealed class StarWinDatabaseWorkspace : IStarWinWorkspace
             Sectors = explorerContext.Sectors;
             AlienRaces = explorerContext.AlienRaces;
             Empires = explorerContext.Empires;
-            EmpireContacts = explorerContext.EmpireContacts;
             CurrentSector = explorerContext.CurrentSector;
             CivilizationSettings = BuildCivilizationSettings(CurrentSector);
             ArmySettings = new ArmyGeneratorSettings();

--- a/StarWin.Infrastructure/Services/StarWinExplorerContextLoader.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerContextLoader.cs
@@ -50,14 +50,12 @@ internal static class StarWinExplorerContextLoader
             sectors,
             sectors.FirstOrDefault() ?? StarWinExplorerContext.Empty.CurrentSector,
             alienRaces,
-            empires,
-            empires.SelectMany(empire => empire.Contacts).ToList());
+            empires);
     }
 
     public static async Task<StarWinExplorerContext> LoadShellAsync(
         StarWinDbContext dbContext,
         int? preferredSectorId = null,
-        bool includeSavedRoutes = false,
         bool includeReferenceData = false,
         CancellationToken cancellationToken = default)
     {
@@ -107,38 +105,6 @@ internal static class StarWinExplorerContextLoader
             });
         }
 
-        if (includeSavedRoutes && preferredSectorId is int selectedSectorId && sectorsById.TryGetValue(selectedSectorId, out var preferredSector))
-        {
-            var savedRoutes = await dbContext.SectorSavedRoutes
-                .AsNoTracking()
-                .Where(route => route.SectorId == selectedSectorId)
-                .OrderBy(route => route.SourceSystemId)
-                .ThenBy(route => route.TargetSystemId)
-                .Select(route => new SectorSavedRoute
-                {
-                    Id = route.Id,
-                    SectorId = route.SectorId,
-                    SourceSystemId = route.SourceSystemId,
-                    TargetSystemId = route.TargetSystemId,
-                    DistanceParsecs = route.DistanceParsecs,
-                    TravelTimeYears = route.TravelTimeYears,
-                    TechnologyLevel = route.TechnologyLevel,
-                    TierName = route.TierName,
-                    PrimaryOwnerEmpireId = route.PrimaryOwnerEmpireId,
-                    PrimaryOwnerEmpireName = route.PrimaryOwnerEmpireName,
-                    SecondaryOwnerEmpireId = route.SecondaryOwnerEmpireId,
-                    SecondaryOwnerEmpireName = route.SecondaryOwnerEmpireName,
-                    IsUserPersisted = route.IsUserPersisted,
-                    GeneratedAtUtc = route.GeneratedAtUtc
-                })
-                .ToListAsync(cancellationToken);
-
-            foreach (var savedRoute in savedRoutes)
-            {
-                preferredSector.SavedRoutes.Add(savedRoute);
-            }
-        }
-
         var alienRaces = includeReferenceData
             ? await dbContext.AlienRaces
                 .AsNoTracking()
@@ -171,7 +137,6 @@ internal static class StarWinExplorerContextLoader
             sectors,
             currentSector ?? sectors.FirstOrDefault() ?? StarWinExplorerContext.Empty.CurrentSector,
             alienRaces,
-            empires,
-            []);
+            empires);
     }
 }

--- a/StarWin.Infrastructure/Services/StarWinExplorerContextLoader.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerContextLoader.cs
@@ -57,6 +57,8 @@ internal static class StarWinExplorerContextLoader
         StarWinDbContext dbContext,
         bool includeSavedRoutes = true,
         bool includeReferenceData = true,
+        int? detailedSectorId = null,
+        ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
         CancellationToken cancellationToken = default)
     {
         IQueryable<StarWinSector> sectorsQuery = dbContext.Sectors
@@ -91,15 +93,31 @@ internal static class StarWinExplorerContextLoader
                 .ToListAsync(cancellationToken)
             : [];
 
+        if (detailedSectorId is int selectedSectorId
+            && selectedSectorId > 0
+            && detailedSectorSections != ExplorerSectorLoadSections.None
+            && await LoadSectorDetailAsync(dbContext, selectedSectorId, detailedSectorSections, cancellationToken) is { } detailedSector)
+        {
+            var sectorIndex = sectors.FindIndex(sector => sector.Id == detailedSector.Id);
+            if (sectorIndex >= 0)
+            {
+                sectors[sectorIndex] = detailedSector;
+            }
+        }
+
+        var currentSector = detailedSectorId is int preferredSectorId && preferredSectorId > 0
+            ? sectors.FirstOrDefault(sector => sector.Id == preferredSectorId)
+            : null;
+
         return new StarWinExplorerContext(
             sectors,
-            sectors.FirstOrDefault() ?? StarWinExplorerContext.Empty.CurrentSector,
+            currentSector ?? sectors.FirstOrDefault() ?? StarWinExplorerContext.Empty.CurrentSector,
             alienRaces,
             empires,
             includeReferenceData ? empires.SelectMany(empire => empire.Contacts).ToList() : []);
     }
 
-    public static async Task<StarWinSector?> LoadSectorAsync(
+    private static async Task<StarWinSector?> LoadSectorDetailAsync(
         StarWinDbContext dbContext,
         int sectorId,
         ExplorerSectorLoadSections loadSections,

--- a/StarWin.Infrastructure/Services/StarWinExplorerContextLoader.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerContextLoader.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using StarWin.Application.Services;
+using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.StarMap;
 using StarWin.Infrastructure.Data;
 
@@ -55,58 +56,115 @@ internal static class StarWinExplorerContextLoader
 
     public static async Task<StarWinExplorerContext> LoadShellAsync(
         StarWinDbContext dbContext,
-        bool includeSavedRoutes = true,
-        bool includeReferenceData = true,
-        int? detailedSectorId = null,
-        ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
+        int? preferredSectorId = null,
+        bool includeSavedRoutes = false,
+        bool includeReferenceData = false,
         CancellationToken cancellationToken = default)
     {
-        IQueryable<StarWinSector> sectorsQuery = dbContext.Sectors
+        var sectorRows = await dbContext.Sectors
             .AsNoTracking()
-            .AsSplitQuery()
-            .Include(sector => sector.Configuration)
-            .Include(sector => sector.Systems)
-            .OrderBy(sector => sector.Name);
+            .OrderBy(sector => sector.Name)
+            .Select(sector => new
+            {
+                sector.Id,
+                sector.Name
+            })
+            .ToListAsync(cancellationToken);
 
-        if (includeSavedRoutes)
+        var systemRows = await dbContext.StarSystems
+            .AsNoTracking()
+            .OrderBy(system => system.Name)
+            .ThenBy(system => system.Id)
+            .Select(system => new
+            {
+                system.Id,
+                system.SectorId,
+                system.Name
+            })
+            .ToListAsync(cancellationToken);
+
+        var sectors = sectorRows
+            .Select(row => new StarWinSector
+            {
+                Id = row.Id,
+                Name = row.Name
+            })
+            .ToList();
+
+        var sectorsById = sectors.ToDictionary(sector => sector.Id);
+        foreach (var systemRow in systemRows)
         {
-            sectorsQuery = sectorsQuery.Include(sector => sector.SavedRoutes);
+            if (!sectorsById.TryGetValue(systemRow.SectorId, out var sector))
+            {
+                continue;
+            }
+
+            sector.Systems.Add(new StarSystem
+            {
+                Id = systemRow.Id,
+                SectorId = systemRow.SectorId,
+                Name = systemRow.Name
+            });
         }
 
-        var sectors = await sectorsQuery.ToListAsync(cancellationToken);
+        if (includeSavedRoutes && preferredSectorId is int selectedSectorId && sectorsById.TryGetValue(selectedSectorId, out var preferredSector))
+        {
+            var savedRoutes = await dbContext.SectorSavedRoutes
+                .AsNoTracking()
+                .Where(route => route.SectorId == selectedSectorId)
+                .OrderBy(route => route.SourceSystemId)
+                .ThenBy(route => route.TargetSystemId)
+                .Select(route => new SectorSavedRoute
+                {
+                    Id = route.Id,
+                    SectorId = route.SectorId,
+                    SourceSystemId = route.SourceSystemId,
+                    TargetSystemId = route.TargetSystemId,
+                    DistanceParsecs = route.DistanceParsecs,
+                    TravelTimeYears = route.TravelTimeYears,
+                    TechnologyLevel = route.TechnologyLevel,
+                    TierName = route.TierName,
+                    PrimaryOwnerEmpireId = route.PrimaryOwnerEmpireId,
+                    PrimaryOwnerEmpireName = route.PrimaryOwnerEmpireName,
+                    SecondaryOwnerEmpireId = route.SecondaryOwnerEmpireId,
+                    SecondaryOwnerEmpireName = route.SecondaryOwnerEmpireName,
+                    IsUserPersisted = route.IsUserPersisted,
+                    GeneratedAtUtc = route.GeneratedAtUtc
+                })
+                .ToListAsync(cancellationToken);
+
+            foreach (var savedRoute in savedRoutes)
+            {
+                preferredSector.SavedRoutes.Add(savedRoute);
+            }
+        }
 
         var alienRaces = includeReferenceData
             ? await dbContext.AlienRaces
                 .AsNoTracking()
                 .OrderBy(race => race.Name)
+                .Select(race => new AlienRace
+                {
+                    Id = race.Id,
+                    Name = race.Name
+                })
                 .ToListAsync(cancellationToken)
             : [];
 
         var empires = includeReferenceData
             ? await dbContext.Empires
                 .AsNoTracking()
-                .AsSplitQuery()
-                .Include(empire => empire.RaceMemberships)
-                .Include(empire => empire.Contacts)
-                .Include(empire => empire.Religions)
                 .OrderBy(empire => empire.Name)
+                .Select(empire => new Empire
+                {
+                    Id = empire.Id,
+                    Name = empire.Name
+                })
                 .ToListAsync(cancellationToken)
             : [];
 
-        if (detailedSectorId is int selectedSectorId
-            && selectedSectorId > 0
-            && detailedSectorSections != ExplorerSectorLoadSections.None
-            && await LoadSectorDetailAsync(dbContext, selectedSectorId, detailedSectorSections, cancellationToken) is { } detailedSector)
-        {
-            var sectorIndex = sectors.FindIndex(sector => sector.Id == detailedSector.Id);
-            if (sectorIndex >= 0)
-            {
-                sectors[sectorIndex] = detailedSector;
-            }
-        }
-
-        var currentSector = detailedSectorId is int preferredSectorId && preferredSectorId > 0
-            ? sectors.FirstOrDefault(sector => sector.Id == preferredSectorId)
+        var currentSector = preferredSectorId is int requestedSectorId && requestedSectorId > 0
+            ? sectors.FirstOrDefault(sector => sector.Id == requestedSectorId)
             : null;
 
         return new StarWinExplorerContext(
@@ -114,77 +172,6 @@ internal static class StarWinExplorerContextLoader
             currentSector ?? sectors.FirstOrDefault() ?? StarWinExplorerContext.Empty.CurrentSector,
             alienRaces,
             empires,
-            includeReferenceData ? empires.SelectMany(empire => empire.Contacts).ToList() : []);
-    }
-
-    private static async Task<StarWinSector?> LoadSectorDetailAsync(
-        StarWinDbContext dbContext,
-        int sectorId,
-        ExplorerSectorLoadSections loadSections,
-        CancellationToken cancellationToken = default)
-    {
-        IQueryable<StarWinSector> sectorQuery = dbContext.Sectors
-            .AsNoTracking()
-            .AsSplitQuery()
-            .Include(sector => sector.Configuration)
-            .Include(sector => sector.Systems);
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.AstralBodies))
-        {
-            sectorQuery = sectorQuery
-                .Include(sector => sector.Systems)
-                    .ThenInclude(system => system.AstralBodies);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.Worlds))
-        {
-            sectorQuery = sectorQuery
-                .Include(sector => sector.Systems)
-                    .ThenInclude(system => system.Worlds);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.WorldCharacteristics))
-        {
-            sectorQuery = sectorQuery
-                .Include(sector => sector.Systems)
-                    .ThenInclude(system => system.Worlds)
-                        .ThenInclude(world => world.UnusualCharacteristics);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.Colonies))
-        {
-            sectorQuery = sectorQuery
-                .Include(sector => sector.Systems)
-                    .ThenInclude(system => system.Worlds)
-                        .ThenInclude(world => world.Colony);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.ColonyDemographics))
-        {
-            sectorQuery = sectorQuery
-                .Include(sector => sector.Systems)
-                    .ThenInclude(system => system.Worlds)
-                        .ThenInclude(world => world.Colony)
-                            .ThenInclude(colony => colony!.Demographics);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.SpaceHabitats))
-        {
-            sectorQuery = sectorQuery
-                .Include(sector => sector.Systems)
-                    .ThenInclude(system => system.SpaceHabitats);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.SavedRoutes))
-        {
-            sectorQuery = sectorQuery.Include(sector => sector.SavedRoutes);
-        }
-
-        if (loadSections.HasFlag(ExplorerSectorLoadSections.History))
-        {
-            sectorQuery = sectorQuery.Include(sector => sector.History);
-        }
-
-        return await sectorQuery.FirstOrDefaultAsync(sector => sector.Id == sectorId, cancellationToken);
+            []);
     }
 }

--- a/StarWin.Infrastructure/Services/StarWinExplorerContextService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerContextService.cs
@@ -10,6 +10,8 @@ public sealed class StarWinExplorerContextService(IDbContextFactory<StarWinDbCon
     public async Task<StarWinExplorerContext> LoadShellAsync(
         bool includeSavedRoutes = true,
         bool includeReferenceData = true,
+        int? detailedSectorId = null,
+        ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
         CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -17,19 +19,8 @@ public sealed class StarWinExplorerContextService(IDbContextFactory<StarWinDbCon
             dbContext,
             includeSavedRoutes,
             includeReferenceData,
-            cancellationToken);
-    }
-
-    public async Task<StarWinSector?> LoadSectorAsync(
-        int sectorId,
-        ExplorerSectorLoadSections loadSections,
-        CancellationToken cancellationToken = default)
-    {
-        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-        return await StarWinExplorerContextLoader.LoadSectorAsync(
-            dbContext,
-            sectorId,
-            loadSections,
+            detailedSectorId,
+            detailedSectorSections,
             cancellationToken);
     }
 }

--- a/StarWin.Infrastructure/Services/StarWinExplorerContextService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerContextService.cs
@@ -7,23 +7,8 @@ namespace StarWin.Infrastructure.Services;
 
 public sealed class StarWinExplorerContextService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinExplorerContextService
 {
-    public Task<StarWinExplorerContext> LoadShellAsync(
-        bool includeSavedRoutes = true,
-        bool includeReferenceData = true,
-        int? detailedSectorId = null,
-        ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
-        CancellationToken cancellationToken = default)
-    {
-        return LoadShellAsync(
-            preferredSectorId: detailedSectorId,
-            includeSavedRoutes: includeSavedRoutes,
-            includeReferenceData: includeReferenceData,
-            cancellationToken: cancellationToken);
-    }
-
     public async Task<StarWinExplorerContext> LoadShellAsync(
         int? preferredSectorId = null,
-        bool includeSavedRoutes = false,
         bool includeReferenceData = false,
         CancellationToken cancellationToken = default)
     {
@@ -31,7 +16,6 @@ public sealed class StarWinExplorerContextService(IDbContextFactory<StarWinDbCon
         return await StarWinExplorerContextLoader.LoadShellAsync(
             dbContext,
             preferredSectorId,
-            includeSavedRoutes,
             includeReferenceData,
             cancellationToken);
     }

--- a/StarWin.Infrastructure/Services/StarWinExplorerContextService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerContextService.cs
@@ -7,20 +7,32 @@ namespace StarWin.Infrastructure.Services;
 
 public sealed class StarWinExplorerContextService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinExplorerContextService
 {
-    public async Task<StarWinExplorerContext> LoadShellAsync(
+    public Task<StarWinExplorerContext> LoadShellAsync(
         bool includeSavedRoutes = true,
         bool includeReferenceData = true,
         int? detailedSectorId = null,
         ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None,
         CancellationToken cancellationToken = default)
     {
+        return LoadShellAsync(
+            preferredSectorId: detailedSectorId,
+            includeSavedRoutes: includeSavedRoutes,
+            includeReferenceData: includeReferenceData,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<StarWinExplorerContext> LoadShellAsync(
+        int? preferredSectorId = null,
+        bool includeSavedRoutes = false,
+        bool includeReferenceData = false,
+        CancellationToken cancellationToken = default)
+    {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         return await StarWinExplorerContextLoader.LoadShellAsync(
             dbContext,
+            preferredSectorId,
             includeSavedRoutes,
             includeReferenceData,
-            detailedSectorId,
-            detailedSectorSections,
             cancellationToken);
     }
 }

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -983,18 +983,86 @@ public sealed class StarWinExplorerQueryService(
                 .FirstOrDefaultAsync(cancellationToken)
             : null;
 
-        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
-        var empires = sectorEmpireIds.Count == 0
+        var sectorEmpireIdSet = sectorEntityUsage.EmpireIds.ToHashSet();
+        var matchingMemberships = sectorEmpireIdSet.Count == 0
+            ? []
+            : (await dbContext.Set<EmpireRaceMembership>()
+                .AsNoTracking()
+                .Where(membership => membership.RaceId == raceId)
+                .Select(membership => new EmpireRaceMembership
+                {
+                    EmpireId = membership.EmpireId,
+                    RaceId = membership.RaceId,
+                    Role = membership.Role,
+                    PopulationMillions = membership.PopulationMillions,
+                    IsPrimary = membership.IsPrimary
+                })
+                .ToListAsync(cancellationToken))
+                .Where(membership => sectorEmpireIdSet.Contains(membership.EmpireId))
+                .OrderByDescending(membership => membership.IsPrimary)
+                .ThenBy(membership => membership.EmpireId)
+                .ToList();
+
+        var matchingEmpireIds = matchingMemberships
+            .Select(membership => membership.EmpireId)
+            .Distinct()
+            .ToList();
+        var empireRows = matchingEmpireIds.Count == 0
             ? []
             : await dbContext.Empires
                 .AsNoTracking()
-                .AsSplitQuery()
-                .Where(empire => sectorEmpireIds.Contains(empire.Id) && empire.RaceMemberships.Any(membership => membership.RaceId == raceId))
-                .Include(empire => empire.RaceMemberships)
-                .Include(empire => empire.Religions)
+                .Where(empire => matchingEmpireIds.Contains(empire.Id))
                 .OrderBy(empire => empire.Name)
                 .ThenBy(empire => empire.Id)
+                .Select(empire => new AlienRaceEmpireDetailProjection(
+                    empire.Id,
+                    empire.Name,
+                    empire.GovernmentType,
+                    empire.CivilizationProfile.Militancy,
+                    empire.CivilizationProfile.Determination,
+                    empire.CivilizationProfile.RacialTolerance,
+                    empire.CivilizationProfile.Progressiveness,
+                    empire.CivilizationProfile.Loyalty,
+                    empire.CivilizationProfile.SocialCohesion,
+                    empire.CivilizationProfile.TechLevel,
+                    empire.CivilizationProfile.Art,
+                    empire.CivilizationProfile.Individualism,
+                    empire.CivilizationProfile.SpatialAge,
+                    empire.CivilizationModifiers.Militancy,
+                    empire.CivilizationModifiers.Determination,
+                    empire.CivilizationModifiers.RacialTolerance,
+                    empire.CivilizationModifiers.Progressiveness,
+                    empire.CivilizationModifiers.Loyalty,
+                    empire.CivilizationModifiers.SocialCohesion,
+                    empire.CivilizationModifiers.Art,
+                    empire.CivilizationModifiers.Individualism))
                 .ToListAsync(cancellationToken);
+        var religionRows = matchingEmpireIds.Count == 0
+            ? []
+            : await dbContext.Set<EmpireReligion>()
+                .AsNoTracking()
+                .Where(religion => matchingEmpireIds.Contains(religion.EmpireId))
+                .OrderBy(religion => religion.EmpireId)
+                .ThenByDescending(religion => religion.PopulationPercent)
+                .ThenBy(religion => religion.ReligionName)
+                .Select(religion => new EmpireReligion
+                {
+                    EmpireId = religion.EmpireId,
+                    ReligionId = religion.ReligionId,
+                    ReligionName = religion.ReligionName,
+                    PopulationPercent = religion.PopulationPercent
+                })
+                .ToListAsync(cancellationToken);
+
+        var membershipsByEmpireId = matchingMemberships
+            .GroupBy(membership => membership.EmpireId)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<EmpireRaceMembership>)group.ToList());
+        var religionsByEmpireId = religionRows
+            .GroupBy(religion => religion.EmpireId)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<EmpireReligion>)group.ToList());
+        var empires = empireRows
+            .Select(row => BuildAlienRaceDetailEmpire(row, membershipsByEmpireId, religionsByEmpireId))
+            .ToList();
 
         var detail = new ExplorerAlienRaceDetail(sectorId, race, homeWorld, empires);
         logger.LogInformation(
@@ -1007,6 +1075,61 @@ public sealed class StarWinExplorerQueryService(
             homeWorld?.Id ?? 0);
 
         return detail;
+    }
+
+    private static Empire BuildAlienRaceDetailEmpire(
+        AlienRaceEmpireDetailProjection projection,
+        IReadOnlyDictionary<int, IReadOnlyList<EmpireRaceMembership>> membershipsByEmpireId,
+        IReadOnlyDictionary<int, IReadOnlyList<EmpireReligion>> religionsByEmpireId)
+    {
+        var empire = new Empire
+        {
+            Id = projection.EmpireId,
+            Name = projection.Name,
+            GovernmentType = projection.GovernmentType,
+            CivilizationProfile = new CivilizationProfile
+            {
+                Militancy = projection.Militancy,
+                Determination = projection.Determination,
+                RacialTolerance = projection.RacialTolerance,
+                Progressiveness = projection.Progressiveness,
+                Loyalty = projection.Loyalty,
+                SocialCohesion = projection.SocialCohesion,
+                TechLevel = projection.TechLevel,
+                Art = projection.Art,
+                Individualism = projection.Individualism,
+                SpatialAge = projection.SpatialAge
+            },
+            CivilizationModifiers = new CivilizationModifierProfile
+            {
+                Militancy = projection.MilitancyModifier,
+                Determination = projection.DeterminationModifier,
+                RacialTolerance = projection.RacialToleranceModifier,
+                Progressiveness = projection.ProgressivenessModifier,
+                Loyalty = projection.LoyaltyModifier,
+                SocialCohesion = projection.SocialCohesionModifier,
+                Art = projection.ArtModifier,
+                Individualism = projection.IndividualismModifier
+            }
+        };
+
+        if (membershipsByEmpireId.TryGetValue(projection.EmpireId, out var memberships))
+        {
+            foreach (var membership in memberships)
+            {
+                empire.RaceMemberships.Add(membership);
+            }
+        }
+
+        if (religionsByEmpireId.TryGetValue(projection.EmpireId, out var religions))
+        {
+            foreach (var religion in religions)
+            {
+                empire.Religions.Add(religion);
+            }
+        }
+
+        return empire;
     }
 
     public async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -2770,4 +2893,27 @@ public sealed class StarWinExplorerQueryService(
         long Population,
         bool FoundedByEmpire,
         bool ForeignFounded);
+
+    private sealed record AlienRaceEmpireDetailProjection(
+        int EmpireId,
+        string Name,
+        string GovernmentType,
+        byte Militancy,
+        byte Determination,
+        byte RacialTolerance,
+        byte Progressiveness,
+        byte Loyalty,
+        byte SocialCohesion,
+        byte TechLevel,
+        byte Art,
+        byte Individualism,
+        byte SpatialAge,
+        int MilitancyModifier,
+        int DeterminationModifier,
+        int RacialToleranceModifier,
+        int ProgressivenessModifier,
+        int LoyaltyModifier,
+        int SocialCohesionModifier,
+        int ArtModifier,
+        int IndividualismModifier);
 }

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -16,114 +16,83 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
 
     public async Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
     {
+        if (sectorId <= 0)
+        {
+            return new ExplorerSectorOverviewData(0, 0, 0, 0, 0, 0);
+        }
+
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var systems = await dbContext.StarSystems
-            .AsNoTracking()
-            .Where(system => system.SectorId == sectorId)
-            .OrderBy(system => system.Name)
-            .ThenBy(system => system.Id)
-            .Select(system => new ExplorerLookupOption(system.Id, system.Name))
-            .ToListAsync(cancellationToken);
-
-        var systemCount = systems.Count;
-
-        var worldCount = await (
-            from world in dbContext.Worlds.AsNoTracking()
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId
-            select world.Id)
-            .CountAsync(cancellationToken);
-
-        var colonyCount = await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId
-            select colony.Id)
-            .CountAsync(cancellationToken);
-
-        var empireIds = new HashSet<int>();
-        empireIds.UnionWith(await dbContext.StarSystems
-            .AsNoTracking()
-            .Where(system => system.SectorId == sectorId && system.AllegianceId != ushort.MaxValue)
-            .Select(system => (int)system.AllegianceId)
-            .ToListAsync(cancellationToken));
-        empireIds.UnionWith(await (
-            from world in dbContext.Worlds.AsNoTracking()
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && world.ControlledByEmpireId.HasValue
-            select world.ControlledByEmpireId!.Value)
-            .ToListAsync(cancellationToken));
-        empireIds.UnionWith(await (
-            from world in dbContext.Worlds.AsNoTracking()
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && world.AllegianceId != ushort.MaxValue
-            select (int)world.AllegianceId)
-            .ToListAsync(cancellationToken));
-        empireIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && colony.ControllingEmpireId.HasValue
-            select colony.ControllingEmpireId!.Value)
-            .ToListAsync(cancellationToken));
-        empireIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && colony.FoundingEmpireId.HasValue
-            select colony.FoundingEmpireId!.Value)
-            .ToListAsync(cancellationToken));
-        empireIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && colony.ParentEmpireId.HasValue
-            select colony.ParentEmpireId!.Value)
-            .ToListAsync(cancellationToken));
-        empireIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && colony.AllegianceId != ushort.MaxValue
-            select (int)colony.AllegianceId)
-            .ToListAsync(cancellationToken));
-
-        var raceIds = new HashSet<int>();
-        raceIds.UnionWith(await (
-            from world in dbContext.Worlds.AsNoTracking()
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId && world.AlienRaceId.HasValue
-            select (int)world.AlienRaceId!.Value)
-            .ToListAsync(cancellationToken));
-        raceIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId
-            select (int)colony.RaceId)
-            .ToListAsync(cancellationToken));
-
-        var empires = empireIds.Count == 0
-            ? []
-            : await dbContext.Empires
-                .AsNoTracking()
-                .Where(empire => empireIds.Contains(empire.Id))
-                .OrderBy(empire => empire.Name)
-                .ThenBy(empire => empire.Id)
-                .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
-                .ToListAsync(cancellationToken);
+        var overviewRow = await dbContext.Database
+            .SqlQuery<ExplorerSectorOverviewRow>($"""
+                WITH SectorSystems AS (
+                    SELECT Id, AllegianceId
+                    FROM StarSystems
+                    WHERE SectorId = {sectorId}
+                ),
+                SectorWorlds AS (
+                    SELECT Worlds.Id, Worlds.AlienRaceId, Worlds.ControlledByEmpireId, Worlds.AllegianceId
+                    FROM Worlds
+                    INNER JOIN SectorSystems ON Worlds.StarSystemId = SectorSystems.Id
+                ),
+                SectorColonies AS (
+                    SELECT Colonies.Id, Colonies.RaceId, Colonies.ControllingEmpireId, Colonies.FoundingEmpireId, Colonies.ParentEmpireId, Colonies.AllegianceId
+                    FROM Colonies
+                    INNER JOIN SectorWorlds ON Colonies.WorldId = SectorWorlds.Id
+                ),
+                SectorEmpireIds AS (
+                    SELECT CAST(AllegianceId AS INTEGER) AS EmpireId
+                    FROM SectorSystems
+                    WHERE AllegianceId <> {ushort.MaxValue}
+                    UNION
+                    SELECT CAST(ControlledByEmpireId AS INTEGER) AS EmpireId
+                    FROM SectorWorlds
+                    WHERE ControlledByEmpireId IS NOT NULL
+                    UNION
+                    SELECT CAST(AllegianceId AS INTEGER) AS EmpireId
+                    FROM SectorWorlds
+                    WHERE AllegianceId <> {ushort.MaxValue}
+                    UNION
+                    SELECT CAST(ControllingEmpireId AS INTEGER) AS EmpireId
+                    FROM SectorColonies
+                    WHERE ControllingEmpireId IS NOT NULL
+                    UNION
+                    SELECT CAST(FoundingEmpireId AS INTEGER) AS EmpireId
+                    FROM SectorColonies
+                    WHERE FoundingEmpireId IS NOT NULL
+                    UNION
+                    SELECT CAST(ParentEmpireId AS INTEGER) AS EmpireId
+                    FROM SectorColonies
+                    WHERE ParentEmpireId IS NOT NULL
+                    UNION
+                    SELECT CAST(AllegianceId AS INTEGER) AS EmpireId
+                    FROM SectorColonies
+                    WHERE AllegianceId <> {ushort.MaxValue}
+                ),
+                SectorRaceIds AS (
+                    SELECT CAST(AlienRaceId AS INTEGER) AS RaceId
+                    FROM SectorWorlds
+                    WHERE AlienRaceId IS NOT NULL
+                    UNION
+                    SELECT CAST(RaceId AS INTEGER) AS RaceId
+                    FROM SectorColonies
+                )
+                SELECT
+                    {sectorId} AS SectorId,
+                    (SELECT COUNT(*) FROM SectorSystems) AS SystemCount,
+                    (SELECT COUNT(*) FROM SectorWorlds) AS WorldCount,
+                    (SELECT COUNT(*) FROM SectorColonies) AS ColonyCount,
+                    (SELECT COUNT(*) FROM SectorEmpireIds) AS EmpireCount,
+                    (SELECT COUNT(*) FROM SectorRaceIds) AS RaceCount
+                """)
+            .SingleAsync(cancellationToken);
 
         return new ExplorerSectorOverviewData(
-            sectorId,
-            systemCount,
-            worldCount,
-            colonyCount,
-            empires.Count,
-            raceIds.Count,
-            systems,
-            empires);
+            overviewRow.SectorId,
+            overviewRow.SystemCount,
+            overviewRow.WorldCount,
+            overviewRow.ColonyCount,
+            overviewRow.EmpireCount,
+            overviewRow.RaceCount);
     }
 
     public async Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -2580,6 +2549,21 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         }
 
         return Math.Round((decimal)population * 100m / totalPopulation, 1, MidpointRounding.AwayFromZero);
+    }
+
+    private sealed class ExplorerSectorOverviewRow
+    {
+        public int SectorId { get; set; }
+
+        public int SystemCount { get; set; }
+
+        public int WorldCount { get; set; }
+
+        public int ColonyCount { get; set; }
+
+        public int EmpireCount { get; set; }
+
+        public int RaceCount { get; set; }
     }
 
     private sealed record RaceDisplayProjection(int RaceId, string RaceName, string? HomeWorldName);

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using StarWin.Application.Services;
 using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.Notes;
@@ -9,10 +12,13 @@ using StarWin.Infrastructure.Data;
 
 namespace StarWin.Infrastructure.Services;
 
-public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinExplorerQueryService
+public sealed class StarWinExplorerQueryService(
+    IDbContextFactory<StarWinDbContext> dbContextFactory,
+    ILogger<StarWinExplorerQueryService>? logger = null) : IStarWinExplorerQueryService
 {
     private static readonly TimeSpan SectorEntityUsageCacheDuration = TimeSpan.FromSeconds(20);
     private readonly Dictionary<int, CachedSectorEntityUsage> sectorEntityUsageCache = [];
+    private readonly ILogger<StarWinExplorerQueryService> logger = logger ?? NullLogger<StarWinExplorerQueryService>.Instance;
 
     public async Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
     {
@@ -761,11 +767,19 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
 
     public async Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
+        var stopwatch = Stopwatch.StartNew();
+        logger.LogInformation("Explorer query start {Operation}. sectorId={SectorId}", nameof(LoadAlienRaceFilterOptionsAsync), sectorId);
+
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
         var raceIds = sectorEntityUsage.RaceIds;
         if (raceIds.Count == 0)
         {
+            logger.LogInformation(
+                "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceCount=0",
+                nameof(LoadAlienRaceFilterOptionsAsync),
+                stopwatch.ElapsedMilliseconds,
+                sectorId);
             return new ExplorerAlienRaceFilterOptions([], [], [], []);
         }
 
@@ -811,7 +825,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
                 .Distinct()
                 .ToListAsync(cancellationToken);
 
-        return new ExplorerAlienRaceFilterOptions(
+        var options = new ExplorerAlienRaceFilterOptions(
             environmentTypes,
             appearanceTypes,
             starWinTechLevels,
@@ -820,15 +834,48 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(value => value, StringComparer.Ordinal)
                 .ToList());
+
+        logger.LogInformation(
+            "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceCount={RaceCount} empireCount={EmpireCount} environmentCount={EnvironmentCount} appearanceCount={AppearanceCount} starWinTechLevelCount={StarWinTechLevelCount} gurpsTechLevelCount={GurpsTechLevelCount}",
+            nameof(LoadAlienRaceFilterOptionsAsync),
+            stopwatch.ElapsedMilliseconds,
+            sectorId,
+            raceIds.Count,
+            sectorEmpireIds.Count,
+            options.EnvironmentTypes.Count,
+            options.AppearanceTypes.Count,
+            options.StarWinTechLevels.Count,
+            options.GurpsTechLevels.Count);
+
+        return options;
     }
 
     public async Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default)
     {
+        var stopwatch = Stopwatch.StartNew();
+        logger.LogInformation(
+            "Explorer query start {Operation}. sectorId={SectorId} offset={Offset} limit={Limit} query={Query} environment={EnvironmentType} appearance={AppearanceType} starWinTechLevel={StarWinTechLevel} gurpsTechLevel={GurpsTechLevel} requireSuperscience={RequireSuperscience}",
+            nameof(LoadAlienRaceListPageAsync),
+            request.SectorId,
+            request.Offset,
+            request.Limit,
+            request.Query,
+            request.EnvironmentType,
+            request.AppearanceType,
+            request.StarWinTechLevel,
+            request.GurpsTechLevel,
+            request.RequireSuperscience);
+
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, request.SectorId, cancellationToken);
         var raceIds = sectorEntityUsage.RaceIds;
         if (raceIds.Count == 0)
         {
+            logger.LogInformation(
+                "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceCount=0",
+                nameof(LoadAlienRaceListPageAsync),
+                stopwatch.ElapsedMilliseconds,
+                request.SectorId);
             return new ExplorerAlienRaceListPage([], false);
         }
 
@@ -852,7 +899,17 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             .ToListAsync(cancellationToken);
 
         var hasMore = races.Count > request.Limit;
-        return new ExplorerAlienRaceListPage(races.Take(request.Limit).ToList(), hasMore);
+        var page = new ExplorerAlienRaceListPage(races.Take(request.Limit).ToList(), hasMore);
+        logger.LogInformation(
+            "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceCount={RaceCount} returnedCount={ReturnedCount} hasMore={HasMore}",
+            nameof(LoadAlienRaceListPageAsync),
+            stopwatch.ElapsedMilliseconds,
+            request.SectorId,
+            raceIds.Count,
+            page.Items.Count,
+            page.HasMore);
+
+        return page;
     }
 
     public async Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
@@ -877,11 +934,24 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
 
     public async Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
     {
+        var stopwatch = Stopwatch.StartNew();
+        logger.LogInformation(
+            "Explorer query start {Operation}. sectorId={SectorId} raceId={RaceId}",
+            nameof(LoadAlienRaceDetailAsync),
+            sectorId,
+            raceId);
+
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
         var raceIds = sectorEntityUsage.RaceIds;
         if (!raceIds.Contains(raceId))
         {
+            logger.LogInformation(
+                "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceId={RaceId} foundInSector=false",
+                nameof(LoadAlienRaceDetailAsync),
+                stopwatch.ElapsedMilliseconds,
+                sectorId,
+                raceId);
             return null;
         }
 
@@ -890,6 +960,12 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             .FirstOrDefaultAsync(item => item.Id == raceId, cancellationToken);
         if (race is null)
         {
+            logger.LogInformation(
+                "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceId={RaceId} raceMissing=true",
+                nameof(LoadAlienRaceDetailAsync),
+                stopwatch.ElapsedMilliseconds,
+                sectorId,
+                raceId);
             return null;
         }
 
@@ -920,7 +996,17 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
                 .ThenBy(empire => empire.Id)
                 .ToListAsync(cancellationToken);
 
-        return new ExplorerAlienRaceDetail(sectorId, race, homeWorld, empires);
+        var detail = new ExplorerAlienRaceDetail(sectorId, race, homeWorld, empires);
+        logger.LogInformation(
+            "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceId={RaceId} empireCount={EmpireCount} homeWorldId={HomeWorldId}",
+            nameof(LoadAlienRaceDetailAsync),
+            stopwatch.ElapsedMilliseconds,
+            sectorId,
+            raceId,
+            empires.Count,
+            homeWorld?.Id ?? 0);
+
+        return detail;
     }
 
     public async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -2016,8 +2102,10 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         return racesQuery;
     }
 
-    private static async Task<HashSet<int>> LoadSectorRaceIdsAsync(StarWinDbContext dbContext, int sectorId, CancellationToken cancellationToken)
+    private async Task<HashSet<int>> LoadSectorRaceIdsAsync(StarWinDbContext dbContext, int sectorId, CancellationToken cancellationToken)
     {
+        var stopwatch = Stopwatch.StartNew();
+        logger.LogInformation("Explorer query start {Operation}. sectorId={SectorId}", nameof(LoadSectorRaceIdsAsync), sectorId);
         var raceIds = new HashSet<int>();
 
         raceIds.UnionWith(await (
@@ -2055,6 +2143,13 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             .Where(history => history.SectorId == sectorId && history.OtherRaceId.HasValue)
             .Select(history => history.OtherRaceId!.Value)
             .ToListAsync(cancellationToken));
+
+        logger.LogInformation(
+            "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceCount={RaceCount}",
+            nameof(LoadSectorRaceIdsAsync),
+            stopwatch.ElapsedMilliseconds,
+            sectorId,
+            raceIds.Count);
 
         return raceIds;
     }
@@ -2097,8 +2192,10 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         return religionIds.ToHashSet();
     }
 
-    private static async Task<HashSet<int>> LoadSectorEmpireIdsAsync(StarWinDbContext dbContext, int sectorId, CancellationToken cancellationToken)
+    private async Task<HashSet<int>> LoadSectorEmpireIdsAsync(StarWinDbContext dbContext, int sectorId, CancellationToken cancellationToken)
     {
+        var stopwatch = Stopwatch.StartNew();
+        logger.LogInformation("Explorer query start {Operation}. sectorId={SectorId}", nameof(LoadSectorEmpireIdsAsync), sectorId);
         var empireIds = new HashSet<int>();
 
         empireIds.UnionWith(await dbContext.StarSystems
@@ -2175,6 +2272,13 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             .Select(history => history.EmpireId!.Value)
             .ToListAsync(cancellationToken));
 
+        logger.LogInformation(
+            "Explorer query complete {Operation} in {ElapsedMs}ms. sectorId={SectorId} empireCount={EmpireCount}",
+            nameof(LoadSectorEmpireIdsAsync),
+            stopwatch.ElapsedMilliseconds,
+            sectorId,
+            empireIds.Count);
+
         return empireIds;
     }
 
@@ -2191,9 +2295,17 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         if (sectorEntityUsageCache.TryGetValue(sectorId, out var cachedUsage)
             && cachedUsage.ExpiresAtUtc > DateTime.UtcNow)
         {
+            logger.LogInformation(
+                "Explorer query cache hit {Operation}. sectorId={SectorId} raceCount={RaceCount} empireCount={EmpireCount}",
+                nameof(GetCachedSectorEntityUsageAsync),
+                sectorId,
+                cachedUsage.RaceIds.Count,
+                cachedUsage.EmpireIds.Count);
             return cachedUsage;
         }
 
+        var stopwatch = Stopwatch.StartNew();
+        logger.LogInformation("Explorer query cache miss {Operation}. sectorId={SectorId}", nameof(GetCachedSectorEntityUsageAsync), sectorId);
         var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
         var empireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
         var cachedValue = new CachedSectorEntityUsage(
@@ -2206,6 +2318,13 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             empireIds);
 
         sectorEntityUsageCache[sectorId] = cachedValue;
+        logger.LogInformation(
+            "Explorer query cache populated {Operation} in {ElapsedMs}ms. sectorId={SectorId} raceCount={RaceCount} empireCount={EmpireCount}",
+            nameof(GetCachedSectorEntityUsageAsync),
+            stopwatch.ElapsedMilliseconds,
+            sectorId,
+            raceIds.Count,
+            empireIds.Count);
         return cachedValue;
     }
 

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -122,6 +122,19 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             empires);
     }
 
+    public async Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
+        var empireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+
+        return new ExplorerSectorEntityUsage(
+            sectorId,
+            raceIds.OrderBy(id => id).ToList(),
+            empireIds.OrderBy(id => id).ToList());
+    }
+
     public async Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using StarWin.Application.Services;
 using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.Notes;
+using StarWin.Domain.Model.Entity.StarMap;
 using StarWin.Domain.Services;
 using StarWin.Infrastructure.Data;
 
@@ -10,6 +11,9 @@ namespace StarWin.Infrastructure.Services;
 
 public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinExplorerQueryService
 {
+    private static readonly TimeSpan SectorEntityUsageCacheDuration = TimeSpan.FromSeconds(20);
+    private readonly Dictionary<int, CachedSectorEntityUsage> sectorEntityUsageCache = [];
+
     public async Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -124,22 +128,672 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
 
     public async Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
     {
+        if (sectorId <= 0)
+        {
+            return new ExplorerSectorEntityUsage(0, [], []);
+        }
+
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).Value;
+    }
+
+    public async Task<IReadOnlyList<StarWinSearchResult>> SearchSectorAsync(
+        int sectorId,
+        string query,
+        int maxResults = 30,
+        CancellationToken cancellationToken = default)
+    {
+        if (sectorId <= 0 || string.IsNullOrWhiteSpace(query))
+        {
+            return [];
+        }
+
+        var normalizedQuery = query.Trim();
+        var searchPattern = $"%{normalizedQuery}%";
+        var hasNumericQuery = int.TryParse(normalizedQuery, out var numericQuery);
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
+
+        var results = new List<StarWinSearchResult>();
+
+        results.AddRange(await dbContext.StarSystems
+            .AsNoTracking()
+            .Where(system => system.SectorId == sectorId
+                && (EF.Functions.Like(system.Name, searchPattern)
+                    || (hasNumericQuery && (system.Id == numericQuery || system.LegacySystemId == numericQuery))))
+            .OrderBy(system => system.Name)
+            .ThenBy(system => system.Id)
+            .Select(system => new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.StarSystem,
+                Title = system.Name,
+                Subtitle = $"System {system.Id} at {DisplayCoordinates(system.Coordinates)}",
+                Tab = "Systems",
+                SectorId = sectorId,
+                SystemId = system.Id
+            })
+            .Take(maxResults)
+            .ToListAsync(cancellationToken));
+
+        results.AddRange(await (
+            from world in dbContext.Worlds.AsNoTracking()
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && (EF.Functions.Like(world.Name, searchPattern)
+                    || EF.Functions.Like(world.WorldType, searchPattern)
+                    || (hasNumericQuery && (world.Id == numericQuery
+                        || world.LegacyPlanetId == numericQuery
+                        || world.LegacyMoonId == numericQuery)))
+            orderby world.Name, world.Id
+            select new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.World,
+                Title = world.Name,
+                Subtitle = $"{world.Kind} {world.Id} in {system.Name}; {world.WorldType}, {world.AtmosphereType}",
+                Tab = "Worlds",
+                SectorId = sectorId,
+                SystemId = system.Id,
+                WorldId = world.Id
+            })
+            .Take(maxResults)
+            .ToListAsync(cancellationToken));
+
+        results.AddRange(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && (EF.Functions.Like(colony.ColonyClass, searchPattern)
+                    || EF.Functions.Like(colony.ColonistRaceName, searchPattern)
+                    || EF.Functions.Like(colony.AllegianceName, searchPattern)
+                    || EF.Functions.Like(colony.Name, searchPattern)
+                    || (hasNumericQuery && (colony.Id == numericQuery || colony.WorldId == numericQuery)))
+            orderby world.Name, colony.Id
+            select new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.Colony,
+                Title = $"{(string.IsNullOrWhiteSpace(colony.Name) ? colony.ColonyClass : colony.Name)} on {world.Name}",
+                Subtitle = $"{colony.ColonistRaceName}; {colony.AllegianceName}; {DisplayPopulation(colony.EstimatedPopulation)}",
+                Tab = "Colonies",
+                SectorId = sectorId,
+                SystemId = system.Id,
+                WorldId = world.Id,
+                ColonyId = colony.Id,
+                RaceId = colony.RaceId,
+                EmpireId = colony.ControllingEmpireId
+            })
+            .Take(maxResults)
+            .ToListAsync(cancellationToken));
+
+        results.AddRange(await (
+            from habitat in dbContext.SpaceHabitats.AsNoTracking()
+            join system in dbContext.StarSystems.AsNoTracking()
+                on EF.Property<int>(habitat, "StarSystemId") equals system.Id
+            where system.SectorId == sectorId
+                && (EF.Functions.Like(habitat.Name, searchPattern)
+                    || (hasNumericQuery && habitat.Id == numericQuery))
+            orderby habitat.Name, habitat.Id
+            select new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.SpaceHabitat,
+                Title = habitat.Name,
+                Subtitle = $"Habitat in {system.Name}; population {DisplayPopulation(habitat.Population)}",
+                Tab = "Worlds",
+                SectorId = sectorId,
+                SystemId = system.Id,
+                SpaceHabitatId = habitat.Id,
+                EmpireId = habitat.ControlledByEmpireId
+            })
+            .Take(maxResults)
+            .ToListAsync(cancellationToken));
+
+        results.AddRange(await dbContext.HistoryEvents
+            .AsNoTracking()
+            .Where(history => history.SectorId == sectorId
+                && (EF.Functions.Like(history.EventType, searchPattern)
+                    || EF.Functions.Like(history.Description, searchPattern)
+                    || (hasNumericQuery && history.Century == numericQuery)))
+            .OrderBy(history => history.Century)
+            .ThenBy(history => history.EventType)
+            .Select(history => new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.History,
+                Title = $"{history.EventType} C{history.Century}",
+                Subtitle = history.Description,
+                Tab = "Timeline",
+                SectorId = sectorId,
+                SystemId = history.StarSystemId,
+                WorldId = history.PlanetId,
+                RaceId = history.RaceId,
+                EmpireId = history.EmpireId
+            })
+            .Take(maxResults)
+            .ToListAsync(cancellationToken));
+
+        if (sectorEntityUsage.EmpireIds.Count > 0)
+        {
+            var sectorEmpireIds = sectorEntityUsage.EmpireIds;
+            results.AddRange(await dbContext.Empires
+                .AsNoTracking()
+                .Where(empire => sectorEmpireIds.Contains(empire.Id)
+                    && (EF.Functions.Like(empire.Name, searchPattern)
+                        || (hasNumericQuery && (empire.Id == numericQuery || empire.CivilizationProfile.TechLevel == numericQuery))))
+                .OrderBy(empire => empire.Name)
+                .ThenBy(empire => empire.Id)
+                .Select(empire => new StarWinSearchResult
+                {
+                    Type = StarWinSearchResultType.Empire,
+                    Title = empire.Name,
+                    Subtitle = $"TL {empire.CivilizationProfile.TechLevel}; {empire.Planets} planets; {empire.MilitaryPower} military power",
+                    Tab = "Empires",
+                    SectorId = sectorId,
+                    EmpireId = empire.Id,
+                    RaceId = empire.LegacyRaceId
+                })
+                .Take(maxResults)
+                .ToListAsync(cancellationToken));
+        }
+
+        if (sectorEntityUsage.RaceIds.Count > 0)
+        {
+            var sectorRaceIds = sectorEntityUsage.RaceIds;
+            results.AddRange(await dbContext.AlienRaces
+                .AsNoTracking()
+                .Where(race => sectorRaceIds.Contains(race.Id)
+                    && (EF.Functions.Like(race.Name, searchPattern)
+                        || EF.Functions.Like(race.AppearanceType, searchPattern)
+                        || EF.Functions.Like(race.EnvironmentType, searchPattern)
+                        || EF.Functions.Like(race.BodyChemistry, searchPattern)
+                        || (hasNumericQuery && race.Id == numericQuery)))
+                .OrderBy(race => race.Name)
+                .ThenBy(race => race.Id)
+                .Select(race => new StarWinSearchResult
+                {
+                    Type = StarWinSearchResultType.AlienRace,
+                    Title = race.Name,
+                    Subtitle = $"{race.AppearanceType}; {race.EnvironmentType}; {race.BodyChemistry} biology",
+                    Tab = "Aliens",
+                    SectorId = sectorId,
+                    RaceId = race.Id
+                })
+                .Take(maxResults)
+                .ToListAsync(cancellationToken));
+        }
+
+        return results
+            .OrderBy(result => RankSearchResult(result, normalizedQuery))
+            .ThenBy(result => result.Title, StringComparer.OrdinalIgnoreCase)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    public async Task<int?> ResolveSystemIdAsync(
+        int sectorId,
+        int? worldId = null,
+        int? colonyId = null,
+        int? habitatId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (sectorId <= 0)
+        {
+            return null;
+        }
+
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-        var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
-        var empireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        if (colonyId is int requestedColonyId && requestedColonyId > 0)
+        {
+            return await (
+                from colony in dbContext.Colonies.AsNoTracking()
+                join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+                join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                where system.SectorId == sectorId && colony.Id == requestedColonyId
+                select (int?)system.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
 
-        return new ExplorerSectorEntityUsage(
+        if (habitatId is int requestedHabitatId && requestedHabitatId > 0)
+        {
+            return await (
+                from habitat in dbContext.SpaceHabitats.AsNoTracking()
+                join system in dbContext.StarSystems.AsNoTracking()
+                    on EF.Property<int>(habitat, "StarSystemId") equals system.Id
+                where system.SectorId == sectorId && habitat.Id == requestedHabitatId
+                select (int?)system.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        if (worldId is int requestedWorldId && requestedWorldId > 0)
+        {
+            return await (
+                from world in dbContext.Worlds.AsNoTracking()
+                join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                where system.SectorId == sectorId && world.Id == requestedWorldId
+                select (int?)system.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        return null;
+    }
+
+    public async Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
+        if (sectorEntityUsage.EmpireIds.Count == 0)
+        {
+            return [];
+        }
+
+        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
+        return await dbContext.Empires
+            .AsNoTracking()
+            .Where(empire => sectorEmpireIds.Contains(empire.Id))
+            .OrderBy(empire => empire.Name)
+            .ThenBy(empire => empire.Id)
+            .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<ExplorerSystemFilterOptions> LoadSystemFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        return new ExplorerSystemFilterOptions(await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken));
+    }
+
+    public async Task<ExplorerSystemListPage> LoadSystemListPageAsync(ExplorerSystemListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var systemsQuery = dbContext.StarSystems
+            .AsNoTracking()
+            .Where(system => system.SectorId == request.SectorId);
+
+        if (request.EmpireId is int empireId)
+        {
+            systemsQuery = systemsQuery.Where(system => system.AllegianceId == empireId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+        {
+            var normalizedQuery = request.Query.Trim();
+            var searchPattern = $"%{normalizedQuery}%";
+            var hasNumericQuery = int.TryParse(normalizedQuery, out var numericQuery);
+            systemsQuery = systemsQuery.Where(system =>
+                EF.Functions.Like(system.Name, searchPattern)
+                || (hasNumericQuery && (system.Id == numericQuery || system.LegacySystemId == numericQuery))
+                || system.AstralBodies.Any(body =>
+                    EF.Functions.Like(body.Classification, searchPattern)
+                    || EF.Functions.Like(body.Role.ToString(), searchPattern)
+                    || EF.Functions.Like(body.Kind.ToString(), searchPattern))
+                || system.Worlds.Any(world =>
+                    EF.Functions.Like(world.Name, searchPattern)
+                    || EF.Functions.Like(world.WorldType, searchPattern))
+                || (system.AllegianceId != ushort.MaxValue
+                    && dbContext.Empires.Any(empire => empire.Id == system.AllegianceId && EF.Functions.Like(empire.Name, searchPattern))));
+        }
+
+        var items = await systemsQuery
+            .OrderBy(system => system.Name)
+            .ThenBy(system => system.Id)
+            .Select(system => new ExplorerSystemListItem(
+                system.Id,
+                system.LegacySystemId,
+                system.Name,
+                system.Coordinates,
+                system.AllegianceId,
+                system.AllegianceId == ushort.MaxValue
+                    ? "Independent"
+                    : dbContext.Empires
+                        .Where(empire => empire.Id == system.AllegianceId)
+                        .Select(empire => empire.Name)
+                        .FirstOrDefault() ?? system.AllegianceId.ToString()))
+            .Skip(request.Offset)
+            .Take(request.Limit + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = items.Count > request.Limit;
+        return new ExplorerSystemListPage(items.Take(request.Limit).ToList(), hasMore);
+    }
+
+    public async Task<ExplorerSystemListItem?> LoadSystemListItemAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await dbContext.StarSystems
+            .AsNoTracking()
+            .Where(system => system.SectorId == sectorId && system.Id == systemId)
+            .Select(system => new ExplorerSystemListItem(
+                system.Id,
+                system.LegacySystemId,
+                system.Name,
+                system.Coordinates,
+                system.AllegianceId,
+                system.AllegianceId == ushort.MaxValue
+                    ? "Independent"
+                    : dbContext.Empires
+                        .Where(empire => empire.Id == system.AllegianceId)
+                        .Select(empire => empire.Name)
+                        .FirstOrDefault() ?? system.AllegianceId.ToString()))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<ExplorerSystemDetail?> LoadSystemDetailAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+    {
+        var system = await LoadProjectedSystemDetailAsync(
             sectorId,
-            raceIds.OrderBy(id => id).ToList(),
-            empireIds.OrderBy(id => id).ToList());
+            systemId,
+            includeWorldCharacteristics: false,
+            includeColonies: false,
+            includeColonyDemographics: false,
+            cancellationToken: cancellationToken);
+
+        return system is null ? null : new ExplorerSystemDetail(sectorId, system);
+    }
+
+    public async Task<ExplorerWorldsWorkspace?> LoadWorldsWorkspaceAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+    {
+        var system = await LoadProjectedSystemDetailAsync(
+            sectorId,
+            systemId,
+            includeWorldCharacteristics: true,
+            includeColonies: true,
+            includeColonyDemographics: true,
+            cancellationToken: cancellationToken);
+        if (system is null)
+        {
+            return null;
+        }
+
+        var empires = await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken);
+        return new ExplorerWorldsWorkspace(sectorId, system, empires);
+    }
+
+    public async Task<ExplorerColonyFilterOptions> LoadColonyFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var sectorEntityUsage = await LoadSectorEntityUsageAsync(sectorId, cancellationToken);
+        var raceIds = sectorEntityUsage.RaceIds.ToHashSet();
+        var empireIds = sectorEntityUsage.EmpireIds.ToHashSet();
+
+        var races = raceIds.Count == 0
+            ? []
+            : await dbContext.AlienRaces
+                .AsNoTracking()
+                .Where(race => raceIds.Contains(race.Id))
+                .OrderBy(race => race.Name)
+                .ThenBy(race => race.Id)
+                .Select(race => new ExplorerLookupOption(race.Id, race.Name))
+                .ToListAsync(cancellationToken);
+
+        var empires = empireIds.Count == 0
+            ? []
+            : await dbContext.Empires
+                .AsNoTracking()
+                .Where(empire => empireIds.Contains(empire.Id))
+                .OrderBy(empire => empire.Name)
+                .ThenBy(empire => empire.Id)
+                .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
+                .ToListAsync(cancellationToken);
+
+        var classes = await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && !string.IsNullOrWhiteSpace(colony.ColonyClass)
+            orderby colony.ColonyClass
+            select colony.ColonyClass)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return new ExplorerColonyFilterOptions(races, empires, classes);
+    }
+
+    public async Task<ExplorerColonyListPage> LoadColonyListPageAsync(ExplorerColonyListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = from colony in dbContext.Colonies.AsNoTracking()
+                    join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+                    join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                    where system.SectorId == request.SectorId
+                    select new
+                    {
+                        Colony = colony,
+                        World = world
+                    };
+
+        if (request.RaceId is int raceId)
+        {
+            query = query.Where(item =>
+                item.Colony.RaceId == raceId
+                || dbContext.Set<ColonyDemographic>().Any(demographic => demographic.ColonyId == item.Colony.Id && demographic.RaceId == raceId));
+        }
+
+        if (request.EmpireId is int empireId)
+        {
+            query = query.Where(item =>
+                item.Colony.AllegianceId == empireId
+                || item.Colony.ControllingEmpireId == empireId
+                || item.Colony.FoundingEmpireId == empireId
+                || item.Colony.ParentEmpireId == empireId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Status)
+            && Enum.TryParse<ColonyPoliticalStatus>(request.Status.Trim(), true, out var politicalStatus))
+        {
+            query = query.Where(item => item.Colony.PoliticalStatus == politicalStatus);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ColonyClass))
+        {
+            var colonyClass = request.ColonyClass.Trim();
+            query = query.Where(item => item.Colony.ColonyClass == colonyClass);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+        {
+            var normalizedQuery = request.Query.Trim();
+            var searchPattern = $"%{normalizedQuery}%";
+            var hasNumericQuery = int.TryParse(normalizedQuery, out var numericQuery);
+            query = query.Where(item =>
+                EF.Functions.Like(item.World.Name, searchPattern)
+                || EF.Functions.Like(item.World.WorldType, searchPattern)
+                || EF.Functions.Like(item.Colony.Name, searchPattern)
+                || EF.Functions.Like(item.Colony.ColonyClass, searchPattern)
+                || EF.Functions.Like(item.Colony.ColonistRaceName, searchPattern)
+                || EF.Functions.Like(item.Colony.AllegianceName, searchPattern)
+                || EF.Functions.Like(item.Colony.Starport, searchPattern)
+                || EF.Functions.Like(item.Colony.GovernmentType, searchPattern)
+                || EF.Functions.Like(item.Colony.ExportResource, searchPattern)
+                || EF.Functions.Like(item.Colony.ImportResource, searchPattern)
+                || dbContext.Set<ColonyDemographic>().Any(demographic => demographic.ColonyId == item.Colony.Id && EF.Functions.Like(demographic.RaceName, searchPattern))
+                || (hasNumericQuery && (item.Colony.Id == numericQuery || item.Colony.WorldId == numericQuery)));
+        }
+
+        var items = await query
+            .OrderByDescending(item => item.Colony.EstimatedPopulation)
+            .ThenBy(item => item.World.Name)
+            .ThenBy(item => item.Colony.Id)
+            .Select(item => new ExplorerColonyListItem(
+                item.Colony.Id,
+                item.World.Id,
+                item.World.StarSystemId ?? 0,
+                string.IsNullOrWhiteSpace(item.Colony.Name) ? item.Colony.ColonyClass : item.Colony.Name,
+                item.World.Name,
+                item.Colony.AllegianceName,
+                item.Colony.EstimatedPopulation))
+            .Skip(request.Offset)
+            .Take(request.Limit + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = items.Count > request.Limit;
+        return new ExplorerColonyListPage(items.Take(request.Limit).ToList(), hasMore);
+    }
+
+    public async Task<ExplorerColonyListItem?> LoadColonyListItemAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && colony.Id == colonyId
+            select new ExplorerColonyListItem(
+                colony.Id,
+                world.Id,
+                world.StarSystemId ?? 0,
+                string.IsNullOrWhiteSpace(colony.Name) ? colony.ColonyClass : colony.Name,
+                world.Name,
+                colony.AllegianceName,
+                colony.EstimatedPopulation))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<ExplorerColonyDetail?> LoadColonyDetailAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var detailRow = await (
+            from colonyRow in dbContext.Colonies.AsNoTracking()
+            join worldRow in dbContext.Worlds.AsNoTracking() on colonyRow.WorldId equals worldRow.Id
+            join systemRow in dbContext.StarSystems.AsNoTracking() on worldRow.StarSystemId equals systemRow.Id
+            where systemRow.SectorId == sectorId && colonyRow.Id == colonyId
+            select new
+            {
+                Colony = colonyRow,
+                World = worldRow
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+        if (detailRow is null)
+        {
+            return null;
+        }
+
+        var demographics = await dbContext.Set<ColonyDemographic>()
+            .AsNoTracking()
+            .Where(demographic => demographic.ColonyId == colonyId)
+            .OrderByDescending(demographic => demographic.PopulationPercent)
+            .ToListAsync(cancellationToken);
+
+        var colony = CopyColony(detailRow.Colony, includeDemographics: false);
+        foreach (var demographic in demographics)
+        {
+            colony.Demographics.Add(new ColonyDemographic
+            {
+                ColonyId = demographic.ColonyId,
+                RaceId = demographic.RaceId,
+                RaceName = demographic.RaceName,
+                PopulationPercent = demographic.PopulationPercent,
+                Population = demographic.Population
+            });
+        }
+
+        var world = CopyWorld(detailRow.World, includeColony: false, includeCharacteristics: false);
+        return new ExplorerColonyDetail(sectorId, colony, world);
+    }
+
+    public async Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var sectorRow = await dbContext.Sectors
+            .AsNoTracking()
+            .Where(sector => sector.Id == sectorId)
+            .Select(sector => new
+            {
+                sector.Id,
+                sector.Name,
+                sector.Configuration
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+        if (sectorRow is null)
+        {
+            return null;
+        }
+
+        var systems = await dbContext.StarSystems
+            .AsNoTracking()
+            .Where(system => system.SectorId == sectorId)
+            .OrderBy(system => system.Name)
+            .ThenBy(system => system.Id)
+            .Select(system => new ExplorerHyperlaneSystem(
+                system.Id,
+                system.LegacySystemId,
+                system.Name,
+                system.Coordinates,
+                system.AllegianceId))
+            .ToListAsync(cancellationToken);
+
+        var savedRoutes = await dbContext.SectorSavedRoutes
+            .AsNoTracking()
+            .Where(route => route.SectorId == sectorId)
+            .OrderBy(route => route.SourceSystemId)
+            .ThenBy(route => route.TargetSystemId)
+            .Select(route => new SectorSavedRoute
+            {
+                Id = route.Id,
+                SectorId = route.SectorId,
+                SourceSystemId = route.SourceSystemId,
+                TargetSystemId = route.TargetSystemId,
+                DistanceParsecs = route.DistanceParsecs,
+                TravelTimeYears = route.TravelTimeYears,
+                TechnologyLevel = route.TechnologyLevel,
+                TierName = route.TierName,
+                PrimaryOwnerEmpireId = route.PrimaryOwnerEmpireId,
+                PrimaryOwnerEmpireName = route.PrimaryOwnerEmpireName,
+                SecondaryOwnerEmpireId = route.SecondaryOwnerEmpireId,
+                SecondaryOwnerEmpireName = route.SecondaryOwnerEmpireName,
+                IsUserPersisted = route.IsUserPersisted,
+                GeneratedAtUtc = route.GeneratedAtUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        var eligibleSystemIds = new HashSet<int>();
+        eligibleSystemIds.UnionWith(await (
+            from system in dbContext.StarSystems.AsNoTracking()
+            join empire in dbContext.Empires.AsNoTracking() on (int)system.AllegianceId equals empire.Id
+            where system.SectorId == sectorId
+                && system.AllegianceId != ushort.MaxValue
+                && empire.CivilizationProfile.TechLevel >= 6
+            select system.Id)
+            .ToListAsync(cancellationToken));
+        eligibleSystemIds.UnionWith(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join empire in dbContext.Empires.AsNoTracking() on colony.ControllingEmpireId equals empire.Id
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && colony.ControllingEmpireId.HasValue
+                && empire.CivilizationProfile.TechLevel >= 6
+            select system.Id)
+            .ToListAsync(cancellationToken));
+        eligibleSystemIds.UnionWith(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join empire in dbContext.Empires.AsNoTracking() on (int)colony.AllegianceId equals empire.Id
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && colony.AllegianceId != ushort.MaxValue
+                && empire.CivilizationProfile.TechLevel >= 6
+            select system.Id)
+            .ToListAsync(cancellationToken));
+
+        var empires = await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken);
+        return new ExplorerHyperlaneWorkspace(
+            sectorRow.Id,
+            sectorRow.Name,
+            CloneSectorConfiguration(sectorRow.Configuration),
+            systems,
+            savedRoutes,
+            eligibleSystemIds.OrderBy(id => id).ToList(),
+            empires);
     }
 
     public async Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
+        var raceIds = sectorEntityUsage.RaceIds;
         if (raceIds.Count == 0)
         {
             return new ExplorerAlienRaceFilterOptions([], [], [], []);
@@ -161,7 +815,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             .OrderBy(value => value)
             .ToListAsync(cancellationToken);
 
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
         var starWinTechLevels = sectorEmpireIds.Count == 0
             ? []
             : await dbContext.Empires
@@ -201,14 +855,14 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var raceIds = await LoadSectorRaceIdsAsync(dbContext, request.SectorId, cancellationToken);
+        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, request.SectorId, cancellationToken);
+        var raceIds = sectorEntityUsage.RaceIds;
         if (raceIds.Count == 0)
         {
             return new ExplorerAlienRaceListPage([], false);
         }
 
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, request.SectorId, cancellationToken);
+        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
         var racesQuery = dbContext.AlienRaces
             .AsNoTracking()
             .Where(race => raceIds.Contains(race.Id));
@@ -234,8 +888,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
+        var raceIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).RaceIds;
         if (!raceIds.Contains(raceId))
         {
             return null;
@@ -255,8 +908,8 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
+        var raceIds = sectorEntityUsage.RaceIds;
         if (!raceIds.Contains(raceId))
         {
             return null;
@@ -284,7 +937,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
                 .FirstOrDefaultAsync(cancellationToken)
             : null;
 
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
         var empires = sectorEmpireIds.Count == 0
             ? []
             : await dbContext.Empires
@@ -303,8 +956,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         if (sectorEmpireIds.Count == 0)
         {
             return new ExplorerEmpireFilterOptions([]);
@@ -339,7 +991,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, request.SectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, request.SectorId, cancellationToken)).EmpireIds;
         if (sectorEmpireIds.Count == 0)
         {
             return new ExplorerEmpireListPage([], false);
@@ -351,40 +1003,12 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
 
         empiresQuery = ApplyEmpireFilters(dbContext, empiresQuery, request);
 
-        var items = await empiresQuery
+        var headerItems = await empiresQuery
             .OrderBy(empire => empire.Name)
             .ThenBy(empire => empire.Id)
-            .Select(empire => new EmpireListProjection(
+            .Select(empire => new EmpireListHeaderProjection(
                 empire.Id,
                 empire.Name,
-                dbContext.Colonies
-                    .Where(colony =>
-                        colony.ControllingEmpireId == empire.Id
-                        && dbContext.Worlds
-                            .Where(world => world.Id == colony.WorldId)
-                            .Join(
-                                dbContext.StarSystems,
-                                world => world.StarSystemId,
-                                system => system.Id,
-                                (world, system) => system.SectorId)
-                            .Contains(request.SectorId))
-                    .Select(colony => colony.WorldId)
-                    .Distinct()
-                    .Count(),
-                dbContext.Colonies
-                    .Where(colony =>
-                        (colony.ControllingEmpireId == empire.Id || colony.FoundingEmpireId == empire.Id)
-                        && dbContext.Worlds
-                            .Where(world => world.Id == colony.WorldId)
-                            .Join(
-                                dbContext.StarSystems,
-                                world => world.StarSystemId,
-                                system => system.Id,
-                                (world, system) => system.SectorId)
-                            .Contains(request.SectorId))
-                    .Select(colony => colony.WorldId)
-                    .Distinct()
-                    .Count(),
                 empire.CivilizationProfile.TechLevel + 2,
                 empire.GovernmentType,
                 empire.Founding.Origin,
@@ -403,11 +1027,32 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
             .Take(request.Limit + 1)
             .ToListAsync(cancellationToken);
 
-        var hasMore = items.Count > request.Limit;
+        var hasMore = headerItems.Count > request.Limit;
+        var visibleHeaders = headerItems.Take(request.Limit).ToList();
+        var worldCountsByEmpireId = await LoadEmpireWorldCountsByEmpireIdAsync(
+            dbContext,
+            request.SectorId,
+            visibleHeaders.Select(item => item.EmpireId).ToList(),
+            cancellationToken);
         return new ExplorerEmpireListPage(
-            items
-                .Take(request.Limit)
-                .Select(BuildEmpireListItem)
+            visibleHeaders
+                .Select(item =>
+                {
+                    var counts = worldCountsByEmpireId.GetValueOrDefault(item.EmpireId) ?? EmptyEmpireWorldCountProjection;
+                    return BuildEmpireListItem(new EmpireListProjection(
+                        item.EmpireId,
+                        item.Name,
+                        counts.ControlledWorldCount,
+                        counts.TrackedWorldCount,
+                        item.GurpsTechLevel,
+                        item.GovernmentType,
+                        item.Origin,
+                        item.FoundingRaceId,
+                        item.FoundingWorldId,
+                        item.FoundingRaceName,
+                        item.FoundingWorldName,
+                        item.IsFallen));
+                })
                 .ToList(),
             hasMore);
     }
@@ -416,7 +1061,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         if (!sectorEmpireIds.Contains(empireId))
         {
             return null;
@@ -425,37 +1070,9 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         var item = await dbContext.Empires
             .AsNoTracking()
             .Where(empire => empire.Id == empireId)
-            .Select(empire => new EmpireListProjection(
+            .Select(empire => new EmpireListHeaderProjection(
                 empire.Id,
                 empire.Name,
-                dbContext.Colonies
-                    .Where(colony =>
-                        colony.ControllingEmpireId == empire.Id
-                        && dbContext.Worlds
-                            .Where(world => world.Id == colony.WorldId)
-                            .Join(
-                                dbContext.StarSystems,
-                                world => world.StarSystemId,
-                                system => system.Id,
-                                (world, system) => system.SectorId)
-                            .Contains(sectorId))
-                    .Select(colony => colony.WorldId)
-                    .Distinct()
-                    .Count(),
-                dbContext.Colonies
-                    .Where(colony =>
-                        (colony.ControllingEmpireId == empire.Id || colony.FoundingEmpireId == empire.Id)
-                        && dbContext.Worlds
-                            .Where(world => world.Id == colony.WorldId)
-                            .Join(
-                                dbContext.StarSystems,
-                                world => world.StarSystemId,
-                                system => system.Id,
-                                (world, system) => system.SectorId)
-                            .Contains(sectorId))
-                    .Select(colony => colony.WorldId)
-                    .Distinct()
-                    .Count(),
                 empire.CivilizationProfile.TechLevel + 2,
                 empire.GovernmentType,
                 empire.Founding.Origin,
@@ -472,16 +1089,38 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
                 empire.IsFallen))
             .FirstOrDefaultAsync(cancellationToken);
 
-        return item is null
-            ? null
-            : BuildEmpireListItem(item);
+        if (item is null)
+        {
+            return null;
+        }
+
+        var counts = (await LoadEmpireWorldCountsByEmpireIdAsync(
+            dbContext,
+            sectorId,
+            [item.EmpireId],
+            cancellationToken))
+            .GetValueOrDefault(item.EmpireId)
+            ?? EmptyEmpireWorldCountProjection;
+        return BuildEmpireListItem(new EmpireListProjection(
+            item.EmpireId,
+            item.Name,
+            counts.ControlledWorldCount,
+            counts.TrackedWorldCount,
+            item.GurpsTechLevel,
+            item.GovernmentType,
+            item.Origin,
+            item.FoundingRaceId,
+            item.FoundingWorldId,
+            item.FoundingRaceName,
+            item.FoundingWorldName,
+            item.IsFallen));
     }
 
     public async Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         if (!sectorEmpireIds.Contains(empireId))
         {
             return null;
@@ -696,8 +1335,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerReligionFilterOptions> LoadReligionFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         if (sectorEmpireIds.Count == 0)
         {
             return new ExplorerReligionFilterOptions([]);
@@ -719,8 +1357,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerReligionListPage> LoadReligionListPageAsync(ExplorerReligionListPageRequest request, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, request.SectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, request.SectorId, cancellationToken)).EmpireIds;
         var religionIds = await LoadSectorReligionIdsAsync(dbContext, sectorEmpireIds, cancellationToken);
         if (religionIds.Count == 0)
         {
@@ -766,8 +1403,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerReligionListItem?> LoadReligionListItemAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         var religionIds = await LoadSectorReligionIdsAsync(dbContext, sectorEmpireIds, cancellationToken);
         if (!religionIds.Contains(religionId))
         {
@@ -790,8 +1426,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     public async Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         var religionIds = await LoadSectorReligionIdsAsync(dbContext, sectorEmpireIds, cancellationToken);
         if (!religionIds.Contains(religionId))
         {
@@ -1042,6 +1677,254 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     private static string BuildTimelineTimeLabel(int century)
     {
         return $"Century {century}";
+    }
+
+    private async Task<StarSystem?> LoadProjectedSystemDetailAsync(
+        int sectorId,
+        int systemId,
+        bool includeWorldCharacteristics,
+        bool includeColonies,
+        bool includeColonyDemographics,
+        CancellationToken cancellationToken)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        IQueryable<StarSystem> query = dbContext.StarSystems
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Where(system => system.SectorId == sectorId && system.Id == systemId)
+            .Include(system => system.AstralBodies)
+            .Include(system => system.Worlds)
+            .Include(system => system.SpaceHabitats);
+
+        if (includeWorldCharacteristics)
+        {
+            query = query
+                .Include(system => system.Worlds)
+                    .ThenInclude(world => world.UnusualCharacteristics);
+        }
+
+        if (includeColonies)
+        {
+            query = query
+                .Include(system => system.Worlds)
+                    .ThenInclude(world => world.Colony);
+        }
+
+        if (includeColonyDemographics)
+        {
+            query = query
+                .Include(system => system.Worlds)
+                    .ThenInclude(world => world.Colony)
+                        .ThenInclude(colony => colony!.Demographics);
+        }
+
+        return await query.FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static int RankSearchResult(StarWinSearchResult result, string query)
+    {
+        if (string.Equals(result.Title, query, StringComparison.OrdinalIgnoreCase))
+        {
+            return 0;
+        }
+
+        if (result.Title.StartsWith(query, StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        return result.Type switch
+        {
+            StarWinSearchResultType.StarSystem => 2,
+            StarWinSearchResultType.World => 3,
+            StarWinSearchResultType.Colony => 4,
+            StarWinSearchResultType.SpaceHabitat => 5,
+            StarWinSearchResultType.AlienRace => 6,
+            StarWinSearchResultType.Empire => 7,
+            StarWinSearchResultType.History => 8,
+            _ => 9
+        };
+    }
+
+    private static string DisplayCoordinates(Coordinates coordinates)
+    {
+        return $"{coordinates.XParsecs:0.#}, {coordinates.YParsecs:0.#}, {coordinates.ZParsecs:0.#}";
+    }
+
+    private static string DisplayPopulation(long population)
+    {
+        return population >= 1_000_000_000
+            ? $"{population / 1_000_000_000m:0.#} billion"
+            : $"{population / 1_000_000m:0.#} million";
+    }
+
+    private static SectorConfiguration CloneSectorConfiguration(SectorConfiguration configuration)
+    {
+        return new SectorConfiguration
+        {
+            SectorId = configuration.SectorId,
+            OffLaneMaximumDistanceParsecs = configuration.OffLaneMaximumDistanceParsecs,
+            Tl9AndBelowMaximumConnectionsPerSystem = configuration.Tl9AndBelowMaximumConnectionsPerSystem,
+            AdditionalCrossEmpireConnectionsPerSystem = configuration.AdditionalCrossEmpireConnectionsPerSystem,
+            Tl6HyperlaneName = configuration.Tl6HyperlaneName,
+            Tl6MaximumDistanceParsecs = configuration.Tl6MaximumDistanceParsecs,
+            Tl6OffLaneSpeedMultiplier = configuration.Tl6OffLaneSpeedMultiplier,
+            Tl6HyperlaneSpeedModifier = configuration.Tl6HyperlaneSpeedModifier,
+            Tl7HyperlaneName = configuration.Tl7HyperlaneName,
+            Tl7MaximumDistanceParsecs = configuration.Tl7MaximumDistanceParsecs,
+            Tl7OffLaneSpeedMultiplier = configuration.Tl7OffLaneSpeedMultiplier,
+            Tl7HyperlaneSpeedModifier = configuration.Tl7HyperlaneSpeedModifier,
+            Tl8HyperlaneName = configuration.Tl8HyperlaneName,
+            Tl8MaximumDistanceParsecs = configuration.Tl8MaximumDistanceParsecs,
+            Tl8OffLaneSpeedMultiplier = configuration.Tl8OffLaneSpeedMultiplier,
+            Tl8HyperlaneSpeedModifier = configuration.Tl8HyperlaneSpeedModifier,
+            Tl9HyperlaneName = configuration.Tl9HyperlaneName,
+            Tl9MaximumDistanceParsecs = configuration.Tl9MaximumDistanceParsecs,
+            Tl9OffLaneSpeedMultiplier = configuration.Tl9OffLaneSpeedMultiplier,
+            Tl9HyperlaneSpeedModifier = configuration.Tl9HyperlaneSpeedModifier,
+            Tl10HyperlaneName = configuration.Tl10HyperlaneName,
+            Tl10MaximumDistanceParsecs = configuration.Tl10MaximumDistanceParsecs,
+            Tl10OffLaneSpeedMultiplier = configuration.Tl10OffLaneSpeedMultiplier,
+            Tl10HyperlaneSpeedModifier = configuration.Tl10HyperlaneSpeedModifier,
+            UpdatedAtUtc = configuration.UpdatedAtUtc
+        };
+    }
+
+    private static Colony CopyColony(Colony colony, bool includeDemographics)
+    {
+        var copy = new Colony
+        {
+            Id = colony.Id,
+            WorldId = colony.WorldId,
+            Name = colony.Name,
+            WorldKind = colony.WorldKind,
+            RaceId = colony.RaceId,
+            ColonistRaceName = colony.ColonistRaceName,
+            AllegianceId = colony.AllegianceId,
+            AllegianceName = colony.AllegianceName,
+            PoliticalStatus = colony.PoliticalStatus,
+            ControllingEmpireId = colony.ControllingEmpireId,
+            ParentEmpireId = colony.ParentEmpireId,
+            FoundingEmpireId = colony.FoundingEmpireId,
+            EncodedPopulation = colony.EncodedPopulation,
+            EstimatedPopulation = colony.EstimatedPopulation,
+            NativePopulationPercent = colony.NativePopulationPercent,
+            ColonyClass = colony.ColonyClass,
+            ColonyClassCode = colony.ColonyClassCode,
+            Crime = colony.Crime,
+            Law = colony.Law,
+            Stability = colony.Stability,
+            AgeCenturies = colony.AgeCenturies,
+            Starport = colony.Starport,
+            StarportCode = colony.StarportCode,
+            GovernmentType = colony.GovernmentType,
+            GovernmentTypeCode = colony.GovernmentTypeCode,
+            GrossWorldProductMcr = colony.GrossWorldProductMcr,
+            MilitaryPower = colony.MilitaryPower,
+            ExportResource = colony.ExportResource,
+            ExportResourceCode = colony.ExportResourceCode,
+            ImportResource = colony.ImportResource,
+            ImportResourceCode = colony.ImportResourceCode
+        };
+
+        foreach (var facility in colony.Facilities)
+        {
+            copy.Facilities.Add(facility);
+        }
+
+        if (includeDemographics)
+        {
+            foreach (var demographic in colony.Demographics)
+            {
+                copy.Demographics.Add(new ColonyDemographic
+                {
+                    ColonyId = demographic.ColonyId,
+                    RaceId = demographic.RaceId,
+                    RaceName = demographic.RaceName,
+                    PopulationPercent = demographic.PopulationPercent,
+                    Population = demographic.Population
+                });
+            }
+        }
+
+        return copy;
+    }
+
+    private static World CopyWorld(World world, bool includeColony, bool includeCharacteristics)
+    {
+        var copy = new World
+        {
+            Id = world.Id,
+            Kind = world.Kind,
+            LegacyPlanetId = world.LegacyPlanetId,
+            LegacyMoonId = world.LegacyMoonId,
+            StarSystemId = world.StarSystemId,
+            ParentWorldId = world.ParentWorldId,
+            PrimaryAstralBodySequence = world.PrimaryAstralBodySequence,
+            Name = world.Name,
+            WorldType = world.WorldType,
+            AtmosphereType = world.AtmosphereType,
+            AtmosphereComposition = world.AtmosphereComposition,
+            WaterType = world.WaterType,
+            Hydrography = new Hydrography
+            {
+                WaterPercent = world.Hydrography.WaterPercent,
+                IcePercent = world.Hydrography.IcePercent,
+                CloudPercent = world.Hydrography.CloudPercent
+            },
+            MineralResources = new MineralResources
+            {
+                MetalOre = world.MineralResources.MetalOre,
+                RadioactiveOre = world.MineralResources.RadioactiveOre,
+                PreciousMetal = world.MineralResources.PreciousMetal,
+                RawCrystals = world.MineralResources.RawCrystals,
+                PreciousGems = world.MineralResources.PreciousGems
+            },
+            DiameterKm = world.DiameterKm,
+            DensityTenthsEarth = world.DensityTenthsEarth,
+            AtmosphericPressure = world.AtmosphericPressure,
+            AverageTemperatureCelsius = world.AverageTemperatureCelsius,
+            MiscellaneousFlags = world.MiscellaneousFlags,
+            Albedo = world.Albedo,
+            AlienRaceId = world.AlienRaceId,
+            ControlledByEmpireId = world.ControlledByEmpireId,
+            AllegianceId = world.AllegianceId,
+            OrbitRadiusAu = world.OrbitRadiusAu,
+            OrbitRadiusKm = world.OrbitRadiusKm,
+            SmallestMolecularWeightRetained = world.SmallestMolecularWeightRetained,
+            AxialTiltDegrees = world.AxialTiltDegrees,
+            OrbitalInclinationDegrees = world.OrbitalInclinationDegrees,
+            RotationPeriodHours = world.RotationPeriodHours,
+            EccentricityThousandths = world.EccentricityThousandths,
+            OrbitPeriodDays = world.OrbitPeriodDays,
+            GravityEarthG = world.GravityEarthG,
+            MassEarthMasses = world.MassEarthMasses,
+            EscapeVelocityKmPerSecond = world.EscapeVelocityKmPerSecond,
+            OxygenPressureAtmospheres = world.OxygenPressureAtmospheres,
+            BoilingPointCelsius = world.BoilingPointCelsius,
+            MagneticFieldGauss = world.MagneticFieldGauss
+        };
+
+        if (includeCharacteristics)
+        {
+            foreach (var characteristic in world.UnusualCharacteristics)
+            {
+                copy.UnusualCharacteristics.Add(new UnusualCharacteristic
+                {
+                    Code = characteristic.Code,
+                    Name = characteristic.Name,
+                    Notes = characteristic.Notes
+                });
+            }
+        }
+
+        if (includeColony && world.Colony is not null)
+        {
+            copy.Colony = CopyColony(world.Colony, includeDemographics: true);
+        }
+
+        return copy;
     }
 
     private static IQueryable<Empire> ApplyEmpireFilters(
@@ -1325,6 +2208,90 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         return empireIds;
     }
 
+    private async Task<CachedSectorEntityUsage> GetCachedSectorEntityUsageAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        if (sectorId <= 0)
+        {
+            return EmptyCachedSectorEntityUsage;
+        }
+
+        if (sectorEntityUsageCache.TryGetValue(sectorId, out var cachedUsage)
+            && cachedUsage.ExpiresAtUtc > DateTime.UtcNow)
+        {
+            return cachedUsage;
+        }
+
+        var raceIds = await LoadSectorRaceIdsAsync(dbContext, sectorId, cancellationToken);
+        var empireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var cachedValue = new CachedSectorEntityUsage(
+            DateTime.UtcNow.Add(SectorEntityUsageCacheDuration),
+            new ExplorerSectorEntityUsage(
+                sectorId,
+                raceIds.OrderBy(id => id).ToList(),
+                empireIds.OrderBy(id => id).ToList()),
+            raceIds,
+            empireIds);
+
+        sectorEntityUsageCache[sectorId] = cachedValue;
+        return cachedValue;
+    }
+
+    private static async Task<Dictionary<int, EmpireWorldCountProjection>> LoadEmpireWorldCountsByEmpireIdAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        IReadOnlyCollection<int> empireIds,
+        CancellationToken cancellationToken)
+    {
+        if (sectorId <= 0 || empireIds.Count == 0)
+        {
+            return [];
+        }
+
+        var empireIdSet = empireIds.Distinct().ToHashSet();
+        var controlledWorldLinks = await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && colony.ControllingEmpireId.HasValue
+                && empireIdSet.Contains(colony.ControllingEmpireId.Value)
+            select new EmpireWorldLinkProjection(colony.ControllingEmpireId!.Value, colony.WorldId))
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var foundedWorldLinks = await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && colony.FoundingEmpireId.HasValue
+                && empireIdSet.Contains(colony.FoundingEmpireId.Value)
+            select new EmpireWorldLinkProjection(colony.FoundingEmpireId!.Value, colony.WorldId))
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var trackedWorldLinks = controlledWorldLinks
+            .Concat(foundedWorldLinks)
+            .Distinct()
+            .ToList();
+
+        var controlledCountsByEmpireId = controlledWorldLinks
+            .GroupBy(link => link.EmpireId)
+            .ToDictionary(group => group.Key, group => group.Count());
+        var trackedCountsByEmpireId = trackedWorldLinks
+            .GroupBy(link => link.EmpireId)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        return empireIdSet.ToDictionary(
+            empireId => empireId,
+            empireId => new EmpireWorldCountProjection(
+                controlledCountsByEmpireId.GetValueOrDefault(empireId),
+                trackedCountsByEmpireId.GetValueOrDefault(empireId)));
+    }
+
     private static string ResolveRaceDisplayName(int raceId, string? raceName, string? homeWorldName)
     {
         if (!IsPlaceholderRaceName(raceName))
@@ -1488,6 +2455,20 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         return string.Format(template, speciesName).Trim();
     }
 
+    private static readonly EmpireWorldCountProjection EmptyEmpireWorldCountProjection = new(0, 0);
+
+    private static readonly CachedSectorEntityUsage EmptyCachedSectorEntityUsage = new(
+        DateTime.MaxValue,
+        new ExplorerSectorEntityUsage(0, [], []),
+        [],
+        []);
+
+    private sealed record CachedSectorEntityUsage(
+        DateTime ExpiresAtUtc,
+        ExplorerSectorEntityUsage Value,
+        HashSet<int> RaceIds,
+        HashSet<int> EmpireIds);
+
     private static IReadOnlyList<ExplorerEmpireRaceMembershipDetail> BuildEmpireRaceMembershipDetails(
         Empire empire,
         IReadOnlyList<EmpireRaceMembershipProjection> membershipRows,
@@ -1602,6 +2583,22 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
     }
 
     private sealed record RaceDisplayProjection(int RaceId, string RaceName, string? HomeWorldName);
+
+    private sealed record EmpireWorldLinkProjection(int EmpireId, int WorldId);
+
+    private sealed record EmpireWorldCountProjection(int ControlledWorldCount, int TrackedWorldCount);
+
+    private sealed record EmpireListHeaderProjection(
+        int EmpireId,
+        string Name,
+        int GurpsTechLevel,
+        string GovernmentType,
+        EmpireOrigin Origin,
+        int? FoundingRaceId,
+        int? FoundingWorldId,
+        string? FoundingRaceName,
+        string? FoundingWorldName,
+        bool IsFallen);
 
     private sealed record EmpireListProjection(
         int EmpireId,

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -22,7 +22,7 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
         }
 
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-        var overviewRow = await dbContext.Database
+        var overviewRows = await dbContext.Database
             .SqlQuery<ExplorerSectorOverviewRow>($"""
                 WITH SectorSystems AS (
                     SELECT Id, AllegianceId
@@ -84,7 +84,8 @@ public sealed class StarWinExplorerQueryService(IDbContextFactory<StarWinDbConte
                     (SELECT COUNT(*) FROM SectorEmpireIds) AS EmpireCount,
                     (SELECT COUNT(*) FROM SectorRaceIds) AS RaceCount
                 """)
-            .SingleAsync(cancellationToken);
+            .ToListAsync(cancellationToken);
+        var overviewRow = overviewRows.Single();
 
         return new ExplorerSectorOverviewData(
             overviewRow.SectorId,

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -695,6 +695,76 @@ public sealed class StarWinExplorerQueryService(
             setupRow.SavedRouteCount);
     }
 
+    public async Task<ExplorerSectorConfigurationState?> LoadSectorConfigurationStateAsync(int sectorId, int? systemId = null, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var stateRow = await dbContext.Sectors
+            .AsNoTracking()
+            .Where(sector => sector.Id == sectorId)
+            .Select(sector => new
+            {
+                sector.Id,
+                sector.Name,
+                sector.Configuration,
+                SavedRouteCount = sector.SavedRoutes.Count
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+        if (stateRow is null)
+        {
+            return null;
+        }
+
+        var selectedSystemRouteCount = systemId is int requestedSystemId and > 0
+            ? await dbContext.SectorSavedRoutes
+                .AsNoTracking()
+                .Where(route =>
+                    route.SectorId == sectorId
+                    && (route.SourceSystemId == requestedSystemId || route.TargetSystemId == requestedSystemId))
+                .CountAsync(cancellationToken)
+            : 0;
+
+        var savedRouteReport = SectorHyperlaneNetworkReport.Empty;
+        if (stateRow.SavedRouteCount > 0)
+        {
+            var eligibleSystemIds = await LoadEligibleHyperlaneSystemIdsAsync(dbContext, sectorId, cancellationToken);
+            if (eligibleSystemIds.Count > 0)
+            {
+                var routeEndpoints = await dbContext.SectorSavedRoutes
+                    .AsNoTracking()
+                    .Where(route => route.SectorId == sectorId)
+                    .Select(route => new
+                    {
+                        route.SourceSystemId,
+                        route.TargetSystemId
+                    })
+                    .ToListAsync(cancellationToken);
+
+                savedRouteReport = SectorRoutePlanner.BuildHyperlaneNetworkReport(
+                    eligibleSystemIds,
+                    routeEndpoints.Select(route => new SectorHyperlaneRouteDefinition(
+                        route.SourceSystemId,
+                        route.TargetSystemId,
+                        0d,
+                        0d,
+                        0,
+                        string.Empty,
+                        null,
+                        string.Empty,
+                        null,
+                        string.Empty)));
+            }
+        }
+
+        return new ExplorerSectorConfigurationState(
+            stateRow.Id,
+            stateRow.Name,
+            CloneSectorConfiguration(stateRow.Configuration),
+            stateRow.SavedRouteCount,
+            savedRouteReport,
+            selectedSystemRouteCount);
+    }
+
     public async Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -751,36 +821,7 @@ public sealed class StarWinExplorerQueryService(
             })
             .ToListAsync(cancellationToken);
 
-        var eligibleSystemIds = new HashSet<int>();
-        eligibleSystemIds.UnionWith(await (
-            from system in dbContext.StarSystems.AsNoTracking()
-            join empire in dbContext.Empires.AsNoTracking() on (int)system.AllegianceId equals empire.Id
-            where system.SectorId == sectorId
-                && system.AllegianceId != ushort.MaxValue
-                && empire.CivilizationProfile.TechLevel >= 6
-            select system.Id)
-            .ToListAsync(cancellationToken));
-        eligibleSystemIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join empire in dbContext.Empires.AsNoTracking() on colony.ControllingEmpireId equals empire.Id
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId
-                && colony.ControllingEmpireId.HasValue
-                && empire.CivilizationProfile.TechLevel >= 6
-            select system.Id)
-            .ToListAsync(cancellationToken));
-        eligibleSystemIds.UnionWith(await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join empire in dbContext.Empires.AsNoTracking() on (int)colony.AllegianceId equals empire.Id
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId
-                && colony.AllegianceId != ushort.MaxValue
-                && empire.CivilizationProfile.TechLevel >= 6
-            select system.Id)
-            .ToListAsync(cancellationToken));
-
+        var eligibleSystemIds = await LoadEligibleHyperlaneSystemIdsAsync(dbContext, sectorId, cancellationToken);
         var empires = await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken);
         return new ExplorerHyperlaneWorkspace(
             sectorRow.Id,
@@ -788,7 +829,7 @@ public sealed class StarWinExplorerQueryService(
             CloneSectorConfiguration(sectorRow.Configuration),
             systems,
             savedRoutes,
-            eligibleSystemIds.OrderBy(id => id).ToList(),
+            eligibleSystemIds,
             empires);
     }
 
@@ -1963,6 +2004,41 @@ public sealed class StarWinExplorerQueryService(
         return population >= 1_000_000_000
             ? $"{population / 1_000_000_000m:0.#} billion"
             : $"{population / 1_000_000m:0.#} million";
+    }
+
+    private static async Task<IReadOnlyList<int>> LoadEligibleHyperlaneSystemIdsAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        return await (
+            (from system in dbContext.StarSystems.AsNoTracking()
+             join empire in dbContext.Empires.AsNoTracking() on (int)system.AllegianceId equals empire.Id
+             where system.SectorId == sectorId
+                 && system.AllegianceId != ushort.MaxValue
+                 && empire.CivilizationProfile.TechLevel >= 6
+             select system.Id)
+            .Union(
+                from colony in dbContext.Colonies.AsNoTracking()
+                join empire in dbContext.Empires.AsNoTracking() on colony.ControllingEmpireId equals empire.Id
+                join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+                join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                where system.SectorId == sectorId
+                    && colony.ControllingEmpireId.HasValue
+                    && empire.CivilizationProfile.TechLevel >= 6
+                select system.Id)
+            .Union(
+                from colony in dbContext.Colonies.AsNoTracking()
+                join empire in dbContext.Empires.AsNoTracking() on (int)colony.AllegianceId equals empire.Id
+                join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+                join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                where system.SectorId == sectorId
+                    && colony.AllegianceId != ushort.MaxValue
+                    && empire.CivilizationProfile.TechLevel >= 6
+                select system.Id))
+            .Distinct()
+            .OrderBy(id => id)
+            .ToListAsync(cancellationToken);
     }
 
     private static SectorConfiguration CloneSectorConfiguration(SectorConfiguration configuration)

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -355,20 +355,7 @@ public sealed class StarWinExplorerQueryService(
     public async Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
-        if (sectorEntityUsage.EmpireIds.Count == 0)
-        {
-            return [];
-        }
-
-        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
-        return await dbContext.Empires
-            .AsNoTracking()
-            .Where(empire => sectorEmpireIds.Contains(empire.Id))
-            .OrderBy(empire => empire.Name)
-            .ThenBy(empire => empire.Id)
-            .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
-            .ToListAsync(cancellationToken);
+        return await LoadSectorEmpireOptionsAsync(dbContext, sectorId, cancellationToken);
     }
 
     public async Task<ExplorerSystemFilterOptions> LoadSystemFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -765,7 +752,7 @@ public sealed class StarWinExplorerQueryService(
             selectedSystemRouteCount);
     }
 
-    public async Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    public async Task<ExplorerHyperlanePageState?> LoadHyperlanePageStateAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
@@ -821,16 +808,36 @@ public sealed class StarWinExplorerQueryService(
             })
             .ToListAsync(cancellationToken);
 
-        var eligibleSystemIds = await LoadEligibleHyperlaneSystemIdsAsync(dbContext, sectorId, cancellationToken);
-        var empires = await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken);
-        return new ExplorerHyperlaneWorkspace(
+        var savedRouteReport = SectorHyperlaneNetworkReport.Empty;
+        if (savedRoutes.Count > 0)
+        {
+            var eligibleSystemIds = await LoadEligibleHyperlaneSystemIdsAsync(dbContext, sectorId, cancellationToken);
+            if (eligibleSystemIds.Count > 0)
+            {
+                savedRouteReport = SectorRoutePlanner.BuildHyperlaneNetworkReport(
+                    eligibleSystemIds,
+                    savedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
+                        route.SourceSystemId,
+                        route.TargetSystemId,
+                        (double)route.DistanceParsecs,
+                        (double)route.TravelTimeYears,
+                        route.TechnologyLevel,
+                        route.TierName,
+                        route.PrimaryOwnerEmpireId,
+                        route.PrimaryOwnerEmpireName,
+                        route.SecondaryOwnerEmpireId,
+                        route.SecondaryOwnerEmpireName)));
+            }
+        }
+
+        return new ExplorerHyperlanePageState(
             sectorRow.Id,
             sectorRow.Name,
             CloneSectorConfiguration(sectorRow.Configuration),
             systems,
             savedRoutes,
-            eligibleSystemIds,
-            empires);
+            savedRouteReport,
+            await LoadSectorEmpireOptionsAsync(dbContext, sectorId, cancellationToken));
     }
 
     public async Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -2038,6 +2045,27 @@ public sealed class StarWinExplorerQueryService(
                 select system.Id))
             .Distinct()
             .OrderBy(id => id)
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var sectorEntityUsage = await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken);
+        if (sectorEntityUsage.EmpireIds.Count == 0)
+        {
+            return [];
+        }
+
+        var sectorEmpireIds = sectorEntityUsage.EmpireIds;
+        return await dbContext.Empires
+            .AsNoTracking()
+            .Where(empire => sectorEmpireIds.Contains(empire.Id))
+            .OrderBy(empire => empire.Name)
+            .ThenBy(empire => empire.Id)
+            .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
             .ToListAsync(cancellationToken);
     }
 

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -668,6 +668,33 @@ public sealed class StarWinExplorerQueryService(
         return new ExplorerColonyDetail(sectorId, colony, world);
     }
 
+    public async Task<ExplorerHyperlaneSetupState?> LoadHyperlaneSetupAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var setupRow = await dbContext.Sectors
+            .AsNoTracking()
+            .Where(sector => sector.Id == sectorId)
+            .Select(sector => new
+            {
+                sector.Id,
+                sector.Name,
+                sector.Configuration,
+                SavedRouteCount = sector.SavedRoutes.Count
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+        if (setupRow is null)
+        {
+            return null;
+        }
+
+        return new ExplorerHyperlaneSetupState(
+            setupRow.Id,
+            setupRow.Name,
+            CloneSectorConfiguration(setupRow.Configuration),
+            setupRow.SavedRouteCount);
+    }
+
     public async Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);

--- a/StarWin.Infrastructure/Services/StarWinImageService.cs
+++ b/StarWin.Infrastructure/Services/StarWinImageService.cs
@@ -34,6 +34,45 @@ public sealed class StarWinImageService(
             .ToList();
     }
 
+    public async Task<IReadOnlyList<EntityImage>> GetImagesAsync(
+        IReadOnlyCollection<EntityImageTarget> targets,
+        CancellationToken cancellationToken = default)
+    {
+        if (targets.Count == 0)
+        {
+            return [];
+        }
+
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var normalizedTargets = targets
+            .Distinct()
+            .GroupBy(target => target.TargetKind)
+            .ToDictionary(group => group.Key, group => group.Select(target => target.TargetId).Distinct().ToList());
+
+        var images = new List<EntityImage>();
+        foreach (var targetGroup in normalizedTargets)
+        {
+            var targetIds = targetGroup.Value;
+            if (targetIds.Count == 0)
+            {
+                continue;
+            }
+
+            images.AddRange(await dbContext.EntityImages
+                .AsNoTracking()
+                .Where(image => image.TargetKind == targetGroup.Key && targetIds.Contains(image.TargetId))
+                .ToListAsync(cancellationToken));
+        }
+
+        return images
+            .OrderBy(image => image.TargetKind)
+            .ThenBy(image => image.TargetId)
+            .ThenByDescending(image => image.IsPrimary)
+            .ThenBy(image => image.UploadedAt.UtcTicks)
+            .ToList();
+    }
+
     public async Task<EntityImage> UploadImageAsync(
         EntityImageTargetKind targetKind,
         int targetId,

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -26,4 +26,17 @@ public sealed class AppCssTests
         Assert.Contains(".loading-modal.import-loading-modal .loading-progress-detail", css);
         Assert.Contains("min-height: calc(1.45em * 4);", css);
     }
+
+    [Fact]
+    public void HeroOverlayUsesAnIsolatedStackingContext()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
+        var css = File.ReadAllText(cssPath);
+
+        Assert.Contains(".explorer-hero {", css);
+        Assert.Contains("isolation: isolate;", css);
+        Assert.Contains(".explorer-hero::before,", css);
+        Assert.Contains("z-index: 0;", css);
+    }
 }

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -39,4 +39,17 @@ public sealed class AppCssTests
         Assert.Contains(".explorer-hero::before,", css);
         Assert.Contains("z-index: 0;", css);
     }
+
+    [Fact]
+    public void NavigationFocusTargetsMainContentInsteadOfHeading()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var routesPath = Path.Combine(repoRoot, "StarWin.Web", "Components", "Routes.razor");
+        var layoutPath = Path.Combine(repoRoot, "StarWin.Web", "Components", "Layout", "MainLayout.razor");
+        var routesMarkup = File.ReadAllText(routesPath);
+        var layoutMarkup = File.ReadAllText(layoutPath);
+
+        Assert.Contains("FocusOnNavigate RouteData=\"routeData\" Selector=\".site-main\"", routesMarkup);
+        Assert.Contains("<main class=\"site-main\" tabindex=\"-1\">", layoutMarkup);
+    }
 }

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -46,10 +46,14 @@ public sealed class AppCssTests
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var routesPath = Path.Combine(repoRoot, "StarWin.Web", "Components", "Routes.razor");
         var layoutPath = Path.Combine(repoRoot, "StarWin.Web", "Components", "Layout", "MainLayout.razor");
+        var layoutCssPath = Path.Combine(repoRoot, "StarWin.Web", "Components", "Layout", "MainLayout.razor.css");
         var routesMarkup = File.ReadAllText(routesPath);
         var layoutMarkup = File.ReadAllText(layoutPath);
+        var layoutCss = File.ReadAllText(layoutCssPath);
 
         Assert.Contains("FocusOnNavigate RouteData=\"routeData\" Selector=\".site-main\"", routesMarkup);
         Assert.Contains("<main class=\"site-main\" tabindex=\"-1\">", layoutMarkup);
+        Assert.Contains(".site-main:focus,", layoutCss);
+        Assert.Contains("outline: none;", layoutCss);
     }
 }

--- a/StarWin.Web.Tests/Components/ExplorerSectionTabsTests.cs
+++ b/StarWin.Web.Tests/Components/ExplorerSectionTabsTests.cs
@@ -37,4 +37,21 @@ public sealed class ExplorerSectionTabsTests : BunitContext
                 Assert.Null(link.GetAttribute("aria-current"));
             });
     }
+
+    [Fact]
+    public void WiresSectionRouteLoadingHandlerIntoLinks()
+    {
+        var cut = Render<ExplorerSectionTabs>(parameters => parameters
+            .Add(component => component.Sections, ["Overview", "Aliens"])
+            .Add(component => component.ActiveSection, "Overview")
+            .Add(component => component.SectionHrefFactory, section => $"/sector-explorer/{section.ToLowerInvariant()}?sectorId=1"));
+
+        var aliensLink = cut.FindAll("a").Single(link => link.TextContent.Trim() == "Aliens");
+        var onclick = aliensLink.GetAttribute("onclick");
+
+        Assert.NotNull(onclick);
+        Assert.Contains("showSectionRouteLoading", onclick, StringComparison.Ordinal);
+        Assert.Contains("/sector-explorer/aliens?sectorId=1", onclick, StringComparison.Ordinal);
+        Assert.Contains("Aliens", onclick, StringComparison.Ordinal);
+    }
 }

--- a/StarWin.Web.Tests/Components/ExplorerTimelineSectionTests.cs
+++ b/StarWin.Web.Tests/Components/ExplorerTimelineSectionTests.cs
@@ -100,7 +100,7 @@ public sealed class ExplorerTimelineSectionTests : BunitContext
 
         public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0, [], []));
+            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0));
         }
 
         public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Components/ExplorerTimelineSectionTests.cs
+++ b/StarWin.Web.Tests/Components/ExplorerTimelineSectionTests.cs
@@ -103,6 +103,11 @@ public sealed class ExplorerTimelineSectionTests : BunitContext
             return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0, [], []));
         }
 
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [], []));
+        }
+
         public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();

--- a/StarWin.Web.Tests/Components/ExplorerTimelineSectionTests.cs
+++ b/StarWin.Web.Tests/Components/ExplorerTimelineSectionTests.cs
@@ -37,6 +37,48 @@ public sealed class ExplorerTimelineSectionTests : BunitContext
     }
 
     [Fact]
+    public void KeepsEventDetailUnloadedUntilAnEventIsExplicitlySelected()
+    {
+        var queryService = new FakeExplorerQueryService
+        {
+            TimelineDetail = new ExplorerTimelineEventDetail(
+                1,
+                "Border war begins",
+                "War",
+                "Century 1",
+                1,
+                "Border war begins",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null)
+        };
+
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService);
+
+        var cut = Render<ExplorerTimelineSection>(parameters => parameters
+            .Add(component => component.SectorId, 7)
+            .Add(component => component.SectorName, "Del Corra"));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select an event", cut.Markup);
+            Assert.Equal(0, queryService.LoadTimelineEventDetailCallCount);
+        });
+
+        cut.Find(".timeline-event-card-button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Border war begins", cut.Markup);
+            Assert.Equal(1, queryService.LoadTimelineEventDetailCallCount);
+        });
+    }
+
+    [Fact]
     public void TogglesImportDataForSelectedEvent()
     {
         var queryService = new FakeExplorerQueryService
@@ -93,6 +135,7 @@ public sealed class ExplorerTimelineSectionTests : BunitContext
     private sealed class FakeExplorerQueryService : IStarWinExplorerQueryService
     {
         public int LoadTimelineEventTypesCallCount { get; private set; }
+        public int LoadTimelineEventDetailCallCount { get; private set; }
 
         public List<ExplorerTimelinePageRequest> PageRequests { get; } = [];
 
@@ -199,6 +242,7 @@ public sealed class ExplorerTimelineSectionTests : BunitContext
 
         public Task<ExplorerTimelineEventDetail?> LoadTimelineEventDetailAsync(int eventId, CancellationToken cancellationToken = default)
         {
+            LoadTimelineEventDetailCallCount++;
             return Task.FromResult(TimelineDetail);
         }
     }

--- a/StarWin.Web.Tests/Pages/AliensPageTests.cs
+++ b/StarWin.Web.Tests/Pages/AliensPageTests.cs
@@ -476,7 +476,7 @@ public sealed class AliensPageTests : BunitContext
             }
         }
 
-        return new StarWinExplorerContext([sector], sector, races, [empire], []);
+        return new StarWinExplorerContext([sector], sector, races, [empire]);
     }
 
     private static AlienRace CreateRace(int raceId, string name, string appearanceType, string environmentType, bool addMembership = true)
@@ -532,7 +532,7 @@ public sealed class AliensPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/AliensPageTests.cs
+++ b/StarWin.Web.Tests/Pages/AliensPageTests.cs
@@ -550,6 +550,11 @@ public sealed class AliensPageTests : BunitContext
             throw new NotSupportedException();
         }
 
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [], []));
+        }
+
         public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             var races = GetSectorRaces(sectorId);

--- a/StarWin.Web.Tests/Pages/AliensPageTests.cs
+++ b/StarWin.Web.Tests/Pages/AliensPageTests.cs
@@ -49,6 +49,58 @@ public sealed class AliensPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsSelectionPromptUntilRaceIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ConfigureServices(CreateContext());
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/aliens?sectorId=7");
+
+        var cut = Render<Aliens>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a race to load its details.", cut.Markup);
+            Assert.Empty(cut.FindAll(".record-row.active"));
+            Assert.DoesNotContain("Homeworld: Helios", cut.Markup);
+        });
+
+        cut.FindAll(".record-row")
+            .Single(button => button.TextContent.Contains("Aurelian", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Homeworld: Helios", cut.Markup);
+            Assert.Single(cut.FindAll(".record-row.active"));
+            Assert.EndsWith("/sector-explorer/aliens?sectorId=7&systemId=11&raceId=1", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LoadsRequestedRaceDetailOnlyOnceOnInitialRender()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var context = CreateContext();
+        var queryService = new CountingAlienRaceQueryService(context);
+        ConfigureServices(context, queryService: queryService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/aliens?sectorId=7&raceId=1");
+
+        var cut = Render<Aliens>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Homeworld: Helios", cut.Markup);
+            Assert.Equal(1, queryService.AlienRaceDetailLoadCount);
+        });
+    }
+
+    [Fact]
     public void FiltersRacesBySearchQueryAndClearsFilters()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -934,6 +986,17 @@ public sealed class AliensPageTests : BunitContext
                 TargetId = targetId,
                 Markdown = markdown
             });
+        }
+    }
+
+    private sealed class CountingAlienRaceQueryService(StarWinExplorerContext context) : FakeExplorerQueryService(context)
+    {
+        public int AlienRaceDetailLoadCount { get; private set; }
+
+        public override Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
+        {
+            AlienRaceDetailLoadCount++;
+            return base.LoadAlienRaceDetailAsync(sectorId, raceId, cancellationToken);
         }
     }
 }

--- a/StarWin.Web.Tests/Pages/AliensPageTests.cs
+++ b/StarWin.Web.Tests/Pages/AliensPageTests.cs
@@ -361,6 +361,7 @@ public sealed class AliensPageTests : BunitContext
         IReadOnlyList<EntityImage>? images = null,
         IStarWinExplorerQueryService? queryService = null)
     {
+        Services.AddLogging();
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
         Services.AddSingleton(queryService ?? new FakeExplorerQueryService(context));

--- a/StarWin.Web.Tests/Pages/AliensPageTests.cs
+++ b/StarWin.Web.Tests/Pages/AliensPageTests.cs
@@ -532,14 +532,9 @@ public sealed class AliensPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/AppConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/AppConfigurationPageTests.cs
@@ -88,8 +88,6 @@ public sealed class AppConfigurationPageTests : BunitContext
 
         public IReadOnlyList<Empire> Empires => [];
 
-        public IReadOnlyList<EmpireContact> EmpireContacts => [];
-
         public CivilizationGeneratorSettings CivilizationSettings { get; } = new();
 
         public ArmyGeneratorSettings ArmySettings { get; } = new();

--- a/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
@@ -177,7 +177,7 @@ public sealed class ColoniesPageTests : BunitContext
         var empire = new Empire { Id = 2, Name = "Orion Compact" };
         var extraEmpire = new Empire { Id = 3, Name = "Zephyr League" };
 
-        return new StarWinExplorerContext([sector], sector, races, [empire, extraEmpire], []);
+        return new StarWinExplorerContext([sector], sector, races, [empire, extraEmpire]);
     }
 
     private static World CreateWorldWithColony(int worldId, string worldName, int colonyId, string colonyName, int allegianceId, string allegianceName, long population, int raceId = 1, string raceName = "Human")
@@ -215,7 +215,7 @@ public sealed class ColoniesPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
@@ -129,6 +129,7 @@ public sealed class ColoniesPageTests : BunitContext
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());

--- a/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
@@ -33,6 +33,56 @@ public sealed class ColoniesPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsSelectionPromptUntilColonyIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        ConfigureServices(CreateContext());
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/colonies?sectorId=7");
+
+        var cut = Render<Colonies>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a colony to load its details.", cut.Markup);
+            Assert.Empty(cut.FindAll(".record-row.active"));
+            Assert.DoesNotContain("Parent world: Helios", cut.Markup);
+        });
+
+        cut.FindAll(".record-row")
+            .Single(button => button.TextContent.Contains("Helios Prime", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Parent world: Helios", cut.Markup);
+            Assert.Single(cut.FindAll(".record-row.active"));
+            Assert.EndsWith("/sector-explorer/colonies?sectorId=7&systemId=11&colonyId=201", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LoadsRequestedColonyDetailOnlyOnceOnInitialRender()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var context = CreateContext();
+        var queryService = new CountingColonyQueryService(context);
+        ConfigureServices(context, queryService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/colonies?sectorId=7&colonyId=201");
+
+        var cut = Render<Colonies>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Parent world: Helios", cut.Markup);
+            Assert.Equal(1, queryService.ColonyDetailLoadCount);
+        });
+    }
+
+    [Fact]
     public void FiltersColoniesBySearchQueryAndClearsFilters()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -125,11 +175,11 @@ public sealed class ColoniesPageTests : BunitContext
         Assert.EndsWith("/sector-explorer/aliens?sectorId=7&systemId=11&colonyId=201&raceId=1", navigationManager.Uri, StringComparison.Ordinal);
     }
 
-    private void ConfigureServices(StarWinExplorerContext context)
+    private void ConfigureServices(StarWinExplorerContext context, IStarWinExplorerQueryService? queryService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
-        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new ContextBackedExplorerQueryService(context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());
@@ -218,6 +268,49 @@ public sealed class ColoniesPageTests : BunitContext
         public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
+        }
+    }
+
+    private sealed class CountingColonyQueryService(StarWinExplorerContext context) : IStarWinExplorerQueryService
+    {
+        private readonly ContextBackedExplorerQueryService inner = new(context);
+
+        public int ColonyDetailLoadCount { get; private set; }
+
+        public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSectorOverviewAsync(sectorId, cancellationToken);
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSectorEntityUsageAsync(sectorId, cancellationToken);
+        public Task<IReadOnlyList<StarWinSearchResult>> SearchSectorAsync(int sectorId, string query, int maxResults = 30, CancellationToken cancellationToken = default) => inner.SearchSectorAsync(sectorId, query, maxResults, cancellationToken);
+        public Task<int?> ResolveSystemIdAsync(int sectorId, int? worldId = null, int? colonyId = null, int? habitatId = null, CancellationToken cancellationToken = default) => inner.ResolveSystemIdAsync(sectorId, worldId, colonyId, habitatId, cancellationToken);
+        public Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSectorEmpireOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadAlienRaceFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadAlienRaceListPageAsync(request, cancellationToken);
+        public Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default) => inner.LoadAlienRaceListItemAsync(sectorId, raceId, cancellationToken);
+        public Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default) => inner.LoadAlienRaceDetailAsync(sectorId, raceId, cancellationToken);
+        public Task<ExplorerSystemFilterOptions> LoadSystemFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSystemFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerSystemListPage> LoadSystemListPageAsync(ExplorerSystemListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadSystemListPageAsync(request, cancellationToken);
+        public Task<ExplorerSystemListItem?> LoadSystemListItemAsync(int sectorId, int systemId, CancellationToken cancellationToken = default) => inner.LoadSystemListItemAsync(sectorId, systemId, cancellationToken);
+        public Task<ExplorerSystemDetail?> LoadSystemDetailAsync(int sectorId, int systemId, CancellationToken cancellationToken = default) => inner.LoadSystemDetailAsync(sectorId, systemId, cancellationToken);
+        public Task<ExplorerWorldsWorkspace?> LoadWorldsWorkspaceAsync(int sectorId, int systemId, CancellationToken cancellationToken = default) => inner.LoadWorldsWorkspaceAsync(sectorId, systemId, cancellationToken);
+        public Task<ExplorerColonyFilterOptions> LoadColonyFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadColonyFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerColonyListPage> LoadColonyListPageAsync(ExplorerColonyListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadColonyListPageAsync(request, cancellationToken);
+        public Task<ExplorerColonyListItem?> LoadColonyListItemAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default) => inner.LoadColonyListItemAsync(sectorId, colonyId, cancellationToken);
+        public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
+        public Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadEmpireFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadEmpireListPageAsync(request, cancellationToken);
+        public Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default) => inner.LoadEmpireListItemAsync(sectorId, empireId, cancellationToken);
+        public Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default) => inner.LoadEmpireDetailAsync(sectorId, empireId, cancellationToken);
+        public Task<ExplorerReligionFilterOptions> LoadReligionFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadReligionFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerReligionListPage> LoadReligionListPageAsync(ExplorerReligionListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadReligionListPageAsync(request, cancellationToken);
+        public Task<ExplorerReligionListItem?> LoadReligionListItemAsync(int sectorId, int religionId, CancellationToken cancellationToken = default) => inner.LoadReligionListItemAsync(sectorId, religionId, cancellationToken);
+        public Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default) => inner.LoadReligionDetailAsync(sectorId, religionId, cancellationToken);
+        public Task<IReadOnlyList<string>> LoadTimelineEventTypesAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadTimelineEventTypesAsync(sectorId, cancellationToken);
+        public Task<ExplorerTimelinePage> LoadTimelinePageAsync(ExplorerTimelinePageRequest request, CancellationToken cancellationToken = default) => inner.LoadTimelinePageAsync(request, cancellationToken);
+        public Task<ExplorerTimelineEventDetail?> LoadTimelineEventDetailAsync(int eventId, CancellationToken cancellationToken = default) => inner.LoadTimelineEventDetailAsync(eventId, cancellationToken);
+
+        public Task<ExplorerColonyDetail?> LoadColonyDetailAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+        {
+            ColonyDetailLoadCount++;
+            return inner.LoadColonyDetailAsync(sectorId, colonyId, cancellationToken);
         }
     }
 

--- a/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
@@ -214,14 +214,9 @@ public sealed class ColoniesPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ColoniesPageTests.cs
@@ -294,7 +294,7 @@ public sealed class ColoniesPageTests : BunitContext
         public Task<ExplorerColonyFilterOptions> LoadColonyFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadColonyFilterOptionsAsync(sectorId, cancellationToken);
         public Task<ExplorerColonyListPage> LoadColonyListPageAsync(ExplorerColonyListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadColonyListPageAsync(request, cancellationToken);
         public Task<ExplorerColonyListItem?> LoadColonyListItemAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default) => inner.LoadColonyListItemAsync(sectorId, colonyId, cancellationToken);
-        public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
+        public Task<ExplorerHyperlanePageState?> LoadHyperlanePageStateAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadHyperlanePageStateAsync(sectorId, cancellationToken);
         public Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadEmpireFilterOptionsAsync(sectorId, cancellationToken);
         public Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadEmpireListPageAsync(request, cancellationToken);
         public Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default) => inner.LoadEmpireListItemAsync(sectorId, empireId, cancellationToken);

--- a/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
+++ b/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
@@ -11,7 +11,7 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
         var sector = GetSector(sectorId);
         if (sector is null)
         {
-            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0, [], []));
+            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0));
         }
 
         var raceIds = GetRaceIds(sector);
@@ -22,18 +22,7 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
             sector.Systems.SelectMany(system => system.Worlds).Count(),
             sector.Systems.SelectMany(system => system.Worlds).Count(world => world.Colony is not null),
             empireIds.Count,
-            raceIds.Count,
-            sector.Systems
-                .OrderBy(system => system.Name, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(system => system.Id)
-                .Select(system => new ExplorerLookupOption(system.Id, system.Name))
-                .ToList(),
-            context.Empires
-                .Where(empire => empireIds.Contains(empire.Id))
-                .OrderBy(empire => empire.Name, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(empire => empire.Id)
-                .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
-                .ToList()));
+            raceIds.Count));
     }
 
     public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
+++ b/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
@@ -1,0 +1,688 @@
+using StarWin.Application.Services;
+using StarWin.Domain.Model.Entity.Civilization;
+using StarWin.Domain.Model.Entity.StarMap;
+
+namespace StarWin.Web.Tests.Pages;
+
+internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext context) : IStarWinExplorerQueryService
+{
+    public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0, [], []));
+        }
+
+        var raceIds = GetRaceIds(sector);
+        var empireIds = GetEmpireIds(sector);
+        return Task.FromResult(new ExplorerSectorOverviewData(
+            sectorId,
+            sector.Systems.Count,
+            sector.Systems.SelectMany(system => system.Worlds).Count(),
+            sector.Systems.SelectMany(system => system.Worlds).Count(world => world.Colony is not null),
+            empireIds.Count,
+            raceIds.Count,
+            sector.Systems
+                .OrderBy(system => system.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(system => system.Id)
+                .Select(system => new ExplorerLookupOption(system.Id, system.Name))
+                .ToList(),
+            context.Empires
+                .Where(empire => empireIds.Contains(empire.Id))
+                .OrderBy(empire => empire.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(empire => empire.Id)
+                .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
+                .ToList()));
+    }
+
+    public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [], []));
+        }
+
+        return Task.FromResult(new ExplorerSectorEntityUsage(
+            sectorId,
+            GetRaceIds(sector).OrderBy(id => id).ToList(),
+            GetEmpireIds(sector).OrderBy(id => id).ToList()));
+    }
+
+    public Task<IReadOnlyList<StarWinSearchResult>> SearchSectorAsync(int sectorId, string query, int maxResults = 30, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null || string.IsNullOrWhiteSpace(query))
+        {
+            return Task.FromResult<IReadOnlyList<StarWinSearchResult>>([]);
+        }
+
+        var normalizedQuery = query.Trim();
+        var results = new List<StarWinSearchResult>();
+
+        results.AddRange(sector.Systems
+            .Where(system => Matches(normalizedQuery, system.Name, system.Id.ToString(), system.LegacySystemId?.ToString(), GetEmpireName(system.AllegianceId)))
+            .OrderBy(system => system.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(system => system.Id)
+            .Select(system => new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.StarSystem,
+                Title = system.Name,
+                Subtitle = $"System {system.Id}",
+                Tab = "Systems",
+                SectorId = sectorId,
+                SystemId = system.Id
+            }));
+
+        results.AddRange(sector.Systems
+            .SelectMany(system => system.Worlds.Select(world => (system, world)))
+            .Where(item => Matches(normalizedQuery, item.world.Name, item.world.WorldType, item.world.AtmosphereType, item.system.Name, item.world.Id.ToString()))
+            .OrderBy(item => item.world.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.world.Id)
+            .Select(item => new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.World,
+                Title = item.world.Name,
+                Subtitle = item.system.Name,
+                Tab = "Worlds",
+                SectorId = sectorId,
+                SystemId = item.system.Id,
+                WorldId = item.world.Id
+            }));
+
+        results.AddRange(sector.Systems
+            .SelectMany(system => system.Worlds
+                .Where(world => world.Colony is not null)
+                .Select(world => (system, world, colony: world.Colony!)))
+            .Where(item => Matches(
+                normalizedQuery,
+                item.colony.Name,
+                item.colony.ColonyClass,
+                item.colony.AllegianceName,
+                item.colony.ColonistRaceName,
+                item.world.Name,
+                item.colony.Id.ToString()))
+            .OrderBy(item => item.world.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.colony.Id)
+            .Select(item => new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.Colony,
+                Title = string.IsNullOrWhiteSpace(item.colony.Name) ? item.colony.ColonyClass : item.colony.Name,
+                Subtitle = item.world.Name,
+                Tab = "Colonies",
+                SectorId = sectorId,
+                SystemId = item.system.Id,
+                WorldId = item.world.Id,
+                ColonyId = item.colony.Id,
+                RaceId = item.colony.RaceId,
+                EmpireId = item.colony.ControllingEmpireId
+            }));
+
+        results.AddRange(sector.Systems
+            .SelectMany(system => system.SpaceHabitats.Select(habitat => (system, habitat)))
+            .Where(item => Matches(normalizedQuery, item.habitat.Name, item.system.Name, item.habitat.Id.ToString()))
+            .OrderBy(item => item.habitat.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.habitat.Id)
+            .Select(item => new StarWinSearchResult
+            {
+                Type = StarWinSearchResultType.SpaceHabitat,
+                Title = item.habitat.Name,
+                Subtitle = item.system.Name,
+                Tab = "Worlds",
+                SectorId = sectorId,
+                SystemId = item.system.Id,
+                SpaceHabitatId = item.habitat.Id,
+                EmpireId = item.habitat.ControlledByEmpireId
+            }));
+
+        return Task.FromResult<IReadOnlyList<StarWinSearchResult>>(results.Take(maxResults).ToList());
+    }
+
+    public Task<int?> ResolveSystemIdAsync(
+        int sectorId,
+        int? worldId = null,
+        int? colonyId = null,
+        int? habitatId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult<int?>(null);
+        }
+
+        if (colonyId is int requestedColonyId)
+        {
+            var colonySystemId = sector.Systems
+                .FirstOrDefault(system => system.Worlds.Any(world => world.Colony?.Id == requestedColonyId))
+                ?.Id;
+            if (colonySystemId.HasValue)
+            {
+                return Task.FromResult<int?>(colonySystemId.Value);
+            }
+        }
+
+        if (habitatId is int requestedHabitatId)
+        {
+            var habitatSystemId = sector.Systems
+                .FirstOrDefault(system => system.SpaceHabitats.Any(habitat => habitat.Id == requestedHabitatId))
+                ?.Id;
+            if (habitatSystemId.HasValue)
+            {
+                return Task.FromResult<int?>(habitatSystemId.Value);
+            }
+        }
+
+        if (worldId is int requestedWorldId)
+        {
+            var worldSystemId = sector.Systems
+                .FirstOrDefault(system => system.Worlds.Any(world => world.Id == requestedWorldId))
+                ?.Id;
+            if (worldSystemId.HasValue)
+            {
+                return Task.FromResult<int?>(worldSystemId.Value);
+            }
+        }
+
+        return Task.FromResult<int?>(null);
+    }
+
+    public Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult<IReadOnlyList<ExplorerLookupOption>>([]);
+        }
+
+        var empireIds = GetEmpireIds(sector);
+        return Task.FromResult<IReadOnlyList<ExplorerLookupOption>>(context.Empires
+            .Where(empire => empireIds.Contains(empire.Id))
+            .OrderBy(empire => empire.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(empire => empire.Id)
+            .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
+            .ToList());
+    }
+
+    public async Task<ExplorerSystemFilterOptions> LoadSystemFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        return new ExplorerSystemFilterOptions(await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken));
+    }
+
+    public Task<ExplorerSystemListPage> LoadSystemListPageAsync(ExplorerSystemListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(request.SectorId);
+        if (sector is null)
+        {
+            return Task.FromResult(new ExplorerSystemListPage([], false));
+        }
+
+        var query = sector.Systems.AsEnumerable();
+        if (request.EmpireId is int empireId)
+        {
+            query = query.Where(system => system.AllegianceId == empireId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+        {
+            var normalizedQuery = request.Query.Trim();
+            query = query.Where(system => Matches(
+                normalizedQuery,
+                system.Name,
+                system.Id.ToString(),
+                system.LegacySystemId?.ToString(),
+                GetEmpireName(system.AllegianceId),
+                system.AstralBodies.Select(body => body.Classification).ToArray(),
+                system.AstralBodies.Select(body => body.Role.ToString()).ToArray(),
+                system.AstralBodies.Select(body => body.Kind.ToString()).ToArray(),
+                system.Worlds.Select(world => world.Name).ToArray(),
+                system.Worlds.Select(world => world.WorldType).ToArray()));
+        }
+
+        var items = query
+            .OrderBy(system => system.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(system => system.Id)
+            .Select(MapSystemListItem)
+            .Skip(request.Offset)
+            .Take(request.Limit + 1)
+            .ToList();
+
+        var hasMore = items.Count > request.Limit;
+        return Task.FromResult(new ExplorerSystemListPage(items.Take(request.Limit).ToList(), hasMore));
+    }
+
+    public Task<ExplorerSystemListItem?> LoadSystemListItemAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        var system = sector?.Systems.FirstOrDefault(item => item.Id == systemId);
+        return Task.FromResult(system is null ? null : MapSystemListItem(system));
+    }
+
+    public Task<ExplorerSystemDetail?> LoadSystemDetailAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        var system = sector?.Systems.FirstOrDefault(item => item.Id == systemId);
+        return Task.FromResult(system is null ? null : new ExplorerSystemDetail(sectorId, system));
+    }
+
+    public async Task<ExplorerWorldsWorkspace?> LoadWorldsWorkspaceAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        var system = sector?.Systems.FirstOrDefault(item => item.Id == systemId);
+        if (system is null)
+        {
+            return null;
+        }
+
+        return new ExplorerWorldsWorkspace(sectorId, system, await LoadSectorEmpireOptionsAsync(sectorId, cancellationToken));
+    }
+
+    public Task<ExplorerColonyFilterOptions> LoadColonyFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult(new ExplorerColonyFilterOptions([], [], []));
+        }
+
+        var colonyWorlds = sector.Systems
+            .SelectMany(system => system.Worlds)
+            .Where(world => world.Colony is not null)
+            .ToList();
+
+        var colonyRaceIds = colonyWorlds
+            .SelectMany(world => world.Colony is null
+                ? []
+                : world.Colony.Demographics.Count == 0
+                    ? [world.Colony.RaceId]
+                    : world.Colony.Demographics.Select(demographic => (int)demographic.RaceId))
+            .Where(id => id > 0)
+            .Distinct()
+            .ToHashSet();
+
+        var races = context.AlienRaces
+            .Where(race => colonyRaceIds.Contains(race.Id))
+            .OrderBy(race => race.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(race => race.Id)
+            .Select(race => new ExplorerLookupOption(race.Id, race.Name))
+            .ToList();
+
+        var empireIds = GetEmpireIds(sector);
+        var empires = context.Empires
+            .Where(empire => empireIds.Contains(empire.Id))
+            .OrderBy(empire => empire.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(empire => empire.Id)
+            .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
+            .ToList();
+
+        var classes = colonyWorlds
+            .Select(world => world.Colony?.ColonyClass)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return Task.FromResult(new ExplorerColonyFilterOptions(races, empires, classes));
+    }
+
+    public Task<ExplorerColonyListPage> LoadColonyListPageAsync(ExplorerColonyListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(request.SectorId);
+        if (sector is null)
+        {
+            return Task.FromResult(new ExplorerColonyListPage([], false));
+        }
+
+        var query = sector.Systems
+            .SelectMany(system => system.Worlds
+                .Where(world => world.Colony is not null)
+                .Select(world => new { System = system, World = world, Colony = world.Colony! }))
+            .AsEnumerable();
+
+        if (request.RaceId is int raceId)
+        {
+            query = query.Where(item =>
+                item.Colony.RaceId == raceId
+                || item.Colony.Demographics.Any(demographic => demographic.RaceId == raceId));
+        }
+
+        if (request.EmpireId is int empireId)
+        {
+            query = query.Where(item =>
+                item.Colony.AllegianceId == empireId
+                || item.Colony.ControllingEmpireId == empireId
+                || item.Colony.FoundingEmpireId == empireId
+                || item.Colony.ParentEmpireId == empireId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Status)
+            && Enum.TryParse<ColonyPoliticalStatus>(request.Status.Trim(), true, out var politicalStatus))
+        {
+            query = query.Where(item => item.Colony.PoliticalStatus == politicalStatus);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ColonyClass))
+        {
+            var colonyClass = request.ColonyClass.Trim();
+            query = query.Where(item => string.Equals(item.Colony.ColonyClass, colonyClass, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+        {
+            var normalizedQuery = request.Query.Trim();
+            query = query.Where(item => Matches(
+                normalizedQuery,
+                item.World.Name,
+                item.World.WorldType,
+                item.Colony.Name,
+                item.Colony.ColonyClass,
+                item.Colony.ColonistRaceName,
+                item.Colony.AllegianceName,
+                item.Colony.Starport,
+                item.Colony.GovernmentType,
+                item.Colony.ExportResource,
+                item.Colony.ImportResource,
+                item.Colony.Id.ToString(),
+                item.Colony.WorldId.ToString(),
+                item.Colony.Demographics.Select(demographic => demographic.RaceName).ToArray()));
+        }
+
+        var items = query
+            .OrderByDescending(item => item.Colony.EstimatedPopulation)
+            .ThenBy(item => item.World.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.Colony.Id)
+            .Select(item => new ExplorerColonyListItem(
+                item.Colony.Id,
+                item.World.Id,
+                item.System.Id,
+                string.IsNullOrWhiteSpace(item.Colony.Name) ? item.Colony.ColonyClass : item.Colony.Name,
+                item.World.Name,
+                item.Colony.AllegianceName,
+                item.Colony.EstimatedPopulation))
+            .Skip(request.Offset)
+            .Take(request.Limit + 1)
+            .ToList();
+
+        var hasMore = items.Count > request.Limit;
+        return Task.FromResult(new ExplorerColonyListPage(items.Take(request.Limit).ToList(), hasMore));
+    }
+
+    public Task<ExplorerColonyListItem?> LoadColonyListItemAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        var match = sector?.Systems
+            .SelectMany(system => system.Worlds
+                .Where(world => world.Colony?.Id == colonyId)
+                .Select(world => new { System = system, World = world, Colony = world.Colony! }))
+            .FirstOrDefault();
+
+        return Task.FromResult(match is null
+            ? null
+            : new ExplorerColonyListItem(
+                match.Colony.Id,
+                match.World.Id,
+                match.System.Id,
+                string.IsNullOrWhiteSpace(match.Colony.Name) ? match.Colony.ColonyClass : match.Colony.Name,
+                match.World.Name,
+                match.Colony.AllegianceName,
+                match.Colony.EstimatedPopulation));
+    }
+
+    public Task<ExplorerColonyDetail?> LoadColonyDetailAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        var match = sector?.Systems
+            .SelectMany(system => system.Worlds
+                .Where(world => world.Colony?.Id == colonyId)
+                .Select(world => new { World = world, Colony = world.Colony! }))
+            .FirstOrDefault();
+
+        return Task.FromResult(match is null ? null : new ExplorerColonyDetail(sectorId, match.Colony, match.World));
+    }
+
+    public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult<ExplorerHyperlaneWorkspace?>(null);
+        }
+
+        var systems = sector.Systems
+            .OrderBy(system => system.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(system => system.Id)
+            .Select(system => new ExplorerHyperlaneSystem(
+                system.Id,
+                system.LegacySystemId,
+                system.Name,
+                system.Coordinates,
+                system.AllegianceId))
+            .ToList();
+
+        var savedRoutes = sector.SavedRoutes
+            .OrderBy(route => route.SourceSystemId)
+            .ThenBy(route => route.TargetSystemId)
+            .ThenBy(route => route.Id)
+            .Select(CloneRoute)
+            .ToList();
+
+        return Task.FromResult<ExplorerHyperlaneWorkspace?>(new ExplorerHyperlaneWorkspace(
+            sector.Id,
+            sector.Name,
+            sector.Configuration ?? new SectorConfiguration { SectorId = sector.Id },
+            systems,
+            savedRoutes,
+            systems.Select(system => system.SystemId).ToList(),
+            context.Empires
+                .OrderBy(empire => empire.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(empire => empire.Id)
+                .Select(empire => new ExplorerLookupOption(empire.Id, empire.Name))
+                .ToList()));
+    }
+
+    public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerReligionFilterOptions> LoadReligionFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerReligionListPage> LoadReligionListPageAsync(ExplorerReligionListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerReligionListItem?> LoadReligionListItemAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<IReadOnlyList<string>> LoadTimelineEventTypesAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerTimelinePage> LoadTimelinePageAsync(ExplorerTimelinePageRequest request, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<ExplorerTimelineEventDetail?> LoadTimelineEventDetailAsync(int eventId, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException();
+    }
+
+    private static SectorSavedRoute CloneRoute(SectorSavedRoute route)
+    {
+        return new SectorSavedRoute
+        {
+            Id = route.Id,
+            SectorId = route.SectorId,
+            SourceSystemId = route.SourceSystemId,
+            TargetSystemId = route.TargetSystemId,
+            DistanceParsecs = route.DistanceParsecs,
+            TravelTimeYears = route.TravelTimeYears,
+            TechnologyLevel = route.TechnologyLevel,
+            TierName = route.TierName,
+            PrimaryOwnerEmpireId = route.PrimaryOwnerEmpireId,
+            PrimaryOwnerEmpireName = route.PrimaryOwnerEmpireName,
+            SecondaryOwnerEmpireId = route.SecondaryOwnerEmpireId,
+            SecondaryOwnerEmpireName = route.SecondaryOwnerEmpireName,
+            IsUserPersisted = route.IsUserPersisted,
+            GeneratedAtUtc = route.GeneratedAtUtc
+        };
+    }
+
+    private static bool Matches(string query, params object?[] values)
+    {
+        foreach (var value in values)
+        {
+            switch (value)
+            {
+                case null:
+                    continue;
+                case string text when !string.IsNullOrWhiteSpace(text)
+                    && text.Contains(query, StringComparison.OrdinalIgnoreCase):
+                    return true;
+                case IEnumerable<string?> valueSet:
+                    foreach (var text in valueSet)
+                    {
+                        if (!string.IsNullOrWhiteSpace(text)
+                            && text.Contains(query, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    private HashSet<int> GetRaceIds(StarWinSector sector)
+    {
+        return sector.Systems
+            .SelectMany(system => system.Worlds)
+            .Where(world => world.Colony is not null)
+            .SelectMany(world => world.Colony!.Demographics.Count == 0
+                ? [world.Colony.RaceId]
+                : world.Colony.Demographics.Select(demographic => (int)demographic.RaceId))
+            .Where(id => id > 0)
+            .ToHashSet();
+    }
+
+    private HashSet<int> GetEmpireIds(StarWinSector sector)
+    {
+        var empireIds = new HashSet<int>();
+
+        foreach (var system in sector.Systems)
+        {
+            if (system.AllegianceId > 0 && system.AllegianceId != ushort.MaxValue)
+            {
+                empireIds.Add(system.AllegianceId);
+            }
+
+            foreach (var world in system.Worlds)
+            {
+                if (world.Colony is not Colony colony)
+                {
+                    continue;
+                }
+
+                AddEmpireId(empireIds, colony.AllegianceId);
+                AddEmpireId(empireIds, colony.ControllingEmpireId);
+                AddEmpireId(empireIds, colony.FoundingEmpireId);
+                AddEmpireId(empireIds, colony.ParentEmpireId);
+            }
+
+            foreach (var habitat in system.SpaceHabitats)
+            {
+                AddEmpireId(empireIds, habitat.ControlledByEmpireId);
+                AddEmpireId(empireIds, habitat.BuiltByEmpireId);
+            }
+        }
+
+        return empireIds;
+    }
+
+    private static void AddEmpireId(ISet<int> empireIds, int? empireId)
+    {
+        if (empireId is > 0 and not ushort.MaxValue)
+        {
+            empireIds.Add(empireId.Value);
+        }
+    }
+
+    private StarWinSector? GetSector(int sectorId)
+    {
+        return context.Sectors.FirstOrDefault(sector => sector.Id == sectorId);
+    }
+
+    private ExplorerSystemListItem MapSystemListItem(StarSystem system)
+    {
+        return new ExplorerSystemListItem(
+            system.Id,
+            system.LegacySystemId,
+            system.Name,
+            system.Coordinates,
+            system.AllegianceId,
+            GetEmpireName(system.AllegianceId));
+    }
+
+    private string GetEmpireName(int? empireId)
+    {
+        if (empireId is not > 0 || empireId == ushort.MaxValue)
+        {
+            return "Independent";
+        }
+
+        return context.Empires.FirstOrDefault(empire => empire.Id == empireId)?.Name
+            ?? empireId.Value.ToString();
+    }
+}

--- a/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
+++ b/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
@@ -8,6 +8,7 @@ namespace StarWin.Web.Tests.Pages;
 internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext context) : IStarWinExplorerQueryService
 {
     public int HyperlaneWorkspaceLoadCount { get; private set; }
+    public int HyperlanePageStateLoadCount { get; private set; }
     public int SectorConfigurationStateLoadCount { get; private set; }
 
     public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -485,13 +486,13 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
             selectedSystemRouteCount));
     }
 
-    public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    public Task<ExplorerHyperlanePageState?> LoadHyperlanePageStateAsync(int sectorId, CancellationToken cancellationToken = default)
     {
-        HyperlaneWorkspaceLoadCount++;
+        HyperlanePageStateLoadCount++;
         var sector = GetSector(sectorId);
         if (sector is null)
         {
-            return Task.FromResult<ExplorerHyperlaneWorkspace?>(null);
+            return Task.FromResult<ExplorerHyperlanePageState?>(null);
         }
 
         var systems = sector.Systems
@@ -512,13 +513,27 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
             .Select(CloneRoute)
             .ToList();
 
-        return Task.FromResult<ExplorerHyperlaneWorkspace?>(new ExplorerHyperlaneWorkspace(
+        var routeReport = SectorRoutePlanner.BuildHyperlaneNetworkReport(
+            systems.Select(system => system.SystemId),
+            savedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
+                route.SourceSystemId,
+                route.TargetSystemId,
+                (double)route.DistanceParsecs,
+                (double)route.TravelTimeYears,
+                route.TechnologyLevel,
+                route.TierName,
+                route.PrimaryOwnerEmpireId,
+                route.PrimaryOwnerEmpireName,
+                route.SecondaryOwnerEmpireId,
+                route.SecondaryOwnerEmpireName)));
+
+        return Task.FromResult<ExplorerHyperlanePageState?>(new ExplorerHyperlanePageState(
             sector.Id,
             sector.Name,
             sector.Configuration ?? new SectorConfiguration { SectorId = sector.Id },
             systems,
             savedRoutes,
-            systems.Select(system => system.SystemId).ToList(),
+            routeReport,
             context.Empires
                 .OrderBy(empire => empire.Name, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(empire => empire.Id)

--- a/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
+++ b/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
@@ -431,6 +431,18 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
         return Task.FromResult(match is null ? null : new ExplorerColonyDetail(sectorId, match.Colony, match.World));
     }
 
+    public Task<ExplorerHyperlaneSetupState?> LoadHyperlaneSetupAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        var sector = GetSector(sectorId);
+        return Task.FromResult(sector is null
+            ? null
+            : new ExplorerHyperlaneSetupState(
+                sector.Id,
+                sector.Name,
+                CloneConfiguration(sector.Configuration ?? new SectorConfiguration { SectorId = sector.Id }),
+                sector.SavedRoutes.Count));
+    }
+
     public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         var sector = GetSector(sectorId);
@@ -564,6 +576,38 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
             SecondaryOwnerEmpireName = route.SecondaryOwnerEmpireName,
             IsUserPersisted = route.IsUserPersisted,
             GeneratedAtUtc = route.GeneratedAtUtc
+        };
+    }
+
+    private static SectorConfiguration CloneConfiguration(SectorConfiguration configuration)
+    {
+        return new SectorConfiguration
+        {
+            SectorId = configuration.SectorId,
+            OffLaneMaximumDistanceParsecs = configuration.OffLaneMaximumDistanceParsecs,
+            Tl9AndBelowMaximumConnectionsPerSystem = configuration.Tl9AndBelowMaximumConnectionsPerSystem,
+            AdditionalCrossEmpireConnectionsPerSystem = configuration.AdditionalCrossEmpireConnectionsPerSystem,
+            Tl6HyperlaneName = configuration.Tl6HyperlaneName,
+            Tl6MaximumDistanceParsecs = configuration.Tl6MaximumDistanceParsecs,
+            Tl6OffLaneSpeedMultiplier = configuration.Tl6OffLaneSpeedMultiplier,
+            Tl6HyperlaneSpeedModifier = configuration.Tl6HyperlaneSpeedModifier,
+            Tl7HyperlaneName = configuration.Tl7HyperlaneName,
+            Tl7MaximumDistanceParsecs = configuration.Tl7MaximumDistanceParsecs,
+            Tl7OffLaneSpeedMultiplier = configuration.Tl7OffLaneSpeedMultiplier,
+            Tl7HyperlaneSpeedModifier = configuration.Tl7HyperlaneSpeedModifier,
+            Tl8HyperlaneName = configuration.Tl8HyperlaneName,
+            Tl8MaximumDistanceParsecs = configuration.Tl8MaximumDistanceParsecs,
+            Tl8OffLaneSpeedMultiplier = configuration.Tl8OffLaneSpeedMultiplier,
+            Tl8HyperlaneSpeedModifier = configuration.Tl8HyperlaneSpeedModifier,
+            Tl9HyperlaneName = configuration.Tl9HyperlaneName,
+            Tl9MaximumDistanceParsecs = configuration.Tl9MaximumDistanceParsecs,
+            Tl9OffLaneSpeedMultiplier = configuration.Tl9OffLaneSpeedMultiplier,
+            Tl9HyperlaneSpeedModifier = configuration.Tl9HyperlaneSpeedModifier,
+            Tl10HyperlaneName = configuration.Tl10HyperlaneName,
+            Tl10MaximumDistanceParsecs = configuration.Tl10MaximumDistanceParsecs,
+            Tl10OffLaneSpeedMultiplier = configuration.Tl10OffLaneSpeedMultiplier,
+            Tl10HyperlaneSpeedModifier = configuration.Tl10HyperlaneSpeedModifier,
+            UpdatedAtUtc = configuration.UpdatedAtUtc
         };
     }
 

--- a/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
+++ b/StarWin.Web.Tests/Pages/ContextBackedExplorerQueryService.cs
@@ -1,11 +1,15 @@
 using StarWin.Application.Services;
 using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.StarMap;
+using StarWin.Domain.Services;
 
 namespace StarWin.Web.Tests.Pages;
 
 internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext context) : IStarWinExplorerQueryService
 {
+    public int HyperlaneWorkspaceLoadCount { get; private set; }
+    public int SectorConfigurationStateLoadCount { get; private set; }
+
     public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         var sector = GetSector(sectorId);
@@ -443,8 +447,47 @@ internal sealed class ContextBackedExplorerQueryService(StarWinExplorerContext c
                 sector.SavedRoutes.Count));
     }
 
+    public Task<ExplorerSectorConfigurationState?> LoadSectorConfigurationStateAsync(int sectorId, int? systemId = null, CancellationToken cancellationToken = default)
+    {
+        SectorConfigurationStateLoadCount++;
+        var sector = GetSector(sectorId);
+        if (sector is null)
+        {
+            return Task.FromResult<ExplorerSectorConfigurationState?>(null);
+        }
+
+        var routeReport = SectorRoutePlanner.BuildHyperlaneNetworkReport(
+            sector.Systems.Select(system => system.Id),
+            sector.SavedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
+                route.SourceSystemId,
+                route.TargetSystemId,
+                (double)route.DistanceParsecs,
+                (double)route.TravelTimeYears,
+                route.TechnologyLevel,
+                route.TierName,
+                route.PrimaryOwnerEmpireId,
+                route.PrimaryOwnerEmpireName,
+                route.SecondaryOwnerEmpireId,
+                route.SecondaryOwnerEmpireName)));
+
+        var selectedSystemRouteCount = systemId is int requestedSystemId and > 0
+            ? sector.SavedRoutes.Count(route =>
+                route.SourceSystemId == requestedSystemId
+                || route.TargetSystemId == requestedSystemId)
+            : 0;
+
+        return Task.FromResult<ExplorerSectorConfigurationState?>(new ExplorerSectorConfigurationState(
+            sector.Id,
+            sector.Name,
+            CloneConfiguration(sector.Configuration ?? new SectorConfiguration { SectorId = sector.Id }),
+            sector.SavedRoutes.Count,
+            routeReport,
+            selectedSystemRouteCount));
+    }
+
     public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
     {
+        HyperlaneWorkspaceLoadCount++;
         var sector = GetSector(sectorId);
         if (sector is null)
         {

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -938,14 +938,9 @@ public sealed class EmpiresPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -854,7 +854,7 @@ public sealed class EmpiresPageTests : BunitContext
             empires.AddRange(additionalEmpires);
         }
 
-        return new StarWinExplorerContext([sector], sector, races, empires, []);
+        return new StarWinExplorerContext([sector], sector, races, empires);
     }
 
     private static World CreateWorld(
@@ -938,7 +938,7 @@ public sealed class EmpiresPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -36,6 +36,58 @@ public sealed class EmpiresPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsSelectionPromptUntilEmpireIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ConfigureServices(CreateContext());
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/empires?sectorId=7");
+
+        var cut = Render<Empires>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select an empire to load its details.", cut.Markup);
+            Assert.Empty(cut.FindAll(".record-row.active"));
+            Assert.DoesNotContain("Homeworld: Helios", cut.Markup);
+        });
+
+        cut.FindAll(".record-row")
+            .Single(button => button.TextContent.Contains("Orion Compact", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Homeworld: Helios", cut.Markup);
+            Assert.Single(cut.FindAll(".record-row.active"));
+            Assert.EndsWith("/sector-explorer/empires?sectorId=7&systemId=11&empireId=2", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LoadsRequestedEmpireDetailOnlyOnceOnInitialRender()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var context = CreateContext();
+        var queryService = new CountingEmpireQueryService(context, new Dictionary<(EntityNoteTargetKind, int), EntityNote>());
+        ConfigureServices(context, queryService: queryService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/empires?sectorId=7&empireId=2");
+
+        var cut = Render<Empires>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Homeworld: Helios", cut.Markup);
+            Assert.Equal(1, queryService.EmpireDetailLoadCount);
+        });
+    }
+
+    [Fact]
     public void FiltersEmpiresBySummarySearchAndClearsFilters()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -1441,6 +1493,20 @@ public sealed class EmpiresPageTests : BunitContext
                 TargetId = targetId,
                 Markdown = markdown
             });
+        }
+    }
+
+    private sealed class CountingEmpireQueryService(
+        StarWinExplorerContext context,
+        IReadOnlyDictionary<(EntityNoteTargetKind TargetKind, int TargetId), EntityNote> notes)
+        : FakeExplorerQueryService(context, notes)
+    {
+        public int EmpireDetailLoadCount { get; private set; }
+
+        public override Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
+        {
+            EmpireDetailLoadCount++;
+            return base.LoadEmpireDetailAsync(sectorId, empireId, cancellationToken);
         }
     }
 }

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -958,6 +958,11 @@ public sealed class EmpiresPageTests : BunitContext
             throw new NotSupportedException();
         }
 
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [], []));
+        }
+
         public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -189,14 +189,14 @@ public sealed class HyperlanesPageTests : BunitContext
             new Empire { Id = 3, Name = "Zephyr League" }
         };
 
-        return new StarWinExplorerContext([sector], sector, [], empires, []);
+        return new StarWinExplorerContext([sector], sector, [], empires);
     }
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
         public StarWinExplorerContext Context { get; } = context;
 
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Context);
         }

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -17,7 +17,8 @@ public sealed class HyperlanesPageTests : BunitContext
     public void RendersRequestedHyperlaneInDedicatedPage()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        ConfigureServices(CreateContext());
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/hyperlanes?sectorId=7&systemId=11&hyperlaneId=2");
@@ -32,6 +33,7 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Contains("TL8 Advanced Hyperlane - 2.5 pc - 4 Months, 28 Days", cut.Markup);
             Assert.Contains("Advanced Hyperlane", cut.Markup);
             Assert.Contains("Orion Compact + Zephyr League", cut.Markup);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -39,7 +41,8 @@ public sealed class HyperlanesPageTests : BunitContext
     public void LoadMoreRevealsAdditionalHyperlanes()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        ConfigureServices(CreateContext(routeCount: 121));
+        var explorerContextService = new FakeExplorerContextService(CreateContext(routeCount: 121));
+        ConfigureServices(explorerContextService);
 
         var cut = Render<Hyperlanes>();
 
@@ -55,6 +58,7 @@ public sealed class HyperlanesPageTests : BunitContext
         {
             Assert.Contains("Showing 121 saved hyperlanes", cut.Markup);
             Assert.Equal(121, cut.FindAll(".hyperlane-record").Count);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -64,7 +68,8 @@ public sealed class HyperlanesPageTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
         var routeService = new FakeSectorRouteService();
         var context = CreateContext();
-        ConfigureServices(context, routeService);
+        var explorerContextService = new FakeExplorerContextService(context);
+        ConfigureServices(explorerContextService, routeService);
 
         var cut = Render<Hyperlanes>();
         cut.FindAll("button").Single(button => button.TextContent.Trim() == "New draft").Click();
@@ -77,6 +82,7 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Equal("Manual Lane", routeService.LastSaveRequest?.TierName);
             Assert.Contains("Created saved hyperlane.", cut.Markup);
             Assert.Contains("Manual Lane", cut.Markup);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -86,7 +92,8 @@ public sealed class HyperlanesPageTests : BunitContext
         JSInterop.Mode = JSRuntimeMode.Loose;
         var routeService = new FakeSectorRouteService();
         var context = CreateContext();
-        ConfigureServices(context, routeService);
+        var explorerContextService = new FakeExplorerContextService(context);
+        ConfigureServices(explorerContextService, routeService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/hyperlanes?sectorId=7&systemId=11&hyperlaneId=2");
@@ -101,6 +108,7 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Equal(2, routeService.DeletedRouteId);
             Assert.Contains("Deleted saved hyperlane.", cut.Markup);
             Assert.DoesNotContain(cut.FindAll(".hyperlane-record").Select(button => button.TextContent), text => text.Contains("Advanced Hyperlane", StringComparison.Ordinal));
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -108,7 +116,8 @@ public sealed class HyperlanesPageTests : BunitContext
     public void OpensSectorConfigurationFromHyperlanesPage()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        ConfigureServices(CreateContext());
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/hyperlanes?sectorId=7&systemId=11");
@@ -117,15 +126,16 @@ public sealed class HyperlanesPageTests : BunitContext
         cut.FindAll("button").Single(button => button.TextContent.Trim() == "Open sector configuration").Click();
 
         Assert.EndsWith("/sector-explorer/configuration?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
+        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
-    private void ConfigureServices(StarWinExplorerContext context, FakeSectorRouteService? routeService = null)
+    private void ConfigureServices(FakeExplorerContextService explorerContextService, FakeSectorRouteService? routeService = null)
     {
         var activeRouteService = routeService ?? new FakeSectorRouteService();
-        activeRouteService.Context = context;
+        activeRouteService.Context = explorerContextService.Context;
 
         Services.AddScoped<SectorExplorerLayoutStateStore>();
-        Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
+        Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorRouteService>(activeRouteService);
         Services.AddSingleton<IStarWinEntityNoteService>(new FakeEntityNoteService());
@@ -188,14 +198,18 @@ public sealed class HyperlanesPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
+        public StarWinExplorerContext Context { get; } = context;
+        public int LoadSectorAsyncCallCount { get; private set; }
+
         public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(context);
+            return Task.FromResult(Context);
         }
 
         public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
+            LoadSectorAsyncCallCount++;
+            return Task.FromResult<StarWinSector?>(Context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -33,7 +33,6 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Contains("TL8 Advanced Hyperlane - 2.5 pc - 4 Months, 28 Days", cut.Markup);
             Assert.Contains("Advanced Hyperlane", cut.Markup);
             Assert.Contains("Orion Compact + Zephyr League", cut.Markup);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -58,7 +57,6 @@ public sealed class HyperlanesPageTests : BunitContext
         {
             Assert.Contains("Showing 121 saved hyperlanes", cut.Markup);
             Assert.Equal(121, cut.FindAll(".hyperlane-record").Count);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -82,7 +80,6 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Equal("Manual Lane", routeService.LastSaveRequest?.TierName);
             Assert.Contains("Created saved hyperlane.", cut.Markup);
             Assert.Contains("Manual Lane", cut.Markup);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -108,7 +105,6 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Equal(2, routeService.DeletedRouteId);
             Assert.Contains("Deleted saved hyperlane.", cut.Markup);
             Assert.DoesNotContain(cut.FindAll(".hyperlane-record").Select(button => button.TextContent), text => text.Contains("Advanced Hyperlane", StringComparison.Ordinal));
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -126,7 +122,6 @@ public sealed class HyperlanesPageTests : BunitContext
         cut.FindAll("button").Single(button => button.TextContent.Trim() == "Open sector configuration").Click();
 
         Assert.EndsWith("/sector-explorer/configuration?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
-        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
     private void ConfigureServices(FakeExplorerContextService explorerContextService, FakeSectorRouteService? routeService = null)
@@ -199,17 +194,10 @@ public sealed class HyperlanesPageTests : BunitContext
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
         public StarWinExplorerContext Context { get; } = context;
-        public int LoadSectorAsyncCallCount { get; private set; }
 
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            LoadSectorAsyncCallCount++;
-            return Task.FromResult<StarWinSector?>(Context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -131,6 +131,7 @@ public sealed class HyperlanesPageTests : BunitContext
 
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
+        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(explorerContextService.Context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorRouteService>(activeRouteService);
         Services.AddSingleton<IStarWinEntityNoteService>(new FakeEntityNoteService());

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -69,6 +69,23 @@ public sealed class HyperlanesPageTests : BunitContext
     }
 
     [Fact]
+    public void SavedRouteFlowUsesPageStateWithoutLoadingLegacyWorkspace()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        var queryService = ConfigureServices(explorerContextService);
+
+        var cut = Render<Hyperlanes>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Showing 2 saved hyperlanes", cut.Markup);
+            Assert.Equal(0, queryService.HyperlaneWorkspaceLoadCount);
+            Assert.True(queryService.HyperlanePageStateLoadCount > 0);
+        });
+    }
+
+    [Fact]
     public void LoadMoreRevealsAdditionalHyperlanes()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -225,17 +242,19 @@ public sealed class HyperlanesPageTests : BunitContext
         });
     }
 
-    private void ConfigureServices(FakeExplorerContextService explorerContextService, FakeSectorRouteService? routeService = null)
+    private ContextBackedExplorerQueryService ConfigureServices(FakeExplorerContextService explorerContextService, FakeSectorRouteService? routeService = null)
     {
         var activeRouteService = routeService ?? new FakeSectorRouteService();
         activeRouteService.Context = explorerContextService.Context;
+        var queryService = new ContextBackedExplorerQueryService(explorerContextService.Context);
 
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
-        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(explorerContextService.Context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService);
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorRouteService>(activeRouteService);
         Services.AddSingleton<IStarWinEntityNoteService>(new FakeEntityNoteService());
+        return queryService;
     }
 
     private static StarWinExplorerContext CreateContext(int routeCount = 2)

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -158,6 +158,50 @@ public sealed class HyperlanesPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsGenerationGateWhenSectorHasNoSavedHyperlanes()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var explorerContextService = new FakeExplorerContextService(CreateContext(routeCount: 0));
+        ConfigureServices(explorerContextService);
+
+        var cut = Render<Hyperlanes>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("This page unlocks after you generate the saved hyperlane cache for this sector.", cut.Markup);
+            Assert.Contains("Generate hyperlanes", cut.Markup);
+            Assert.Contains("Open sector configuration", cut.Markup);
+            Assert.Contains("Basic Hyperlane up to 1 pc", cut.Markup);
+            Assert.DoesNotContain("Add hyperlane", cut.Markup);
+            Assert.DoesNotContain("Create saved hyperlane", cut.Markup);
+            Assert.Empty(cut.FindAll(".hyperlane-record"));
+        });
+    }
+
+    [Fact]
+    public void GenerateHyperlanesUnlocksPageWhenNoSavedHyperlanesExist()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var routeService = new FakeSectorRouteService();
+        var context = CreateContext(routeCount: 0);
+        var explorerContextService = new FakeExplorerContextService(context);
+        ConfigureServices(explorerContextService, routeService);
+
+        var cut = Render<Hyperlanes>();
+        cut.WaitForAssertion(() => Assert.Contains("Generate hyperlanes", cut.Markup));
+
+        cut.FindAll("button").Single(button => button.TextContent.Trim() == "Generate hyperlanes").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(routeService.SaveCurrentRoutesCalled);
+            Assert.Contains("Showing 1 saved hyperlane", cut.Markup);
+            Assert.Contains("Create saved hyperlane", cut.Markup);
+            Assert.Contains("Saved 1 hyperlane segment for Del Corra.", cut.Markup);
+        });
+    }
+
+    [Fact]
     public void NewDraftClearsExplicitHyperlaneSelectionFromRoute()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -197,7 +241,8 @@ public sealed class HyperlanesPageTests : BunitContext
     private static StarWinExplorerContext CreateContext(int routeCount = 2)
     {
         var systems = new List<StarSystem>();
-        for (var index = 0; index <= routeCount; index++)
+        var systemCount = Math.Max(routeCount + 1, 2);
+        for (var index = 0; index < systemCount; index++)
         {
             systems.Add(new StarSystem
             {
@@ -214,7 +259,28 @@ public sealed class HyperlanesPageTests : BunitContext
             });
         }
 
-        var sector = new StarWinSector { Id = 7, Name = "Del Corra" };
+        var sector = new StarWinSector
+        {
+            Id = 7,
+            Name = "Del Corra",
+            Configuration = new StarWin.Domain.Model.Entity.StarMap.SectorConfiguration
+            {
+                SectorId = 7,
+                OffLaneMaximumDistanceParsecs = 2.5m,
+                Tl9AndBelowMaximumConnectionsPerSystem = 4,
+                AdditionalCrossEmpireConnectionsPerSystem = 1,
+                Tl6HyperlaneName = "Basic Hyperlane",
+                Tl6MaximumDistanceParsecs = 1.0m,
+                Tl7HyperlaneName = "Enhanced Hyperlane",
+                Tl7MaximumDistanceParsecs = 1.2m,
+                Tl8HyperlaneName = "Advanced Hyperlane",
+                Tl8MaximumDistanceParsecs = 1.4m,
+                Tl9HyperlaneName = "Prime Hyperlane",
+                Tl9MaximumDistanceParsecs = 1.6m,
+                Tl10HyperlaneName = "Ascendant Hyperlane",
+                Tl10MaximumDistanceParsecs = -1m
+            }
+        };
         foreach (var system in systems)
         {
             sector.Systems.Add(system);
@@ -286,12 +352,62 @@ public sealed class HyperlanesPageTests : BunitContext
     {
         public StarWinExplorerContext Context { get; set; } = StarWinExplorerContext.Empty;
         public bool SaveCalled { get; private set; }
+        public bool SaveCurrentRoutesCalled { get; private set; }
         public SectorManualRouteSaveRequest? LastSaveRequest { get; private set; }
         public int DeletedRouteId { get; private set; }
 
         public Task<SectorRouteSaveResult> SaveCurrentRoutesAsync(int sectorId, IProgress<SectorRouteSaveProgress>? progress = null, CancellationToken cancellationToken = default)
         {
-            throw new NotSupportedException();
+            SaveCurrentRoutesCalled = true;
+            var sector = Context.Sectors.First(item => item.Id == sectorId);
+            var replacedExistingRoutes = sector.SavedRoutes.Count > 0;
+
+            progress?.Report(new SectorRouteSaveProgress("Loading sector", "Reading the active sector and travel configuration.", 10));
+            progress?.Report(new SectorRouteSaveProgress("Generating routes", $"Scanning {sector.Systems.Count:N0} systems for TL6+ colony hyperlane endpoints.", 35, 0, sector.Systems.Count));
+
+            if (sector.SavedRoutes.Count == 0 && sector.Systems.Count >= 2)
+            {
+                sector.SavedRoutes.Add(new SectorSavedRoute
+                {
+                    Id = 1,
+                    SectorId = sectorId,
+                    SourceSystemId = sector.Systems[0].Id,
+                    TargetSystemId = sector.Systems[1].Id,
+                    DistanceParsecs = 1.0m,
+                    TravelTimeYears = 0.4m,
+                    TechnologyLevel = 6,
+                    TierName = sector.Configuration.Tl6HyperlaneName,
+                    GeneratedAtUtc = DateTime.UtcNow
+                });
+            }
+
+            progress?.Report(new SectorRouteSaveProgress("Writing database", "Saving the updated route cache to the database.", 90));
+            var finalRoutes = sector.SavedRoutes
+                .Select(route => new SectorHyperlaneRouteDefinition(
+                    route.SourceSystemId,
+                    route.TargetSystemId,
+                    (double)route.DistanceParsecs,
+                    (double)route.TravelTimeYears,
+                    route.TechnologyLevel,
+                    route.TierName,
+                    route.PrimaryOwnerEmpireId,
+                    route.PrimaryOwnerEmpireName,
+                    route.SecondaryOwnerEmpireId,
+                    route.SecondaryOwnerEmpireName))
+                .ToList();
+            var networkReport = SectorRoutePlanner.BuildHyperlaneNetworkReport(
+                sector.Systems.Select(system => system.Id),
+                finalRoutes);
+
+            progress?.Report(new SectorRouteSaveProgress("Routes saved", $"Stored {sector.SavedRoutes.Count:N0} cached hyperlane segment{(sector.SavedRoutes.Count == 1 ? string.Empty : "s")} for this sector.", 100));
+            return Task.FromResult(new SectorRouteSaveResult(
+                sectorId,
+                sector.SavedRoutes.Count,
+                sector.SavedRoutes.Count,
+                sector.SavedRoutes.Count(route => route.IsUserPersisted),
+                replacedExistingRoutes,
+                DateTime.UtcNow,
+                networkReport));
         }
 
         public Task<SectorSavedRoute> SaveManualRouteAsync(SectorManualRouteSaveRequest request, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
+++ b/StarWin.Web.Tests/Pages/HyperlanesPageTests.cs
@@ -37,6 +37,38 @@ public sealed class HyperlanesPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsNewDraftUntilSavedHyperlaneIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/hyperlanes?sectorId=7&systemId=11");
+
+        var cut = Render<Hyperlanes>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Create saved hyperlane", cut.Markup);
+            Assert.Empty(cut.FindAll(".hyperlane-record.active"));
+            Assert.DoesNotContain("Delete hyperlane", cut.Markup);
+        });
+
+        cut.FindAll(".hyperlane-record")
+            .Single(button => button.TextContent.Contains("Advanced Hyperlane", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Edit saved hyperlane", cut.Markup);
+            Assert.Single(cut.FindAll(".hyperlane-record.active"));
+            Assert.Contains("Delete hyperlane", cut.Markup);
+            Assert.EndsWith("/sector-explorer/hyperlanes?sectorId=7&systemId=11&hyperlaneId=2", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
     public void LoadMoreRevealsAdditionalHyperlanes()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -80,6 +112,7 @@ public sealed class HyperlanesPageTests : BunitContext
             Assert.Equal("Manual Lane", routeService.LastSaveRequest?.TierName);
             Assert.Contains("Created saved hyperlane.", cut.Markup);
             Assert.Contains("Manual Lane", cut.Markup);
+            Assert.EndsWith("/sector-explorer/hyperlanes?sectorId=7&systemId=11&hyperlaneId=3", Services.GetRequiredService<NavigationManager>().Uri, StringComparison.Ordinal);
         });
     }
 
@@ -122,6 +155,30 @@ public sealed class HyperlanesPageTests : BunitContext
         cut.FindAll("button").Single(button => button.TextContent.Trim() == "Open sector configuration").Click();
 
         Assert.EndsWith("/sector-explorer/configuration?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NewDraftClearsExplicitHyperlaneSelectionFromRoute()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/hyperlanes?sectorId=7&systemId=11&hyperlaneId=2");
+
+        var cut = Render<Hyperlanes>();
+        cut.WaitForAssertion(() => Assert.Contains("Edit saved hyperlane", cut.Markup));
+
+        cut.FindAll("button").Single(button => button.TextContent.Trim() == "New draft").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Create saved hyperlane", cut.Markup);
+            Assert.Empty(cut.FindAll(".hyperlane-record.active"));
+            Assert.DoesNotContain("Delete hyperlane", cut.Markup);
+            Assert.EndsWith("/sector-explorer/hyperlanes?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
+        });
     }
 
     private void ConfigureServices(FakeExplorerContextService explorerContextService, FakeSectorRouteService? routeService = null)

--- a/StarWin.Web.Tests/Pages/ImportPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ImportPageTests.cs
@@ -106,8 +106,6 @@ public sealed class ImportPageTests : BunitContext
 
         public IReadOnlyList<Empire> Empires => [];
 
-        public IReadOnlyList<EmpireContact> EmpireContacts => [];
-
         public CivilizationGeneratorSettings CivilizationSettings { get; } = new();
 
         public ArmyGeneratorSettings ArmySettings { get; } = new();

--- a/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
@@ -148,7 +148,7 @@ public sealed class ReligionsPageTests : BunitContext
         krellReach.CivilizationProfile.TechLevel = 8;
         krellReach.Founding.FoundingWorldId = 101;
 
-        return new StarWinExplorerContext([sector], sector, races, [orionCompact, krellReach], []);
+        return new StarWinExplorerContext([sector], sector, races, [orionCompact, krellReach]);
     }
 
     private static IReadOnlyList<ExplorerReligionDetail> CreateReligionDetails()
@@ -193,7 +193,7 @@ public sealed class ReligionsPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
@@ -35,6 +35,58 @@ public sealed class ReligionsPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsSelectionPromptUntilReligionIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ConfigureServices(CreateContext(), CreateReligionDetails());
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/religions?sectorId=7");
+
+        var cut = Render<Religions>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a religion to load its details.", cut.Markup);
+            Assert.Empty(cut.FindAll(".record-row.active"));
+            Assert.DoesNotContain("Solar Doctrine", cut.FindAll(".detail-panel").Last().TextContent);
+        });
+
+        cut.FindAll(".record-row")
+            .Single(button => button.TextContent.Contains("Solar Doctrine", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Religion profile", cut.Markup);
+            Assert.Contains("Solar Doctrine", cut.Markup);
+            Assert.Single(cut.FindAll(".record-row.active"));
+            Assert.EndsWith("/sector-explorer/religions?sectorId=7&systemId=11&religionId=10", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LoadsRequestedReligionDetailOnlyOnceOnInitialRender()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var queryService = new CountingReligionQueryService(CreateReligionDetails());
+        ConfigureServices(CreateContext(), queryService.ReligionDetails, queryService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/religions?sectorId=7&religionId=10");
+
+        var cut = Render<Religions>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Solar Doctrine", cut.Markup);
+            Assert.Equal(1, queryService.ReligionDetailLoadCount);
+        });
+    }
+
+    [Fact]
     public void FiltersReligionsBySearchAndType()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -93,11 +145,14 @@ public sealed class ReligionsPageTests : BunitContext
         Assert.EndsWith("/sector-explorer/empires?sectorId=7&systemId=11&empireId=2&religionId=10", navigationManager.Uri, StringComparison.Ordinal);
     }
 
-    private void ConfigureServices(StarWinExplorerContext context, IReadOnlyList<ExplorerReligionDetail> religionDetails)
+    private void ConfigureServices(
+        StarWinExplorerContext context,
+        IReadOnlyList<ExplorerReligionDetail> religionDetails,
+        IStarWinExplorerQueryService? queryService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
-        Services.AddSingleton<IStarWinExplorerQueryService>(new FakeExplorerQueryService(religionDetails));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new FakeExplorerQueryService(religionDetails));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
     }
 
@@ -199,7 +254,25 @@ public sealed class ReligionsPageTests : BunitContext
         }
     }
 
-    private sealed class FakeExplorerQueryService(IReadOnlyList<ExplorerReligionDetail> religionDetails) : IStarWinExplorerQueryService
+    private sealed class CountingReligionQueryService : FakeExplorerQueryService
+    {
+        public CountingReligionQueryService(IReadOnlyList<ExplorerReligionDetail> religionDetails)
+            : base(religionDetails)
+        {
+            ReligionDetails = religionDetails;
+        }
+
+        public IReadOnlyList<ExplorerReligionDetail> ReligionDetails { get; }
+        public int ReligionDetailLoadCount { get; private set; }
+
+        public override Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
+        {
+            ReligionDetailLoadCount++;
+            return base.LoadReligionDetailAsync(sectorId, religionId, cancellationToken);
+        }
+    }
+
+    private class FakeExplorerQueryService(IReadOnlyList<ExplorerReligionDetail> religionDetails) : IStarWinExplorerQueryService
     {
         public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
         {
@@ -290,7 +363,7 @@ public sealed class ReligionsPageTests : BunitContext
                     detail.Empires.Count));
         }
 
-        public Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
+        public virtual Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(religionDetails.FirstOrDefault(item => item.Religion.Id == religionId));
         }

--- a/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
@@ -193,14 +193,9 @@ public sealed class ReligionsPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/ReligionsPageTests.cs
@@ -211,6 +211,11 @@ public sealed class ReligionsPageTests : BunitContext
             throw new NotSupportedException();
         }
 
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [], []));
+        }
+
         public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();

--- a/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
@@ -140,14 +140,14 @@ public sealed class SectorConfigurationPageTests : BunitContext
         });
 
         var empire = new Empire { Id = 2, Name = "Orion Compact" };
-        return new StarWinExplorerContext([sector], sector, [], [empire], []);
+        return new StarWinExplorerContext([sector], sector, [], [empire]);
     }
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
         public StarWinExplorerContext Context { get; } = context;
 
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Context);
         }

--- a/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
@@ -99,6 +99,7 @@ public sealed class SectorConfigurationPageTests : BunitContext
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
+        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(explorerContextService.Context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorConfigurationService>(configService ?? new FakeSectorConfigurationService());
         Services.AddSingleton<IStarWinSectorRouteService>(routeService ?? new FakeSectorRouteService());
@@ -144,9 +145,11 @@ public sealed class SectorConfigurationPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
+        public StarWinExplorerContext Context { get; } = context;
+
         public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(context);
+            return Task.FromResult(Context);
         }
     }
 

--- a/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
@@ -18,7 +18,8 @@ public sealed class SectorConfigurationPageTests : BunitContext
     public void RendersDedicatedConfigurationPage()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
-        ConfigureServices(CreateContext());
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/configuration?sectorId=7&systemId=11");
@@ -31,6 +32,7 @@ public sealed class SectorConfigurationPageTests : BunitContext
             Assert.Contains("Del Corra", cut.Markup);
             Assert.Contains("Save configuration", cut.Markup);
             Assert.Contains("Saved route report", cut.Markup);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -39,7 +41,8 @@ public sealed class SectorConfigurationPageTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         var configService = new FakeSectorConfigurationService();
-        ConfigureServices(CreateContext(), configService: configService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, configService: configService);
 
         var cut = Render<SectorConfigurationPage>();
         cut.Find("input[maxlength='160']").Change("Del Corra Prime");
@@ -50,6 +53,7 @@ public sealed class SectorConfigurationPageTests : BunitContext
             Assert.Equal("Del Corra Prime", configService.SavedSectorName);
             Assert.NotNull(configService.SavedConfiguration);
             Assert.Contains("Del Corra Prime saved.", cut.Markup);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -58,7 +62,8 @@ public sealed class SectorConfigurationPageTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         var routeService = new FakeSectorRouteService();
-        ConfigureServices(CreateContext(), routeService: routeService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, routeService: routeService);
 
         var cut = Render<SectorConfigurationPage>();
         cut.FindAll("button").Single(button => button.TextContent.Trim() == "Update Current Routes").Click();
@@ -67,6 +72,7 @@ public sealed class SectorConfigurationPageTests : BunitContext
         {
             Assert.True(routeService.SaveCalled);
             Assert.Contains("Updated 3 saved hyperlane segments", cut.Markup);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -75,7 +81,8 @@ public sealed class SectorConfigurationPageTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         var colonyService = new FakeIndependentColonyService();
-        ConfigureServices(CreateContext(), colonyService: colonyService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, colonyService: colonyService);
 
         var cut = Render<SectorConfigurationPage>();
         cut.FindAll("button").Single(button => button.TextContent.Trim() == "Convert independent colonies").Click();
@@ -84,17 +91,18 @@ public sealed class SectorConfigurationPageTests : BunitContext
         {
             Assert.True(colonyService.ConvertCalled);
             Assert.Contains("Created 1 empire and assigned 2 colonies.", cut.Markup);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
     private void ConfigureServices(
-        StarWinExplorerContext context,
+        FakeExplorerContextService explorerContextService,
         FakeSectorConfigurationService? configService = null,
         FakeSectorRouteService? routeService = null,
         FakeIndependentColonyService? colonyService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
-        Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
+        Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorConfigurationService>(configService ?? new FakeSectorConfigurationService());
         Services.AddSingleton<IStarWinSectorRouteService>(routeService ?? new FakeSectorRouteService());
@@ -140,6 +148,8 @@ public sealed class SectorConfigurationPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
+        public int LoadSectorAsyncCallCount { get; private set; }
+
         public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
@@ -147,6 +157,7 @@ public sealed class SectorConfigurationPageTests : BunitContext
 
         public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
         {
+            LoadSectorAsyncCallCount++;
             return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }

--- a/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
@@ -32,7 +32,6 @@ public sealed class SectorConfigurationPageTests : BunitContext
             Assert.Contains("Del Corra", cut.Markup);
             Assert.Contains("Save configuration", cut.Markup);
             Assert.Contains("Saved route report", cut.Markup);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -53,7 +52,6 @@ public sealed class SectorConfigurationPageTests : BunitContext
             Assert.Equal("Del Corra Prime", configService.SavedSectorName);
             Assert.NotNull(configService.SavedConfiguration);
             Assert.Contains("Del Corra Prime saved.", cut.Markup);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -72,7 +70,6 @@ public sealed class SectorConfigurationPageTests : BunitContext
         {
             Assert.True(routeService.SaveCalled);
             Assert.Contains("Updated 3 saved hyperlane segments", cut.Markup);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -91,7 +88,6 @@ public sealed class SectorConfigurationPageTests : BunitContext
         {
             Assert.True(colonyService.ConvertCalled);
             Assert.Contains("Created 1 empire and assigned 2 colonies.", cut.Markup);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
     }
 
@@ -148,17 +144,9 @@ public sealed class SectorConfigurationPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public int LoadSectorAsyncCallCount { get; private set; }
-
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            LoadSectorAsyncCallCount++;
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
@@ -19,7 +19,8 @@ public sealed class SectorConfigurationPageTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         var explorerContextService = new FakeExplorerContextService(CreateContext());
-        ConfigureServices(explorerContextService);
+        var queryService = new ContextBackedExplorerQueryService(explorerContextService.Context);
+        ConfigureServices(explorerContextService, queryService: queryService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/configuration?sectorId=7&systemId=11");
@@ -33,6 +34,9 @@ public sealed class SectorConfigurationPageTests : BunitContext
             Assert.Contains("Save configuration", cut.Markup);
             Assert.Contains("Saved route report", cut.Markup);
         });
+
+        Assert.Equal(0, queryService.HyperlaneWorkspaceLoadCount);
+        Assert.True(queryService.SectorConfigurationStateLoadCount > 0);
     }
 
     [Fact]
@@ -93,13 +97,14 @@ public sealed class SectorConfigurationPageTests : BunitContext
 
     private void ConfigureServices(
         FakeExplorerContextService explorerContextService,
+        ContextBackedExplorerQueryService? queryService = null,
         FakeSectorConfigurationService? configService = null,
         FakeSectorRouteService? routeService = null,
         FakeIndependentColonyService? colonyService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
-        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(explorerContextService.Context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new ContextBackedExplorerQueryService(explorerContextService.Context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorConfigurationService>(configService ?? new FakeSectorConfigurationService());
         Services.AddSingleton<IStarWinSectorRouteService>(routeService ?? new FakeSectorRouteService());

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -393,14 +393,9 @@ public sealed class SectorExplorerPageTests : BunitContext
                 []);
         }
 
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -353,8 +353,6 @@ public sealed class SectorExplorerPageTests : BunitContext
 
         public IReadOnlyList<Empire> Empires => [new Empire { Id = 8, Name = "Orion Compact" }];
 
-        public IReadOnlyList<EmpireContact> EmpireContacts => [];
-
         public CivilizationGeneratorSettings CivilizationSettings { get; } = new();
 
         public ArmyGeneratorSettings ArmySettings { get; } = new();
@@ -389,11 +387,10 @@ public sealed class SectorExplorerPageTests : BunitContext
                 [sector],
                 sector,
                 [new AlienRace { Id = 3, Name = "Krell" }],
-                [new Empire { Id = 8, Name = "Orion Compact" }],
-                []);
+                [new Empire { Id = 8, Name = "Orion Compact" }]);
         }
 
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -243,6 +243,55 @@ public sealed class SectorExplorerPageTests : BunitContext
     }
 
     [Fact]
+    public void MapWorkspacePromptsToPreGenerateRoutesWhenSavedRoutesAreMissing()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var sector = CreateSector(includeSavedRoutes: false);
+        var workspace = new FakeWorkspace(sector);
+        ConfigureServices(sector, workspace);
+
+        var cut = Render<SectorExplorerMapWorkspace>(parameters => parameters
+            .Add(component => component.SectorId, 7)
+            .Add(component => component.SystemId, 11));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("does not have saved hyperlane routes yet", cut.Markup);
+            Assert.Contains("Open sector configuration", cut.Markup);
+        });
+
+        var configurationLink = cut.FindAll("a")
+            .Single(link => link.TextContent.Contains("Open sector configuration", StringComparison.Ordinal));
+        Assert.Equal("/sector-explorer/configuration?sectorId=7&systemId=11", configurationLink.GetAttribute("href"));
+
+        cut.FindAll("button.overlay-action")
+            .First(button => button.TextContent.Contains("Load 3D map", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() => Assert.Contains("using dynamically generated hyperlane routes", cut.Markup));
+    }
+
+    [Fact]
+    public void MapWorkspaceSkipsPreGenerationPromptWhenSavedRoutesExist()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var sector = CreateSector();
+        var workspace = new FakeWorkspace(sector);
+        ConfigureServices(sector, workspace);
+
+        var cut = Render<SectorExplorerMapWorkspace>(parameters => parameters
+            .Add(component => component.SectorId, 7)
+            .Add(component => component.SystemId, 11));
+
+        cut.WaitForAssertion(() => Assert.Contains("Load 3D map", cut.Markup));
+
+        Assert.DoesNotContain("Open sector configuration", cut.Markup);
+        Assert.DoesNotContain("saved hyperlane routes yet", cut.Markup);
+    }
+
+    [Fact]
     public void MapWorkspaceBuildsPayloadWithExpectedRendererFields()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -289,7 +338,7 @@ public sealed class SectorExplorerPageTests : BunitContext
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());
     }
 
-    private static StarWinSector CreateSector()
+    private static StarWinSector CreateSector(bool includeSavedRoutes = true)
     {
         var sector = new StarWinSector
         {
@@ -345,17 +394,20 @@ public sealed class SectorExplorerPageTests : BunitContext
             Coordinates = new Coordinates(1, 0, 0),
             AllegianceId = 8
         });
-        sector.SavedRoutes.Add(new SectorSavedRoute
+        if (includeSavedRoutes)
         {
-            Id = 1,
-            SectorId = 7,
-            SourceSystemId = 11,
-            TargetSystemId = 12,
-            DistanceParsecs = 1m,
-            TravelTimeYears = 0.01m,
-            TechnologyLevel = 6,
-            TierName = "Basic Hyperlane"
-        });
+            sector.SavedRoutes.Add(new SectorSavedRoute
+            {
+                Id = 1,
+                SectorId = 7,
+                SourceSystemId = 11,
+                TargetSystemId = 12,
+                DistanceParsecs = 1m,
+                TravelTimeYears = 0.01m,
+                TechnologyLevel = 6,
+                TierName = "Basic Hyperlane"
+            });
+        }
 
         return sector;
     }

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -215,6 +215,53 @@ public sealed class SectorExplorerPageTests : BunitContext
     }
 
     [Fact]
+    public void OverviewSectorSelectorChangeUpdatesRouteAndMapWorkspace()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var delcora = CreateSector(
+            sectorId: 1,
+            sectorName: "Delcora Sector",
+            primarySystemId: 224157,
+            primarySystemName: "A'Hearn",
+            secondarySystemId: 224158,
+            secondarySystemName: "Bastion");
+        var testImport = CreateSector(
+            sectorId: 2,
+            sectorName: "test import",
+            primarySystemId: 11,
+            primarySystemName: "Helios",
+            secondarySystemId: 12,
+            secondarySystemName: "Selene",
+            includeSavedRoutes: false);
+
+        var workspace = new FakeWorkspace([delcora, testImport], currentSectorId: delcora.Id);
+        var queryService = new FakeExplorerQueryService([delcora, testImport]);
+        ConfigureServices([delcora, testImport], workspace, queryService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer?sectorId=1&systemId=224157");
+
+        var cut = Render<SectorExplorer>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Delcora Sector", cut.Markup);
+            Assert.Contains("224157 - A'Hearn", cut.Markup);
+            Assert.Contains("<strong>2</strong>", cut.Markup);
+        });
+
+        cut.Find("select").Change("2");
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.EndsWith("/sector-explorer?sectorId=2&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
+            Assert.Contains("test import", cut.Markup);
+            Assert.Contains("11 - Helios", cut.Markup);
+        });
+    }
+
+    [Fact]
     public async Task MapWorkspaceNavigatesDirectlyToSystemsPage()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -353,33 +400,45 @@ public sealed class SectorExplorerPageTests : BunitContext
 
     private void ConfigureServices(StarWinSector sector, FakeWorkspace workspace, FakeExplorerQueryService? queryService = null)
     {
+        ConfigureServices([sector], workspace, queryService);
+    }
+
+    private void ConfigureServices(IReadOnlyList<StarWinSector> sectors, FakeWorkspace workspace, FakeExplorerQueryService? queryService = null)
+    {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinWorkspace>(workspace);
-        Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(sector));
-        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new FakeExplorerQueryService(sector));
+        Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(sectors));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new FakeExplorerQueryService(sectors));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());
     }
 
-    private static StarWinSector CreateSector(bool includeSavedRoutes = true)
+    private static StarWinSector CreateSector(
+        int sectorId = 7,
+        string sectorName = "Del Corra",
+        int primarySystemId = 11,
+        string primarySystemName = "Helios",
+        int secondarySystemId = 12,
+        string secondarySystemName = "Selene",
+        bool includeSavedRoutes = true)
     {
         var sector = new StarWinSector
         {
-            Id = 7,
-            Name = "Del Corra",
+            Id = sectorId,
+            Name = sectorName,
             Configuration = new StarWin.Domain.Model.Entity.StarMap.SectorConfiguration
             {
-                SectorId = 7,
+                SectorId = sectorId,
                 OffLaneMaximumDistanceParsecs = 2m
             }
         };
 
         var system = new StarSystem
         {
-            Id = 11,
-            SectorId = 7,
-            Name = "Helios",
+            Id = primarySystemId,
+            SectorId = sectorId,
+            Name = primarySystemName,
             Coordinates = new Coordinates(0, 0, 0),
             AllegianceId = 8
         };
@@ -412,9 +471,9 @@ public sealed class SectorExplorerPageTests : BunitContext
         sector.Systems.Add(system);
         sector.Systems.Add(new StarSystem
         {
-            Id = 12,
-            SectorId = 7,
-            Name = "Selene",
+            Id = secondarySystemId,
+            SectorId = sectorId,
+            Name = secondarySystemName,
             Coordinates = new Coordinates(1, 0, 0),
             AllegianceId = 8
         });
@@ -423,9 +482,9 @@ public sealed class SectorExplorerPageTests : BunitContext
             sector.SavedRoutes.Add(new SectorSavedRoute
             {
                 Id = 1,
-                SectorId = 7,
-                SourceSystemId = 11,
-                TargetSystemId = 12,
+                SectorId = sectorId,
+                SourceSystemId = primarySystemId,
+                TargetSystemId = secondarySystemId,
                 DistanceParsecs = 1m,
                 TravelTimeYears = 0.01m,
                 TechnologyLevel = 6,
@@ -438,20 +497,25 @@ public sealed class SectorExplorerPageTests : BunitContext
 
     private sealed class FakeWorkspace : IStarWinWorkspace
     {
-        private readonly StarWinSector sector;
+        private readonly IReadOnlyList<StarWinSector> sectors;
         private readonly TaskCompletionSource reloadTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public FakeWorkspace(StarWinSector sector)
+            : this([sector], sector.Id)
         {
-            this.sector = sector;
-            CurrentSector = sector;
+        }
+
+        public FakeWorkspace(IReadOnlyList<StarWinSector> sectors, int? currentSectorId = null)
+        {
+            this.sectors = sectors;
+            CurrentSector = ResolveCurrentSector(currentSectorId);
         }
 
         public bool DelayReload { get; set; }
 
         public bool IsLoaded { get; private set; }
 
-        public IReadOnlyList<StarWinSector> Sectors => IsLoaded ? [sector] : [];
+        public IReadOnlyList<StarWinSector> Sectors => IsLoaded ? sectors : [];
 
         public StarWinSector CurrentSector { get; private set; }
 
@@ -474,12 +538,18 @@ public sealed class SectorExplorerPageTests : BunitContext
             }
 
             IsLoaded = true;
-            CurrentSector = sector;
+            CurrentSector = ResolveCurrentSector(CurrentSector.Id);
         }
 
         public void ReleaseReload()
         {
             reloadTcs.TrySetResult();
+        }
+
+        private StarWinSector ResolveCurrentSector(int? currentSectorId)
+        {
+            return sectors.FirstOrDefault(item => item.Id == currentSectorId)
+                ?? sectors.First();
         }
     }
 
@@ -487,11 +557,12 @@ public sealed class SectorExplorerPageTests : BunitContext
     {
         private readonly StarWinExplorerContext context;
 
-        public FakeExplorerContextService(StarWinSector sector)
+        public FakeExplorerContextService(IReadOnlyList<StarWinSector> sectors)
         {
+            var currentSector = sectors.First();
             context = new StarWinExplorerContext(
-                [sector],
-                sector,
+                sectors,
+                currentSector,
                 [new AlienRace { Id = 3, Name = "Krell" }],
                 [new Empire { Id = 8, Name = "Orion Compact" }]);
         }
@@ -504,18 +575,25 @@ public sealed class SectorExplorerPageTests : BunitContext
 
     private sealed class FakeExplorerQueryService : IStarWinExplorerQueryService
     {
-        private readonly ExplorerSectorOverviewData overviewData;
+        private readonly Dictionary<int, ExplorerSectorOverviewData> overviewDataBySectorId;
         private readonly TaskCompletionSource overviewLoadTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public FakeExplorerQueryService(StarWinSector sector)
+            : this([sector])
         {
-            overviewData = new ExplorerSectorOverviewData(
-                sector.Id,
-                sector.Systems.Count,
-                sector.Systems.SelectMany(system => system.Worlds).Count(),
-                sector.Systems.SelectMany(system => system.Worlds).Count(world => world.Colony is not null),
-                1,
-                1);
+        }
+
+        public FakeExplorerQueryService(IReadOnlyList<StarWinSector> sectors)
+        {
+            overviewDataBySectorId = sectors.ToDictionary(
+                sector => sector.Id,
+                sector => new ExplorerSectorOverviewData(
+                    sector.Id,
+                    sector.Systems.Count,
+                    sector.Systems.SelectMany(system => system.Worlds).Count(),
+                    sector.Systems.SelectMany(system => system.Worlds).Count(world => world.Colony is not null),
+                    1,
+                    1));
         }
 
         public bool DelayOverviewLoads { get; set; }
@@ -531,6 +609,10 @@ public sealed class SectorExplorerPageTests : BunitContext
                 using var registration = cancellationToken.Register(() => overviewLoadTcs.TrySetCanceled(cancellationToken));
                 await overviewLoadTcs.Task;
             }
+
+            var overviewData = overviewDataBySectorId.TryGetValue(sectorId, out var requestedOverviewData)
+                ? requestedOverviewData
+                : overviewDataBySectorId.Values.First();
 
             return overviewData with { SectorId = sectorId };
         }

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -426,6 +426,11 @@ public sealed class SectorExplorerPageTests : BunitContext
             return Task.FromResult(overviewData);
         }
 
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [], []));
+        }
+
         public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -215,7 +215,7 @@ public sealed class SectorExplorerPageTests : BunitContext
     }
 
     [Fact]
-    public void MapWorkspaceNavigatesDirectlyToSystemsPage()
+    public async Task MapWorkspaceNavigatesDirectlyToSystemsPage()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -231,19 +231,16 @@ public sealed class SectorExplorerPageTests : BunitContext
             .Add(component => component.SystemId, 12));
 
         cut.WaitForAssertion(() => Assert.Contains("Load 3D map", cut.Markup));
-        cut.FindAll("button.overlay-action")
-            .First(button => button.TextContent.Contains("Load 3D map", StringComparison.Ordinal))
-            .Click();
-        cut.WaitForAssertion(() => Assert.Contains("Open system record", cut.Markup));
-        cut.FindAll("button.overlay-action")
-            .First(button => button.TextContent.Contains("Open system record", StringComparison.Ordinal))
-            .Click();
+        var openRecordMethod = typeof(SectorExplorerMapWorkspace).GetMethod("OpenSelectedSystemRecordAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(openRecordMethod);
+
+        await cut.InvokeAsync(() => (Task)openRecordMethod!.Invoke(cut.Instance, [])!);
 
         Assert.EndsWith("/sector-explorer/systems?sectorId=7&systemId=12", navigationManager.Uri, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void MapWorkspacePromptsToPreGenerateRoutesWhenSavedRoutesAreMissing()
+    public void MapWorkspaceSkipsPersistentDynamicRouteFallbackPromptWhenSavedRoutesAreMissing()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -255,29 +252,28 @@ public sealed class SectorExplorerPageTests : BunitContext
             .Add(component => component.SectorId, 7)
             .Add(component => component.SystemId, 11));
 
-        cut.WaitForAssertion(() =>
-        {
-            Assert.Contains("does not have saved hyperlane routes yet", cut.Markup);
-            Assert.Contains("Open sector configuration", cut.Markup);
-        });
-
-        var configurationLink = cut.FindAll("a")
-            .Single(link => link.TextContent.Contains("Open sector configuration", StringComparison.Ordinal));
-        Assert.Equal("/sector-explorer/configuration?sectorId=7&systemId=11", configurationLink.GetAttribute("href"));
-
-        cut.FindAll("button.overlay-action")
-            .First(button => button.TextContent.Contains("Load 3D map", StringComparison.Ordinal))
-            .Click();
-
-        cut.WaitForAssertion(() => Assert.Contains("using dynamically generated hyperlane routes", cut.Markup));
+        cut.WaitForAssertion(() => Assert.Contains("Load 3D map", cut.Markup));
+        Assert.DoesNotContain("Open sector configuration", cut.Markup);
+        Assert.DoesNotContain("No saved routes yet. The map is generating them dynamically.", cut.Markup);
     }
 
     [Fact]
-    public void MapWorkspaceSkipsPreGenerationPromptWhenSavedRoutesExist()
+    public void MapWorkspaceUsesShortDynamicRouteFallbackOverlayCopy()
+    {
+        var noteMethod = typeof(SectorExplorerMapWorkspace).GetMethod("GetSavedRouteGenerationLoadingNote", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(noteMethod);
+
+        var note = noteMethod!.Invoke(null, []) as string;
+
+        Assert.Equal("No saved routes yet. The map is generating them dynamically. Use Save Current Routes in Sector Configuration to speed up future loads.", note);
+    }
+
+    [Fact]
+    public async Task MapWorkspaceHidesDynamicRouteFallbackHintAfterMapRenderCompletes()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
-        var sector = CreateSector();
+        var sector = CreateSector(includeSavedRoutes: false);
         var workspace = new FakeWorkspace(sector);
         ConfigureServices(sector, workspace);
 
@@ -287,8 +283,36 @@ public sealed class SectorExplorerPageTests : BunitContext
 
         cut.WaitForAssertion(() => Assert.Contains("Load 3D map", cut.Markup));
 
-        Assert.DoesNotContain("Open sector configuration", cut.Markup);
-        Assert.DoesNotContain("saved hyperlane routes yet", cut.Markup);
+        var sectorMapRequestedField = typeof(SectorExplorerMapWorkspace).GetField("sectorMapRequested", BindingFlags.Instance | BindingFlags.NonPublic);
+        var renderedOverviewField = typeof(SectorExplorerMapWorkspace).GetField("renderedOverview", BindingFlags.Instance | BindingFlags.NonPublic);
+        var stateHasChangedMethod = typeof(ComponentBase).GetMethod("StateHasChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(sectorMapRequestedField);
+        Assert.NotNull(renderedOverviewField);
+        Assert.NotNull(stateHasChangedMethod);
+
+        await cut.InvokeAsync(() =>
+        {
+            sectorMapRequestedField!.SetValue(cut.Instance, true);
+            renderedOverviewField!.SetValue(cut.Instance, false);
+            stateHasChangedMethod!.Invoke(cut.Instance, []);
+        });
+
+        cut.WaitForAssertion(() => Assert.Contains("No saved routes yet. The map is generating them dynamically. Use Save Current Routes in Sector Configuration to speed up future loads.", cut.Markup));
+
+        await cut.InvokeAsync(() =>
+        {
+            sectorMapRequestedField!.SetValue(cut.Instance, true);
+            renderedOverviewField!.SetValue(cut.Instance, true);
+            stateHasChangedMethod!.Invoke(cut.Instance, []);
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Open system record", cut.Markup);
+            Assert.DoesNotContain("No saved routes yet. The map is generating them dynamically. Use Save Current Routes in Sector Configuration to speed up future loads.", cut.Markup);
+            Assert.DoesNotContain("Open sector configuration", cut.Markup);
+        });
     }
 
     [Fact]

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -320,6 +320,9 @@ public sealed class SectorExplorerPageTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
+        var mapModule = JSInterop.SetupModule("./js/sectorMap3d.js");
+        var renderHandler = mapModule.SetupVoid("renderSectorMap", _ => true);
+
         var sector = CreateSector(includeSavedRoutes: false);
         var workspace = new FakeWorkspace(sector);
         ConfigureServices(sector, workspace);
@@ -347,6 +350,8 @@ public sealed class SectorExplorerPageTests : BunitContext
 
         cut.WaitForAssertion(() => Assert.Contains("No saved routes yet. The map is generating them dynamically. Use Save Current Routes in Sector Configuration to speed up future loads.", cut.Markup));
 
+        renderHandler.SetVoidResult();
+
         await cut.InvokeAsync(() =>
         {
             sectorMapRequestedField!.SetValue(cut.Instance, true);
@@ -359,6 +364,44 @@ public sealed class SectorExplorerPageTests : BunitContext
             Assert.Contains("Open system record", cut.Markup);
             Assert.DoesNotContain("No saved routes yet. The map is generating them dynamically. Use Save Current Routes in Sector Configuration to speed up future loads.", cut.Markup);
             Assert.DoesNotContain("Open sector configuration", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public async Task MapWorkspaceHidesLoadingModalAfterRenderCompletes()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var mapModule = JSInterop.SetupModule("./js/sectorMap3d.js");
+        var renderHandler = mapModule.SetupVoid("renderSectorMap", _ => true);
+        renderHandler.SetVoidResult();
+
+        var sector = CreateSector(includeSavedRoutes: false);
+        var workspace = new FakeWorkspace(sector);
+        ConfigureServices(sector, workspace);
+
+        var cut = Render<SectorExplorerMapWorkspace>(parameters => parameters
+            .Add(component => component.SectorId, 7)
+            .Add(component => component.SystemId, 11));
+
+        cut.WaitForAssertion(() => Assert.Contains("Load 3D map", cut.Markup));
+
+        var sectorMapRequestedField = typeof(SectorExplorerMapWorkspace).GetField("sectorMapRequested", BindingFlags.Instance | BindingFlags.NonPublic);
+        var stateHasChangedMethod = typeof(ComponentBase).GetMethod("StateHasChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(sectorMapRequestedField);
+        Assert.NotNull(stateHasChangedMethod);
+
+        await cut.InvokeAsync(() =>
+        {
+            sectorMapRequestedField!.SetValue(cut.Instance, true);
+            stateHasChangedMethod!.Invoke(cut.Instance, []);
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.DoesNotContain("Loading 3D sector map", cut.Markup);
+            Assert.Contains("Open system record", cut.Markup);
         });
     }
 

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -76,6 +76,36 @@ public sealed class SectorExplorerPageTests : BunitContext
     }
 
     [Fact]
+    public async Task OverviewMetricsLoadOncePerSectorWhileSameSectorRequestsAreInFlight()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var sector = CreateSector();
+        var workspace = new FakeWorkspace(sector);
+        var queryService = new FakeExplorerQueryService(sector);
+        ConfigureServices(sector, workspace, queryService);
+
+        var cut = Render<SectorExplorer>();
+        cut.WaitForAssertion(() => Assert.Contains("<strong>2</strong>", cut.Markup));
+
+        var baselineCallCount = queryService.LoadSectorOverviewCallCount;
+        queryService.DelayOverviewLoads = true;
+
+        var loadMethod = typeof(SectorExplorer).GetMethod("LoadSectorOverviewDataAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(loadMethod);
+
+        var loadOne = cut.InvokeAsync(() => (Task)loadMethod!.Invoke(cut.Instance, [99, CancellationToken.None])!);
+        var loadTwo = cut.InvokeAsync(() => (Task)loadMethod!.Invoke(cut.Instance, [99, CancellationToken.None])!);
+
+        cut.WaitForAssertion(() => Assert.Equal(baselineCallCount + 1, queryService.LoadSectorOverviewCallCount));
+
+        queryService.ReleaseOverviewLoad();
+        await Task.WhenAll(loadOne, loadTwo);
+
+        Assert.Equal(baselineCallCount + 1, queryService.LoadSectorOverviewCallCount);
+    }
+
+    [Fact]
     public void MapWorkspaceShowsSingleSharedLoadingModalWhileDeferredWorkspaceLoads()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -105,7 +135,7 @@ public sealed class SectorExplorerPageTests : BunitContext
     }
 
     [Fact]
-    public void MapWorkspaceUpdatesOverviewQueryWithoutParentCallback()
+    public async Task MapWorkspaceUpdatesOverviewQueryWithoutParentCallback()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -121,7 +151,7 @@ public sealed class SectorExplorerPageTests : BunitContext
             .Add(component => component.SystemId, 11));
 
         cut.WaitForAssertion(() => Assert.Contains("Load 3D map", cut.Markup));
-        cut.InvokeAsync(() => cut.Instance.SelectSystemFromMap(12));
+        await cut.InvokeAsync(() => cut.Instance.SelectSystemFromMap(12));
 
         Assert.EndsWith("/sector-explorer?sectorId=7&systemId=12", navigationManager.Uri, StringComparison.Ordinal);
     }
@@ -248,12 +278,12 @@ public sealed class SectorExplorerPageTests : BunitContext
         Assert.Contains("\"solarMasses\":1.01", json);
     }
 
-    private void ConfigureServices(StarWinSector sector, FakeWorkspace workspace)
+    private void ConfigureServices(StarWinSector sector, FakeWorkspace workspace, FakeExplorerQueryService? queryService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinWorkspace>(workspace);
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(sector));
-        Services.AddSingleton<IStarWinExplorerQueryService>(new FakeExplorerQueryService(sector));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new FakeExplorerQueryService(sector));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());
@@ -399,6 +429,7 @@ public sealed class SectorExplorerPageTests : BunitContext
     private sealed class FakeExplorerQueryService : IStarWinExplorerQueryService
     {
         private readonly ExplorerSectorOverviewData overviewData;
+        private readonly TaskCompletionSource overviewLoadTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public FakeExplorerQueryService(StarWinSector sector)
         {
@@ -408,14 +439,29 @@ public sealed class SectorExplorerPageTests : BunitContext
                 sector.Systems.SelectMany(system => system.Worlds).Count(),
                 sector.Systems.SelectMany(system => system.Worlds).Count(world => world.Colony is not null),
                 1,
-                1,
-                [new ExplorerLookupOption(11, "Helios")],
-                [new ExplorerLookupOption(8, "Orion Compact")]);
+                1);
         }
 
-        public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
+        public bool DelayOverviewLoads { get; set; }
+
+        public int LoadSectorOverviewCallCount { get; private set; }
+
+        public async Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(overviewData);
+            LoadSectorOverviewCallCount++;
+
+            if (DelayOverviewLoads)
+            {
+                using var registration = cancellationToken.Register(() => overviewLoadTcs.TrySetCanceled(cancellationToken));
+                await overviewLoadTcs.Task;
+            }
+
+            return overviewData with { SectorId = sectorId };
+        }
+
+        public void ReleaseOverviewLoad()
+        {
+            overviewLoadTcs.TrySetResult();
         }
 
         public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Pages/SystemsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SystemsPageTests.cs
@@ -125,6 +125,7 @@ public sealed class SystemsPageTests : BunitContext
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());

--- a/StarWin.Web.Tests/Pages/SystemsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SystemsPageTests.cs
@@ -157,7 +157,7 @@ public sealed class SystemsPageTests : BunitContext
             new Empire { Id = 3, Name = "Zephyr League" }
         };
 
-        return new StarWinExplorerContext([sector], sector, [], empires, []);
+        return new StarWinExplorerContext([sector], sector, [], empires);
     }
 
     private static StarSystem CreateSystem(int systemId, string name, ushort allegianceId, string worldName = "Eos")
@@ -208,7 +208,7 @@ public sealed class SystemsPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/SystemsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SystemsPageTests.cs
@@ -207,14 +207,9 @@ public sealed class SystemsPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/SystemsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SystemsPageTests.cs
@@ -376,6 +376,6 @@ public sealed class SystemsPageTests : BunitContext
         public Task<IReadOnlyList<string>> LoadTimelineEventTypesAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadTimelineEventTypesAsync(sectorId, cancellationToken);
         public Task<ExplorerTimelinePage> LoadTimelinePageAsync(ExplorerTimelinePageRequest request, CancellationToken cancellationToken = default) => inner.LoadTimelinePageAsync(request, cancellationToken);
         public Task<ExplorerTimelineEventDetail?> LoadTimelineEventDetailAsync(int eventId, CancellationToken cancellationToken = default) => inner.LoadTimelineEventDetailAsync(eventId, cancellationToken);
-        public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
+        public Task<ExplorerHyperlanePageState?> LoadHyperlanePageStateAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadHyperlanePageStateAsync(sectorId, cancellationToken);
     }
 }

--- a/StarWin.Web.Tests/Pages/SystemsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SystemsPageTests.cs
@@ -34,6 +34,57 @@ public sealed class SystemsPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsSelectionPromptUntilSystemIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        ConfigureServices(CreateContext());
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/systems?sectorId=7");
+
+        var cut = Render<Systems>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a system to load its details.", cut.Markup);
+            Assert.Empty(cut.FindAll(".record-row.active"));
+            Assert.DoesNotContain("System survey", cut.Markup);
+        });
+
+        cut.FindAll(".record-row")
+            .Single(button => button.TextContent.Contains("Helios", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("System survey", cut.Markup);
+            Assert.Contains("Helios", cut.Markup);
+            Assert.Single(cut.FindAll(".record-row.active"));
+            Assert.EndsWith("/sector-explorer/systems?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LoadsRequestedSystemDetailOnlyOnceOnInitialRender()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var context = CreateContext();
+        var queryService = new CountingSystemQueryService(context);
+        ConfigureServices(context, queryService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/systems?sectorId=7&systemId=11");
+
+        var cut = Render<Systems>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("System survey", cut.Markup);
+            Assert.Equal(1, queryService.SystemDetailLoadCount);
+        });
+    }
+
+    [Fact]
     public void FiltersSystemsBySearchQueryAndClearsFilters()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -121,11 +172,11 @@ public sealed class SystemsPageTests : BunitContext
         Assert.EndsWith("/sector-explorer/worlds?sectorId=7&systemId=11&worldId=111", navigationManager.Uri, StringComparison.Ordinal);
     }
 
-    private void ConfigureServices(StarWinExplorerContext context)
+    private void ConfigureServices(StarWinExplorerContext context, IStarWinExplorerQueryService? queryService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
-        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new ContextBackedExplorerQueryService(context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());
@@ -282,5 +333,49 @@ public sealed class SystemsPageTests : BunitContext
                 ControlledByEmpireId = empireId
             });
         }
+    }
+
+    private sealed class CountingSystemQueryService(StarWinExplorerContext context) : IStarWinExplorerQueryService
+    {
+        private readonly ContextBackedExplorerQueryService inner = new(context);
+
+        public int SystemDetailLoadCount { get; private set; }
+
+        public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSectorOverviewAsync(sectorId, cancellationToken);
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSectorEntityUsageAsync(sectorId, cancellationToken);
+        public Task<IReadOnlyList<StarWinSearchResult>> SearchSectorAsync(int sectorId, string query, int maxResults = 30, CancellationToken cancellationToken = default) => inner.SearchSectorAsync(sectorId, query, maxResults, cancellationToken);
+        public Task<int?> ResolveSystemIdAsync(int sectorId, int? worldId = null, int? colonyId = null, int? habitatId = null, CancellationToken cancellationToken = default) => inner.ResolveSystemIdAsync(sectorId, worldId, colonyId, habitatId, cancellationToken);
+        public Task<IReadOnlyList<ExplorerLookupOption>> LoadSectorEmpireOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSectorEmpireOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadAlienRaceFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerAlienRaceListPage> LoadAlienRaceListPageAsync(ExplorerAlienRaceListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadAlienRaceListPageAsync(request, cancellationToken);
+        public Task<ExplorerAlienRaceListItem?> LoadAlienRaceListItemAsync(int sectorId, int raceId, CancellationToken cancellationToken = default) => inner.LoadAlienRaceListItemAsync(sectorId, raceId, cancellationToken);
+        public Task<ExplorerAlienRaceDetail?> LoadAlienRaceDetailAsync(int sectorId, int raceId, CancellationToken cancellationToken = default) => inner.LoadAlienRaceDetailAsync(sectorId, raceId, cancellationToken);
+        public Task<ExplorerSystemFilterOptions> LoadSystemFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadSystemFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerSystemListPage> LoadSystemListPageAsync(ExplorerSystemListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadSystemListPageAsync(request, cancellationToken);
+        public Task<ExplorerSystemListItem?> LoadSystemListItemAsync(int sectorId, int systemId, CancellationToken cancellationToken = default) => inner.LoadSystemListItemAsync(sectorId, systemId, cancellationToken);
+
+        public Task<ExplorerSystemDetail?> LoadSystemDetailAsync(int sectorId, int systemId, CancellationToken cancellationToken = default)
+        {
+            SystemDetailLoadCount++;
+            return inner.LoadSystemDetailAsync(sectorId, systemId, cancellationToken);
+        }
+
+        public Task<ExplorerWorldsWorkspace?> LoadWorldsWorkspaceAsync(int sectorId, int systemId, CancellationToken cancellationToken = default) => inner.LoadWorldsWorkspaceAsync(sectorId, systemId, cancellationToken);
+        public Task<ExplorerColonyFilterOptions> LoadColonyFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadColonyFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerColonyListPage> LoadColonyListPageAsync(ExplorerColonyListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadColonyListPageAsync(request, cancellationToken);
+        public Task<ExplorerColonyListItem?> LoadColonyListItemAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default) => inner.LoadColonyListItemAsync(sectorId, colonyId, cancellationToken);
+        public Task<ExplorerColonyDetail?> LoadColonyDetailAsync(int sectorId, int colonyId, CancellationToken cancellationToken = default) => inner.LoadColonyDetailAsync(sectorId, colonyId, cancellationToken);
+        public Task<ExplorerReligionFilterOptions> LoadReligionFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadReligionFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerReligionListPage> LoadReligionListPageAsync(ExplorerReligionListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadReligionListPageAsync(request, cancellationToken);
+        public Task<ExplorerReligionListItem?> LoadReligionListItemAsync(int sectorId, int religionId, CancellationToken cancellationToken = default) => inner.LoadReligionListItemAsync(sectorId, religionId, cancellationToken);
+        public Task<ExplorerReligionDetail?> LoadReligionDetailAsync(int sectorId, int religionId, CancellationToken cancellationToken = default) => inner.LoadReligionDetailAsync(sectorId, religionId, cancellationToken);
+        public Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadEmpireFilterOptionsAsync(sectorId, cancellationToken);
+        public Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default) => inner.LoadEmpireListPageAsync(request, cancellationToken);
+        public Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default) => inner.LoadEmpireListItemAsync(sectorId, empireId, cancellationToken);
+        public Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default) => inner.LoadEmpireDetailAsync(sectorId, empireId, cancellationToken);
+        public Task<IReadOnlyList<string>> LoadTimelineEventTypesAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadTimelineEventTypesAsync(sectorId, cancellationToken);
+        public Task<ExplorerTimelinePage> LoadTimelinePageAsync(ExplorerTimelinePageRequest request, CancellationToken cancellationToken = default) => inner.LoadTimelinePageAsync(request, cancellationToken);
+        public Task<ExplorerTimelineEventDetail?> LoadTimelineEventDetailAsync(int eventId, CancellationToken cancellationToken = default) => inner.LoadTimelineEventDetailAsync(eventId, cancellationToken);
+        public Task<ExplorerHyperlaneWorkspace?> LoadHyperlaneWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default) => inner.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
     }
 }

--- a/StarWin.Web.Tests/Pages/TimelinePageTests.cs
+++ b/StarWin.Web.Tests/Pages/TimelinePageTests.cs
@@ -16,7 +16,8 @@ public sealed class TimelinePageTests : BunitContext
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
         var queryService = new FakeExplorerQueryService();
-        ConfigureServices(CreateContext(), queryService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, queryService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/timeline?sectorId=7&systemId=11");
@@ -29,6 +30,8 @@ public sealed class TimelinePageTests : BunitContext
             Assert.Contains("Border war begins", cut.Markup);
             Assert.Equal(1, queryService.LoadTimelineEventTypesCallCount);
             Assert.Single(queryService.PageRequests);
+            Assert.Equal(1, queryService.LoadSectorEntityUsageCallCount);
+            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
 
         cut.Find(".timeline-filter-panel select").Change("War");
@@ -62,7 +65,8 @@ public sealed class TimelinePageTests : BunitContext
                 new ExplorerLookupOption(101, "Eos"),
                 new ExplorerLookupOption(11, "Helios"))
         };
-        ConfigureServices(CreateContext(), queryService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, queryService);
 
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo("http://localhost/sector-explorer/timeline?sectorId=7&systemId=11");
@@ -87,6 +91,7 @@ public sealed class TimelinePageTests : BunitContext
 
         cut.FindAll(".timeline-links button").Single(button => button.TextContent.Contains("System: Helios", StringComparison.Ordinal)).Click();
         Assert.EndsWith("/sector-explorer/systems?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
+        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
     [Fact]
@@ -110,7 +115,8 @@ public sealed class TimelinePageTests : BunitContext
                 null,
                 null)
         };
-        ConfigureServices(CreateContext(), queryService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, queryService);
 
         var cut = Render<Timeline>();
         cut.WaitForAssertion(() => Assert.Contains("Border war begins", cut.Markup));
@@ -120,6 +126,7 @@ public sealed class TimelinePageTests : BunitContext
 
         cut.Find(".timeline-secondary-button").Click();
         cut.WaitForAssertion(() => Assert.Contains("\"Century\": \"1\"", cut.Markup));
+        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
     [Fact]
@@ -130,7 +137,8 @@ public sealed class TimelinePageTests : BunitContext
         {
             DelayFirstTimelinePage = true
         };
-        ConfigureServices(CreateContext(), queryService);
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, queryService);
 
         var cut = Render<Timeline>();
 
@@ -148,12 +156,13 @@ public sealed class TimelinePageTests : BunitContext
             Assert.DoesNotContain("Preparing timeline events for the selected sector.", cut.Markup);
             Assert.Contains("Border war begins", cut.Markup);
         });
+        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
-    private void ConfigureServices(StarWinExplorerContext context, FakeExplorerQueryService? queryService = null)
+    private void ConfigureServices(FakeExplorerContextService explorerContextService, FakeExplorerQueryService? queryService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
-        Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
+        Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new FakeExplorerQueryService());
     }
@@ -203,6 +212,8 @@ public sealed class TimelinePageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
+        public int LoadSectorAsyncCallCount { get; private set; }
+
         public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
@@ -210,6 +221,7 @@ public sealed class TimelinePageTests : BunitContext
 
         public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
         {
+            LoadSectorAsyncCallCount++;
             return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
@@ -221,6 +233,7 @@ public sealed class TimelinePageTests : BunitContext
 
     private sealed class FakeExplorerQueryService : IStarWinExplorerQueryService
     {
+        public int LoadSectorEntityUsageCallCount { get; private set; }
         public int LoadTimelineEventTypesCallCount { get; private set; }
 
         public List<ExplorerTimelinePageRequest> PageRequests { get; } = [];
@@ -232,6 +245,12 @@ public sealed class TimelinePageTests : BunitContext
         public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0, [], []));
+        }
+
+        public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            LoadSectorEntityUsageCallCount++;
+            return Task.FromResult(new ExplorerSectorEntityUsage(sectorId, [3], [8]));
         }
 
         public Task<ExplorerAlienRaceFilterOptions> LoadAlienRaceFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Pages/TimelinePageTests.cs
+++ b/StarWin.Web.Tests/Pages/TimelinePageTests.cs
@@ -31,7 +31,6 @@ public sealed class TimelinePageTests : BunitContext
             Assert.Equal(1, queryService.LoadTimelineEventTypesCallCount);
             Assert.Single(queryService.PageRequests);
             Assert.Equal(1, queryService.LoadSectorEntityUsageCallCount);
-            Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
         });
 
         cut.Find(".timeline-filter-panel select").Change("War");
@@ -91,7 +90,6 @@ public sealed class TimelinePageTests : BunitContext
 
         cut.FindAll(".timeline-links button").Single(button => button.TextContent.Contains("System: Helios", StringComparison.Ordinal)).Click();
         Assert.EndsWith("/sector-explorer/systems?sectorId=7&systemId=11", navigationManager.Uri, StringComparison.Ordinal);
-        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
     [Fact]
@@ -126,7 +124,6 @@ public sealed class TimelinePageTests : BunitContext
 
         cut.Find(".timeline-secondary-button").Click();
         cut.WaitForAssertion(() => Assert.Contains("\"Century\": \"1\"", cut.Markup));
-        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
     [Fact]
@@ -156,7 +153,6 @@ public sealed class TimelinePageTests : BunitContext
             Assert.DoesNotContain("Preparing timeline events for the selected sector.", cut.Markup);
             Assert.Contains("Border war begins", cut.Markup);
         });
-        Assert.Equal(0, explorerContextService.LoadSectorAsyncCallCount);
     }
 
     private void ConfigureServices(FakeExplorerContextService explorerContextService, FakeExplorerQueryService? queryService = null)
@@ -212,17 +208,9 @@ public sealed class TimelinePageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public int LoadSectorAsyncCallCount { get; private set; }
-
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            LoadSectorAsyncCallCount++;
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/TimelinePageTests.cs
+++ b/StarWin.Web.Tests/Pages/TimelinePageTests.cs
@@ -202,13 +202,12 @@ public sealed class TimelinePageTests : BunitContext
             [sector],
             sector,
             [new AlienRace { Id = 3, Name = "Krell" }],
-            [new Empire { Id = 8, Name = "Orion Compact" }],
-            []);
+            [new Empire { Id = 8, Name = "Orion Compact" }]);
     }
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/TimelinePageTests.cs
+++ b/StarWin.Web.Tests/Pages/TimelinePageTests.cs
@@ -231,7 +231,7 @@ public sealed class TimelinePageTests : BunitContext
 
         public Task<ExplorerSectorOverviewData> LoadSectorOverviewAsync(int sectorId, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0, [], []));
+            return Task.FromResult(new ExplorerSectorOverviewData(sectorId, 0, 0, 0, 0, 0));
         }
 
         public Task<ExplorerSectorEntityUsage> LoadSectorEntityUsageAsync(int sectorId, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Pages/TimelinePageTests.cs
+++ b/StarWin.Web.Tests/Pages/TimelinePageTests.cs
@@ -30,7 +30,7 @@ public sealed class TimelinePageTests : BunitContext
             Assert.Contains("Border war begins", cut.Markup);
             Assert.Equal(1, queryService.LoadTimelineEventTypesCallCount);
             Assert.Single(queryService.PageRequests);
-            Assert.Equal(1, queryService.LoadSectorEntityUsageCallCount);
+            Assert.Equal(0, queryService.LoadSectorEntityUsageCallCount);
         });
 
         cut.Find(".timeline-filter-panel select").Change("War");

--- a/StarWin.Web.Tests/Pages/WorldsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/WorldsPageTests.cs
@@ -258,14 +258,9 @@ public sealed class WorldsPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
-        }
-
-        public Task<StarWinSector?> LoadSectorAsync(int sectorId, ExplorerSectorLoadSections loadSections, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<StarWinSector?>(context.Sectors.FirstOrDefault(sector => sector.Id == sectorId));
         }
     }
 

--- a/StarWin.Web.Tests/Pages/WorldsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/WorldsPageTests.cs
@@ -231,8 +231,7 @@ public sealed class WorldsPageTests : BunitContext
             [sector],
             sector,
             [],
-            [new Empire { Id = 2, Name = "Orion Compact" }, new Empire { Id = 3, Name = "Zephyr League" }],
-            []);
+            [new Empire { Id = 2, Name = "Orion Compact" }, new Empire { Id = 3, Name = "Zephyr League" }]);
     }
 
     private static World CreateWorld(int id, string name, string worldType)
@@ -259,7 +258,7 @@ public sealed class WorldsPageTests : BunitContext
 
     private sealed class FakeExplorerContextService(StarWinExplorerContext context) : IStarWinExplorerContextService
     {
-        public Task<StarWinExplorerContext> LoadShellAsync(bool includeSavedRoutes = true, bool includeReferenceData = true, int? detailedSectorId = null, ExplorerSectorLoadSections detailedSectorSections = ExplorerSectorLoadSections.None, CancellationToken cancellationToken = default)
+        public Task<StarWinExplorerContext> LoadShellAsync(int? preferredSectorId = null, bool includeReferenceData = false, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(context);
         }

--- a/StarWin.Web.Tests/Pages/WorldsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/WorldsPageTests.cs
@@ -152,6 +152,7 @@ public sealed class WorldsPageTests : BunitContext
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
+        Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinImageService>(new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());

--- a/StarWin.Web.Tests/Pages/WorldsPageTests.cs
+++ b/StarWin.Web.Tests/Pages/WorldsPageTests.cs
@@ -52,6 +52,59 @@ public sealed class WorldsPageTests : BunitContext
     }
 
     [Fact]
+    public void ShowsSelectionPromptUntilWorldOrHabitatIsExplicitlyChosen()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var imageService = new CountingImageService();
+        ConfigureServices(CreateContext(), imageService: imageService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/worlds?sectorId=7");
+
+        var cut = Render<Worlds>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Select a world or habitat to load its details.", cut.Markup);
+            Assert.Empty(cut.FindAll(".record-row.active"));
+            Assert.DoesNotContain("Planet survey", cut.Markup);
+            Assert.Equal(0, imageService.ImageLoadCount);
+        });
+
+        cut.FindAll(".record-row")
+            .Single(button => button.TextContent.Contains("Eos", StringComparison.Ordinal))
+            .Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Planet survey", cut.Markup);
+            Assert.Contains("Eos", cut.Markup);
+            Assert.Single(cut.FindAll(".record-row.active"));
+            Assert.Equal(1, imageService.ImageLoadCount);
+            Assert.EndsWith("/sector-explorer/worlds?sectorId=7&systemId=11&worldId=101", navigationManager.Uri, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void LoadsRequestedWorldImagesOnlyOnceOnInitialRender()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var imageService = new CountingImageService();
+        ConfigureServices(CreateContext(), imageService: imageService);
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/worlds?sectorId=7&systemId=11&worldId=101");
+
+        var cut = Render<Worlds>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Planet survey", cut.Markup);
+            Assert.Equal(1, imageService.ImageLoadCount);
+        });
+    }
+
+    [Fact]
     public void FiltersWorldsBySearchQueryAndClearsFilters()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -148,13 +201,16 @@ public sealed class WorldsPageTests : BunitContext
         Assert.EndsWith("/sector-explorer/colonies?sectorId=7&systemId=11&worldId=101&colonyId=501", navigationManager.Uri, StringComparison.Ordinal);
     }
 
-    private void ConfigureServices(StarWinExplorerContext context, FakeSpaceHabitatService? habitatService = null)
+    private void ConfigureServices(
+        StarWinExplorerContext context,
+        FakeSpaceHabitatService? habitatService = null,
+        IStarWinImageService? imageService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(new FakeExplorerContextService(context));
         Services.AddSingleton<IStarWinExplorerQueryService>(new ContextBackedExplorerQueryService(context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
-        Services.AddSingleton<IStarWinImageService>(new FakeImageService());
+        Services.AddSingleton(imageService ?? new FakeImageService());
         Services.AddSingleton<IStarWinEntityNameService>(new FakeEntityNameService());
         Services.AddSingleton<IStarWinEntityNoteService>(new FakeEntityNoteService());
         Services.AddSingleton<IStarWinSpaceHabitatService>(habitatService ?? new FakeSpaceHabitatService());
@@ -273,6 +329,38 @@ public sealed class WorldsPageTests : BunitContext
     {
         public Task<IReadOnlyList<EntityImage>> GetImagesAsync(CancellationToken cancellationToken = default)
         {
+            return Task.FromResult<IReadOnlyList<EntityImage>>([]);
+        }
+
+        public Task<EntityImage> UploadImageAsync(EntityImageTargetKind targetKind, int targetId, string fileName, string contentType, Stream content, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new EntityImage
+            {
+                TargetKind = targetKind,
+                TargetId = targetId,
+                FileName = fileName
+            });
+        }
+    }
+
+    private sealed class CountingImageService : IStarWinImageService
+    {
+        public int ImageLoadCount { get; private set; }
+
+        public Task<IReadOnlyList<EntityImage>> GetImagesAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<EntityImage>>([]);
+        }
+
+        public Task<IReadOnlyList<EntityImage>> GetImagesAsync(
+            IReadOnlyCollection<EntityImageTarget> targets,
+            CancellationToken cancellationToken = default)
+        {
+            if (targets.Count > 0)
+            {
+                ImageLoadCount++;
+            }
+
             return Task.FromResult<IReadOnlyList<EntityImage>>([]);
         }
 

--- a/StarWin.Web/Components/Explorer/ExplorerTimelineLinkTarget.cs
+++ b/StarWin.Web/Components/Explorer/ExplorerTimelineLinkTarget.cs
@@ -1,0 +1,6 @@
+namespace StarWin.Web.Components.Explorer;
+
+public sealed record ExplorerTimelineLinkTarget(
+    int SystemId,
+    int WorldId = 0,
+    int ColonyId = 0);

--- a/StarWin.Web/Components/Explorer/ExplorerTimelineSection.razor
+++ b/StarWin.Web/Components/Explorer/ExplorerTimelineSection.razor
@@ -92,11 +92,11 @@
                 }
                 @if (selectedTimelineEventDetail.Colony is { } colony)
                 {
-                    <button type="button" @onclick="() => ColonySelected.InvokeAsync(colony.Id)">Colony: @colony.Name</button>
+                    <button type="button" @onclick="() => ColonySelected.InvokeAsync(BuildColonyLinkTarget(colony.Id))">Colony: @colony.Name</button>
                 }
                 @if (selectedTimelineEventDetail.World is { } world)
                 {
-                    <button type="button" @onclick="() => WorldSelected.InvokeAsync(world.Id)">World: @world.Name</button>
+                    <button type="button" @onclick="() => WorldSelected.InvokeAsync(BuildWorldLinkTarget(world.Id))">World: @world.Name</button>
                 }
                 @if (selectedTimelineEventDetail.System is { } system)
                 {
@@ -133,10 +133,10 @@
     public EventCallback<int> EmpireSelected { get; set; }
 
     [Parameter]
-    public EventCallback<int> ColonySelected { get; set; }
+    public EventCallback<ExplorerTimelineLinkTarget> ColonySelected { get; set; }
 
     [Parameter]
-    public EventCallback<int> WorldSelected { get; set; }
+    public EventCallback<ExplorerTimelineLinkTarget> WorldSelected { get; set; }
 
     [Parameter]
     public EventCallback<int> SystemSelected { get; set; }
@@ -318,6 +318,21 @@
             offset,
             limit,
             selectedEventType);
+    }
+
+    private ExplorerTimelineLinkTarget BuildColonyLinkTarget(int colonyId)
+    {
+        return new ExplorerTimelineLinkTarget(
+            selectedTimelineEventDetail?.System?.Id ?? 0,
+            selectedTimelineEventDetail?.World?.Id ?? 0,
+            colonyId);
+    }
+
+    private ExplorerTimelineLinkTarget BuildWorldLinkTarget(int worldId)
+    {
+        return new ExplorerTimelineLinkTarget(
+            selectedTimelineEventDetail?.System?.Id ?? 0,
+            worldId);
     }
 
     private string GetFilterSummary()

--- a/StarWin.Web/Components/Explorer/SectorExplorerMapWorkspace.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerMapWorkspace.razor
@@ -551,6 +551,7 @@ else
             renderedRouteConfigurationStamp = GetRouteConfigurationStamp(sector);
             renderedOverview = true;
             renderError = string.Empty;
+            await InvokeAsync(StateHasChanged);
         }
         catch (Exception ex)
         {

--- a/StarWin.Web/Components/Explorer/SectorExplorerMapWorkspace.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerMapWorkspace.razor
@@ -63,6 +63,16 @@ else
                 <span class="panel-kicker">3D Sector Map</span>
                 <h2>@mapPanelTitle</h2>
                 <p>The interactive map is available on request so large imported sectors do not slow down the explorer while you browse records.</p>
+                @if (ShouldRecommendSavedRouteGeneration(mapSector))
+                {
+                    <div class="route-cache-note">
+                        <p>@GetSavedRouteGenerationRecommendation(mapSector, isDynamicFallbackActive: false)</p>
+                        <a class="overlay-action route-cache-action"
+                           href="@BuildSectorConfigurationRoute()">
+                            Open sector configuration
+                        </a>
+                    </div>
+                }
                 <label class="switch-field">
                     <input type="checkbox"
                            checked="@autoLoadRequested"
@@ -86,6 +96,16 @@ else
                 @if (!string.IsNullOrWhiteSpace(sectorMapPerformanceStatus))
                 {
                     <small class="map-performance-status">@sectorMapPerformanceStatus</small>
+                }
+                @if (ShouldRecommendSavedRouteGeneration(mapSector))
+                {
+                    <div class="route-cache-note route-cache-note-compact">
+                        <p>@GetSavedRouteGenerationRecommendation(mapSector, isDynamicFallbackActive: true)</p>
+                        <a class="overlay-action route-cache-action"
+                           href="@BuildSectorConfigurationRoute()">
+                            Open sector configuration
+                        </a>
+                    </div>
                 }
                 @if (selectedRoutePlan is { } hudRoutePlan)
                 {
@@ -532,6 +552,23 @@ else
     private StarWinSector GetSelectionSector()
     {
         return GetMapSector();
+    }
+
+    private string BuildSectorConfigurationRoute()
+    {
+        return SectorExplorerRoutes.BuildSectionUri("Configuration", SectorId, selectedSystemId);
+    }
+
+    private static string GetSavedRouteGenerationRecommendation(StarWinSector sector, bool isDynamicFallbackActive)
+    {
+        return isDynamicFallbackActive
+            ? $"{sector.Name} is using dynamically generated hyperlane routes because this sector does not have saved routes yet. Run Save Current Routes in Sector Configuration to make future map loads much faster."
+            : $"{sector.Name} does not have saved hyperlane routes yet. The map can generate them dynamically, but running Save Current Routes in Sector Configuration will make future map loads much faster.";
+    }
+
+    private static bool ShouldRecommendSavedRouteGeneration(StarWinSector sector)
+    {
+        return sector.SavedRoutes.Count == 0;
     }
 
     private static int ResolveSelectedSystemId(StarWinSector sector, int requestedSystemId)

--- a/StarWin.Web/Components/Explorer/SectorExplorerMapWorkspace.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerMapWorkspace.razor
@@ -63,16 +63,6 @@ else
                 <span class="panel-kicker">3D Sector Map</span>
                 <h2>@mapPanelTitle</h2>
                 <p>The interactive map is available on request so large imported sectors do not slow down the explorer while you browse records.</p>
-                @if (ShouldRecommendSavedRouteGeneration(mapSector))
-                {
-                    <div class="route-cache-note">
-                        <p>@GetSavedRouteGenerationRecommendation(mapSector, isDynamicFallbackActive: false)</p>
-                        <a class="overlay-action route-cache-action"
-                           href="@BuildSectorConfigurationRoute()">
-                            Open sector configuration
-                        </a>
-                    </div>
-                }
                 <label class="switch-field">
                     <input type="checkbox"
                            checked="@autoLoadRequested"
@@ -88,63 +78,83 @@ else
         }
         else
         {
-            <div class="map-hud">
-                <span>3D Sector Map</span>
-                <strong>@mapSector.Name</strong>
-                <small>@GetSectorMapSystemCount(mapSector, selectedMapSystem) of @mapSector.Systems.Count systems within @sectorMapViewDistanceParsecs parsecs@(IsSectorMapCapped(mapSector, selectedMapSystem) ? $" (closest {sectorMapRenderLimit:N0} shown)" : string.Empty)</small>
-                <small>@GetSectorMapRouteCount(mapSector, selectedMapSystem) visible hyperlanes</small>
-                @if (!string.IsNullOrWhiteSpace(sectorMapPerformanceStatus))
-                {
-                    <small class="map-performance-status">@sectorMapPerformanceStatus</small>
-                }
-                @if (ShouldRecommendSavedRouteGeneration(mapSector))
-                {
-                    <div class="route-cache-note route-cache-note-compact">
-                        <p>@GetSavedRouteGenerationRecommendation(mapSector, isDynamicFallbackActive: true)</p>
-                        <a class="overlay-action route-cache-action"
-                           href="@BuildSectorConfigurationRoute()">
-                            Open sector configuration
-                        </a>
-                    </div>
-                }
-                @if (selectedRoutePlan is { } hudRoutePlan)
-                {
-                    <small>@hudRoutePlan.Legs.Count route legs from @hudRoutePlan.Origin.Name to @hudRoutePlan.Destination.Name; @hudRoutePlan.OffHyperlaneLegCount off-lane</small>
-                }
-                <label class="switch-field compact">
-                    <input type="checkbox"
-                           checked="@autoLoadRequested"
-                           @onchange="ToggleAutoLoadSectorMap" />
-                    <span>Auto-load</span>
-                </label>
-                <label class="map-distance-control">
-                    <span>View distance</span>
-                    <input type="range"
-                           min="@DefaultSectorMapViewDistanceParsecs"
-                           max="@GetSectorMapMaximumViewDistance(mapSector)"
-                           step="1"
-                           @bind="sectorMapViewDistanceParsecs"
-                           @bind:event="oninput" />
-                    <strong>@sectorMapViewDistanceParsecs pc</strong>
-                </label>
-                <button type="button" class="overlay-action" @onclick="RefreshSectorMapContextAsync" disabled="@mapContextRefreshing">@mapContextActionLabel</button>
-                @if (!string.IsNullOrWhiteSpace(mapContextStatus))
-                {
-                    <small>@mapContextStatus</small>
-                }
-            </div>
-            <button type="button" class="map-fullscreen-button" @onclick="ToggleSectorMapFullscreen">
-                <span class="enter-fullscreen">Full screen</span>
-                <span class="exit-fullscreen">Exit full screen</span>
-            </button>
-            <div class="map-controls-hint">
-                <span>Drag rotate</span>
-                <span>WASD/QE rotate</span>
-                <span>Wheel zoom</span>
-                <span>Right-drag pan</span>
+            if (!renderedOverview)
+            {
+                <article class="map-request-panel workspace-loading-copy">
+                    <span class="panel-kicker">3D Sector Map</span>
+                    <h2>Preparing map workspace</h2>
+                    <p>The interactive map and route planner are loading for the selected sector.</p>
+                </article>
+            }
+            else
+            {
+                <div class="map-hud">
+                    <span>3D Sector Map</span>
+                    <strong>@mapSector.Name</strong>
+                    <small>@GetSectorMapSystemCount(mapSector, selectedMapSystem) of @mapSector.Systems.Count systems within @sectorMapViewDistanceParsecs parsecs@(IsSectorMapCapped(mapSector, selectedMapSystem) ? $" (closest {sectorMapRenderLimit:N0} shown)" : string.Empty)</small>
+                    <small>@GetSectorMapRouteCount(mapSector, selectedMapSystem) visible hyperlanes</small>
+                    @if (!string.IsNullOrWhiteSpace(sectorMapPerformanceStatus))
+                    {
+                        <small class="map-performance-status">@sectorMapPerformanceStatus</small>
+                    }
+                    @if (selectedRoutePlan is { } hudRoutePlan)
+                    {
+                        <small>@hudRoutePlan.Legs.Count route legs from @hudRoutePlan.Origin.Name to @hudRoutePlan.Destination.Name; @hudRoutePlan.OffHyperlaneLegCount off-lane</small>
+                    }
+                    <label class="switch-field compact">
+                        <input type="checkbox"
+                               checked="@autoLoadRequested"
+                               @onchange="ToggleAutoLoadSectorMap" />
+                        <span>Auto-load</span>
+                    </label>
+                    <label class="map-distance-control">
+                        <span>View distance</span>
+                        <input type="range"
+                               min="@DefaultSectorMapViewDistanceParsecs"
+                               max="@GetSectorMapMaximumViewDistance(mapSector)"
+                               step="1"
+                               @bind="sectorMapViewDistanceParsecs"
+                               @bind:event="oninput" />
+                        <strong>@sectorMapViewDistanceParsecs pc</strong>
+                    </label>
+                    <button type="button" class="overlay-action" @onclick="RefreshSectorMapContextAsync" disabled="@mapContextRefreshing">@mapContextActionLabel</button>
+                    @if (!string.IsNullOrWhiteSpace(mapContextStatus))
+                    {
+                        <small>@mapContextStatus</small>
+                    }
+                </div>
+                <button type="button" class="map-fullscreen-button" @onclick="ToggleSectorMapFullscreen">
+                    <span class="enter-fullscreen">Full screen</span>
+                    <span class="exit-fullscreen">Exit full screen</span>
+                </button>
+                <div class="map-controls-hint">
+                    <span>Drag rotate</span>
+                    <span>WASD/QE rotate</span>
+                    <span>Wheel zoom</span>
+                    <span>Right-drag pan</span>
+                </div>
+            }
+        }
+        @if (sectorMapRequested && !renderedOverview)
+        {
+            <div class="workspace-loading-modal-host">
+                <LoadingModal IsVisible="true"
+                              BackdropClass="inline-loading-modal-backdrop workspace-loading-backdrop workspace-loading-shared-backdrop"
+                              AriaLabel="Loading 3D sector map"
+                              Kicker="3D sector map"
+                              Title="Loading 3D sector map"
+                              Detail="Preparing the selected sector for the interactive map and route planner."
+                              Steps="@mapContextLoadingSteps">
+                    <AfterMeterContent>
+                        @if (ShouldRecommendSavedRouteGeneration(mapSector))
+                        {
+                            <p class="workspace-loading-note">@GetSavedRouteGenerationLoadingNote()</p>
+                        }
+                    </AfterMeterContent>
+                </LoadingModal>
             </div>
         }
-        @if (sectorMapRequested && selectedMapSystem is not null)
+        @if (sectorMapRequested && renderedOverview && selectedMapSystem is not null)
         {
             <article class="fullscreen-system-overlay">
                 <span class="panel-kicker">Current system</span>
@@ -159,7 +169,7 @@ else
                 <button type="button" class="overlay-action" @onclick="OpenSelectedSystemRecordAsync">Open system record</button>
             </article>
         }
-        @if (sectorMapRequested)
+        @if (sectorMapRequested && renderedOverview)
         {
             <article class="fullscreen-route-planner route-planner-panel">
                 <span class="panel-kicker">Route planner</span>
@@ -554,21 +564,14 @@ else
         return GetMapSector();
     }
 
-    private string BuildSectorConfigurationRoute()
-    {
-        return SectorExplorerRoutes.BuildSectionUri("Configuration", SectorId, selectedSystemId);
-    }
-
-    private static string GetSavedRouteGenerationRecommendation(StarWinSector sector, bool isDynamicFallbackActive)
-    {
-        return isDynamicFallbackActive
-            ? $"{sector.Name} is using dynamically generated hyperlane routes because this sector does not have saved routes yet. Run Save Current Routes in Sector Configuration to make future map loads much faster."
-            : $"{sector.Name} does not have saved hyperlane routes yet. The map can generate them dynamically, but running Save Current Routes in Sector Configuration will make future map loads much faster.";
-    }
-
     private static bool ShouldRecommendSavedRouteGeneration(StarWinSector sector)
     {
         return sector.SavedRoutes.Count == 0;
+    }
+
+    private static string GetSavedRouteGenerationLoadingNote()
+    {
+        return "No saved routes yet. The map is generating them dynamically. Use Save Current Routes in Sector Configuration to speed up future loads.";
     }
 
     private static int ResolveSelectedSystemId(StarWinSector sector, int requestedSystemId)

--- a/StarWin.Web/Components/Explorer/SectorExplorerRoutes.cs
+++ b/StarWin.Web/Components/Explorer/SectorExplorerRoutes.cs
@@ -53,7 +53,8 @@ public static class SectorExplorerRoutes
         int habitatId = 0,
         int raceId = 0,
         int empireId = 0,
-        int religionId = 0)
+        int religionId = 0,
+        int hyperlaneId = 0)
     {
         var slug = GetSectionSlug(sectionName);
         var path = slug == "overview"
@@ -69,6 +70,7 @@ public static class SectorExplorerRoutes
         AddIfPositive(query, "raceId", raceId);
         AddIfPositive(query, "empireId", empireId);
         AddIfPositive(query, "religionId", religionId);
+        AddIfPositive(query, "hyperlaneId", hyperlaneId);
 
         return query.Count == 0 ? path : QueryHelpers.AddQueryString(path, query);
     }

--- a/StarWin.Web/Components/Layout/MainLayout.razor
+++ b/StarWin.Web/Components/Layout/MainLayout.razor
@@ -3,7 +3,7 @@
 <div class="page">
     <NavMenu />
 
-    <main class="site-main">
+    <main class="site-main" tabindex="-1">
         @Body
     </main>
 </div>

--- a/StarWin.Web/Components/Layout/MainLayout.razor.css
+++ b/StarWin.Web/Components/Layout/MainLayout.razor.css
@@ -6,6 +6,12 @@
     min-height: calc(100vh - 72px);
 }
 
+.site-main:focus,
+.site-main:focus-visible {
+    outline: none;
+    box-shadow: none;
+}
+
 #blazor-error-ui {
     color-scheme: dark;
     background: #7f1d1d;

--- a/StarWin.Web/Components/Layout/SectorExplorerFrame.razor
+++ b/StarWin.Web/Components/Layout/SectorExplorerFrame.razor
@@ -1,0 +1,30 @@
+<section class="explorer-page">
+    <SectorExplorerShell HeroContent="State.HeroContent"
+                         Sectors="State.Sectors"
+                         Systems="State.Systems"
+                         SelectedSectorId="@State.SelectedSectorId"
+                         SelectedSectorChanged="State.SelectedSectorChanged"
+                         SelectedSystemText="@State.SelectedSystemText"
+                         SelectedSystemTextChanged="State.SelectedSystemTextChanged"
+                         SearchQuery="@State.SearchQuery"
+                         SearchQueryChanged="State.SearchQueryChanged"
+                         SearchResults="State.SearchResults"
+                         SearchResultSelected="State.SearchResultSelected"
+                         Sections="State.Sections"
+                         ActiveSection="@State.ActiveSection"
+                         ErrorMessage="@State.ErrorMessage"
+                         ResultTypeDisplayFactory="State.ResultTypeDisplayFactory"
+                         SectionHrefFactory="State.SectionHrefFactory"
+                         HeaderContent="State.HeaderContent"
+                         FooterContent="State.FooterContent">
+        @ChildContent
+    </SectorExplorerShell>
+</section>
+
+@code {
+    [Parameter, EditorRequired]
+    public SectorExplorerLayoutState State { get; set; } = default!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}

--- a/StarWin.Web/Components/Pages/Aliens.razor
+++ b/StarWin.Web/Components/Pages/Aliens.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/aliens"
 @rendermode InteractiveServer
 
@@ -27,7 +27,7 @@
 }
 
 <PageTitle>Aliens | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="content-grid">
             <div class="record-list">
@@ -163,3 +163,4 @@
                                   WorldSelected="NavigateToWorld"
                                   EmpireSelected="NavigateToEmpire" />
         </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Aliens.razor.cs
+++ b/StarWin.Web/Components/Pages/Aliens.razor.cs
@@ -327,8 +327,6 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
-            includeSavedRoutes: false,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 

--- a/StarWin.Web/Components/Pages/Aliens.razor.cs
+++ b/StarWin.Web/Components/Pages/Aliens.razor.cs
@@ -71,6 +71,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     private bool browserSessionReady;
     private bool browserSessionRestored;
     private int loadedRaceSectorId;
+    private int loadedRaceDetailId;
     private readonly List<ExplorerAlienRaceListItem> loadedRaceSummaries = [];
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
@@ -131,6 +132,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         var sector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await EnsureSelectedRaceSummaryVisibleAsync();
         await EnsureSelectedRaceDetailAsync();
 
         Logger.LogInformation(
@@ -431,8 +433,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         {
             loadedRaceSummaries.Clear();
             raceHasMoreRecords = false;
-            selectedRaceId = 0;
-            selectedRaceDetail = null;
+            ClearSelectedRaceDetail();
             raceFilterOptions = new([], [], [], []);
             Logger.LogInformation("Aliens page LoadRacePageAsync reset to empty state because selectedSectorId <= 0.");
             return;
@@ -444,6 +445,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             loadedRaceSectorId = selectedSectorId;
             raceHasMoreRecords = false;
             raceObserverConfigured = false;
+            ClearSelectedRaceDetail();
             raceFilterOptions = await ExplorerQueryService.LoadAlienRaceFilterOptionsAsync(selectedSectorId, cancellationToken);
             await LoadMoreRaceSummariesAsync(cancellationToken);
         }
@@ -495,17 +497,6 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             }
 
             raceHasMoreRecords = page.HasMore;
-            if (selectedRaceId == 0 && loadedRaceSummaries.Count > 0)
-            {
-                selectedRaceId = loadedRaceSummaries[0].RaceId;
-            }
-            else if (selectedRaceId > 0 && loadedRaceSummaries.All(item => item.RaceId != selectedRaceId))
-            {
-                selectedRaceId = loadedRaceSummaries.FirstOrDefault()?.RaceId ?? 0;
-            }
-
-            await EnsureSelectedRaceSummaryVisibleAsync(cancellationToken);
-            await EnsureSelectedRaceDetailAsync(cancellationToken);
             await InvokeAsync(StateHasChanged);
 
             Logger.LogInformation(
@@ -574,14 +565,18 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             : RequestedRaceId ?? selectedRaceId;
         if (targetRaceId <= 0)
         {
-            targetRaceId = loadedRaceSummaries.FirstOrDefault()?.RaceId ?? 0;
+            ClearSelectedRaceDetail();
+            Logger.LogDebug("Aliens page EnsureSelectedRaceDetailAsync cleared detail because no race target is available.");
+            return;
         }
 
-        if (targetRaceId <= 0)
+        if (selectedRaceDetail?.Race.Id == targetRaceId && loadedRaceDetailId == targetRaceId)
         {
-            selectedRaceId = 0;
-            selectedRaceDetail = null;
-            Logger.LogDebug("Aliens page EnsureSelectedRaceDetailAsync cleared detail because no race target is available.");
+            selectedRaceId = targetRaceId;
+            Logger.LogDebug(
+                "Aliens page EnsureSelectedRaceDetailAsync skipped because target race detail is already loaded. selectedSectorId={SelectedSectorId} targetRaceId={TargetRaceId}",
+                selectedSectorId,
+                targetRaceId);
             return;
         }
 
@@ -607,14 +602,9 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         {
             var previousRaceId = selectedRaceDetail?.Race.Id ?? 0;
             var detail = await ExplorerQueryService.LoadAlienRaceDetailAsync(selectedSectorId, targetRaceId, cancellationToken);
-            if (detail is null && loadedRaceSummaries.Count > 0)
-            {
-                targetRaceId = loadedRaceSummaries[0].RaceId;
-                detail = await ExplorerQueryService.LoadAlienRaceDetailAsync(selectedSectorId, targetRaceId, cancellationToken);
-            }
-
             selectedRaceDetail = detail;
             selectedRaceId = detail?.Race.Id ?? 0;
+            loadedRaceDetailId = selectedRaceId;
             if (previousRaceId != selectedRaceId)
             {
                 entityImages = [];
@@ -632,6 +622,15 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         {
             raceDetailLoading = false;
         }
+    }
+
+    private void ClearSelectedRaceDetail()
+    {
+        selectedRaceId = 0;
+        selectedRaceDetail = null;
+        loadedRaceDetailId = 0;
+        entityImages = [];
+        lastLoadedRaceImageTargetId = 0;
     }
 
     private async Task PersistExplorerSessionAsync()

--- a/StarWin.Web/Components/Pages/Aliens.razor.cs
+++ b/StarWin.Web/Components/Pages/Aliens.razor.cs
@@ -16,7 +16,6 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     private const int ComboAllFilterId = -1;
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
     [Inject] protected IStarWinEntityNameService EntityNameService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
@@ -57,8 +56,8 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     protected ExplorerAlienRaceFilterOptions raceFilterOptions = new([], [], [], []);
 
     private IReadOnlyList<EntityImage> entityImages = [];
-    private bool entityImagesLoaded;
     private bool entityImagesLoading;
+    private int lastLoadedRaceImageTargetId;
     private bool raceListLoading;
     private bool raceDetailLoading;
     private string imageUploadStatus = string.Empty;
@@ -176,8 +175,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -187,7 +185,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -290,7 +288,15 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
 
     private async Task EnsureEntityImagesLoadedAsync(bool backgroundLoad = false)
     {
-        if (entityImagesLoaded || entityImagesLoading)
+        var raceId = selectedRaceDetail?.Race.Id ?? 0;
+        if (raceId <= 0)
+        {
+            entityImages = [];
+            lastLoadedRaceImageTargetId = 0;
+            return;
+        }
+
+        if (entityImagesLoading || lastLoadedRaceImageTargetId == raceId)
         {
             return;
         }
@@ -298,8 +304,9 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         entityImagesLoading = true;
         try
         {
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
+            entityImages = await ImageService.GetImagesAsync(
+                [new EntityImageTarget(EntityImageTargetKind.AlienRace, raceId)]);
+            lastLoadedRaceImageTargetId = raceId;
             explorerRenderError = string.Empty;
             if (backgroundLoad)
             {
@@ -319,16 +326,15 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
             includeSavedRoutes: false,
             includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 
-    private void RunSearch()
+    private async Task RunSearchAsync()
     {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private async Task RestoreExplorerSessionAsync()
@@ -480,6 +486,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         raceDetailLoading = true;
         try
         {
+            var previousRaceId = selectedRaceDetail?.Race.Id ?? 0;
             var detail = await ExplorerQueryService.LoadAlienRaceDetailAsync(selectedSectorId, targetRaceId, cancellationToken);
             if (detail is null && loadedRaceSummaries.Count > 0)
             {
@@ -489,6 +496,11 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
 
             selectedRaceDetail = detail;
             selectedRaceId = detail?.Race.Id ?? 0;
+            if (previousRaceId != selectedRaceId)
+            {
+                entityImages = [];
+                lastLoadedRaceImageTargetId = 0;
+            }
         }
         finally
         {
@@ -516,8 +528,8 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         {
             await using var stream = file.OpenReadStream(10 * 1024 * 1024);
             await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
+            lastLoadedRaceImageTargetId = 0;
+            await EnsureEntityImagesLoadedAsync();
             imageUploadStatus = $"{file.Name} uploaded.";
         }
         catch (Exception exception)

--- a/StarWin.Web/Components/Pages/Aliens.razor.cs
+++ b/StarWin.Web/Components/Pages/Aliens.razor.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using System.Diagnostics;
 using System.Globalization;
 using StarWin.Application.Services;
 using StarWin.Domain.Model.Entity.Media;
@@ -20,6 +22,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     [Inject] protected IStarWinEntityNameService EntityNameService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
     [Inject] protected IJSRuntime JS { get; set; } = default!;
+    [Inject] protected ILogger<Aliens> Logger { get; set; } = default!;
 
     [SupplyParameterFromQuery(Name = "sectorId")]
     public int? RequestedSectorId { get; set; }
@@ -75,6 +78,13 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page OnInitializedAsync start. requestedSectorId={RequestedSectorId} requestedSystemId={RequestedSystemId} requestedRaceId={RequestedRaceId}",
+            RequestedSectorId,
+            RequestedSystemId,
+            RequestedRaceId);
+
         await RefreshExplorerDataAsync();
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
@@ -84,12 +94,30 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         await LoadRacePageAsync(resetList: true);
+
+        Logger.LogInformation(
+            "Aliens page OnInitializedAsync complete in {ElapsedMs}ms. selectedSectorId={SelectedSectorId} selectedSystemId={SelectedSystemId} selectedRaceId={SelectedRaceId} loadedRaceCount={LoadedRaceCount}",
+            stopwatch.ElapsedMilliseconds,
+            selectedSectorId,
+            selectedSystemId,
+            selectedRaceId,
+            loadedRaceSummaries.Count);
     }
 
     protected override async Task OnParametersSetAsync()
     {
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page OnParametersSetAsync start. requestedSectorId={RequestedSectorId} requestedSystemId={RequestedSystemId} requestedRaceId={RequestedRaceId} currentSectorId={SelectedSectorId} currentRaceId={SelectedRaceId}",
+            RequestedSectorId,
+            RequestedSystemId,
+            RequestedRaceId,
+            selectedSectorId,
+            selectedRaceId);
+
         if (ExplorerSectors.Count == 0)
         {
+            Logger.LogInformation("Aliens page OnParametersSetAsync skipped because explorer shell has no sectors.");
             return;
         }
 
@@ -104,10 +132,23 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         await EnsureSelectedRaceDetailAsync();
+
+        Logger.LogInformation(
+            "Aliens page OnParametersSetAsync complete in {ElapsedMs}ms. selectedSectorId={SelectedSectorId} selectedSystemId={SelectedSystemId} selectedRaceId={SelectedRaceId}",
+            stopwatch.ElapsedMilliseconds,
+            selectedSectorId,
+            selectedSystemId,
+            selectedRaceId);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        Logger.LogDebug(
+            "Aliens page OnAfterRenderAsync invoked. firstRender={FirstRender} selectedSectorId={SelectedSectorId} selectedRaceId={SelectedRaceId}",
+            firstRender,
+            selectedSectorId,
+            selectedRaceId);
+
         if (firstRender)
         {
             await RestoreExplorerSessionAsync();
@@ -325,9 +366,20 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
 
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page RefreshExplorerDataAsync start. preferredSectorId={PreferredSectorId}",
+            RequestedSectorId ?? selectedSectorId);
+
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
             cancellationToken: cancellationToken);
+
+        Logger.LogInformation(
+            "Aliens page RefreshExplorerDataAsync complete in {ElapsedMs}ms. sectorCount={SectorCount} currentSectorId={CurrentSectorId}",
+            stopwatch.ElapsedMilliseconds,
+            explorerContext.Sectors.Count,
+            explorerContext.CurrentSector.Id);
     }
 
     private async Task RunSearchAsync()
@@ -366,6 +418,15 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
 
     private async Task LoadRacePageAsync(bool resetList, CancellationToken cancellationToken = default)
     {
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page LoadRacePageAsync start. resetList={ResetList} selectedSectorId={SelectedSectorId} loadedRaceSectorId={LoadedRaceSectorId} requestedRaceId={RequestedRaceId} selectedRaceId={SelectedRaceId}",
+            resetList,
+            selectedSectorId,
+            loadedRaceSectorId,
+            RequestedRaceId,
+            selectedRaceId);
+
         if (selectedSectorId <= 0)
         {
             loadedRaceSummaries.Clear();
@@ -373,6 +434,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             selectedRaceId = 0;
             selectedRaceDetail = null;
             raceFilterOptions = new([], [], [], []);
+            Logger.LogInformation("Aliens page LoadRacePageAsync reset to empty state because selectedSectorId <= 0.");
             return;
         }
 
@@ -388,14 +450,34 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
 
         await EnsureSelectedRaceSummaryVisibleAsync(cancellationToken);
         await EnsureSelectedRaceDetailAsync(cancellationToken);
+
+        Logger.LogInformation(
+            "Aliens page LoadRacePageAsync complete in {ElapsedMs}ms. selectedSectorId={SelectedSectorId} loadedRaceCount={LoadedRaceCount} hasMore={HasMore} selectedRaceId={SelectedRaceId} detailRaceId={DetailRaceId}",
+            stopwatch.ElapsedMilliseconds,
+            selectedSectorId,
+            loadedRaceSummaries.Count,
+            raceHasMoreRecords,
+            selectedRaceId,
+            selectedRaceDetail?.Race.Id ?? 0);
     }
 
     private async Task LoadMoreRaceSummariesAsync(CancellationToken cancellationToken = default)
     {
         if (raceListLoading || selectedSectorId <= 0)
         {
+            Logger.LogDebug(
+                "Aliens page LoadMoreRaceSummariesAsync skipped. raceListLoading={RaceListLoading} selectedSectorId={SelectedSectorId}",
+                raceListLoading,
+                selectedSectorId);
             return;
         }
+
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page LoadMoreRaceSummariesAsync start. selectedSectorId={SelectedSectorId} offset={Offset} selectedRaceId={SelectedRaceId}",
+            selectedSectorId,
+            loadedRaceSummaries.Count,
+            selectedRaceId);
 
         raceListLoading = true;
         try
@@ -425,6 +507,13 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             await EnsureSelectedRaceSummaryVisibleAsync(cancellationToken);
             await EnsureSelectedRaceDetailAsync(cancellationToken);
             await InvokeAsync(StateHasChanged);
+
+            Logger.LogInformation(
+                "Aliens page LoadMoreRaceSummariesAsync complete in {ElapsedMs}ms. loadedRaceCount={LoadedRaceCount} hasMore={HasMore} selectedRaceId={SelectedRaceId}",
+                stopwatch.ElapsedMilliseconds,
+                loadedRaceSummaries.Count,
+                raceHasMoreRecords,
+                selectedRaceId);
         }
         finally
         {
@@ -436,6 +525,7 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
     {
         if (HasActiveRaceFilters())
         {
+            Logger.LogDebug("Aliens page EnsureSelectedRaceSummaryVisibleAsync skipped because filters are active.");
             return;
         }
 
@@ -445,9 +535,20 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             return;
         }
 
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page EnsureSelectedRaceSummaryVisibleAsync loading missing requested race summary. selectedSectorId={SelectedSectorId} requestedRaceId={RequestedRaceId}",
+            selectedSectorId,
+            requestedRaceId);
+
         var requestedItem = await ExplorerQueryService.LoadAlienRaceListItemAsync(selectedSectorId, requestedRaceId, cancellationToken);
         if (requestedItem is null)
         {
+            Logger.LogInformation(
+                "Aliens page EnsureSelectedRaceSummaryVisibleAsync could not find requested race summary. selectedSectorId={SelectedSectorId} requestedRaceId={RequestedRaceId} elapsedMs={ElapsedMs}",
+                selectedSectorId,
+                requestedRaceId,
+                stopwatch.ElapsedMilliseconds);
             return;
         }
 
@@ -457,6 +558,13 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
             var nameComparison = string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase);
             return nameComparison != 0 ? nameComparison : left.RaceId.CompareTo(right.RaceId);
         });
+
+        Logger.LogInformation(
+            "Aliens page EnsureSelectedRaceSummaryVisibleAsync added missing requested race summary in {ElapsedMs}ms. selectedSectorId={SelectedSectorId} requestedRaceId={RequestedRaceId} loadedRaceCount={LoadedRaceCount}",
+            stopwatch.ElapsedMilliseconds,
+            selectedSectorId,
+            requestedRaceId,
+            loadedRaceSummaries.Count);
     }
 
     private async Task EnsureSelectedRaceDetailAsync(CancellationToken cancellationToken = default)
@@ -473,13 +581,26 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
         {
             selectedRaceId = 0;
             selectedRaceDetail = null;
+            Logger.LogDebug("Aliens page EnsureSelectedRaceDetailAsync cleared detail because no race target is available.");
             return;
         }
 
         if (raceDetailLoading)
         {
+            Logger.LogDebug(
+                "Aliens page EnsureSelectedRaceDetailAsync skipped because detail load is already in progress. selectedSectorId={SelectedSectorId} targetRaceId={TargetRaceId}",
+                selectedSectorId,
+                targetRaceId);
             return;
         }
+
+        var stopwatch = Stopwatch.StartNew();
+        Logger.LogInformation(
+            "Aliens page EnsureSelectedRaceDetailAsync start. selectedSectorId={SelectedSectorId} targetRaceId={TargetRaceId} requestedRaceId={RequestedRaceId} selectedRaceId={SelectedRaceId}",
+            selectedSectorId,
+            targetRaceId,
+            RequestedRaceId,
+            selectedRaceId);
 
         raceDetailLoading = true;
         try
@@ -499,6 +620,13 @@ public partial class Aliens : ComponentBase, IAsyncDisposable
                 entityImages = [];
                 lastLoadedRaceImageTargetId = 0;
             }
+
+            Logger.LogInformation(
+                "Aliens page EnsureSelectedRaceDetailAsync complete in {ElapsedMs}ms. selectedSectorId={SelectedSectorId} selectedRaceId={SelectedRaceId} detailLoaded={DetailLoaded}",
+                stopwatch.ElapsedMilliseconds,
+                selectedSectorId,
+                selectedRaceId,
+                selectedRaceDetail is not null);
         }
         finally
         {

--- a/StarWin.Web/Components/Pages/Colonies.razor
+++ b/StarWin.Web/Components/Pages/Colonies.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/colonies"
 @rendermode InteractiveServer
 
@@ -27,7 +27,7 @@
 }
 
 <PageTitle>Colonies | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="content-grid">
     <div class="record-list colony-record-list">
@@ -212,3 +212,4 @@
         </article>
     }
 </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Colonies.razor
+++ b/StarWin.Web/Components/Pages/Colonies.razor
@@ -4,15 +4,8 @@
 
 @{
     var sector = GetSelectedSector();
-    var sectionCache = GetSectorCache(sector);
-    var sectorColonies = sectionCache.Colonies;
-    var sectorRaces = ExplorerAlienRaces.Where(race => sectionCache.RaceIds.Contains(race.Id)).OrderBy(race => race.Name).ToList();
-    var sectorEmpires = ExplorerEmpires.Where(empire => sectionCache.EmpireIds.Contains(empire.Id)).OrderBy(empire => empire.Name).ToList();
-    var selectedColony = sectorColonies.Select(item => item.Colony).FirstOrDefault(colony => colony.Id == selectedColonyId)
-        ?? sectorColonies.Select(item => item.Colony).FirstOrDefault();
-    var selectedColonyWorld = selectedColony is null || !WorldsById.TryGetValue(selectedColony.WorldId, out var colonyWorld)
-        ? null
-        : colonyWorld;
+    var selectedColony = selectedColonyDetail?.Colony;
+    var selectedColonyWorld = selectedColonyDetail?.World;
     var colonyImages = selectedColony is null ? [] : GetEntityImages(EntityImageTargetKind.Colony, selectedColony.Id);
     var layoutState = new SectorExplorerLayoutState(
         null,
@@ -37,186 +30,185 @@
 <SectorExplorerLayoutSync State="layoutState" />
 
 <section class="content-grid">
-            <div class="record-list colony-record-list">
-                <details class="record-filter-panel" open>
-                    <summary class="record-filter-summary">Search</summary>
-                    <label>
-                        Search
-                        <input placeholder="Name, allegiance, population..."
-                               @bind="colonyQuery"
-                               @bind:event="oninput"
-                               @bind:after="ResetColonyWindow" />
-                    </label>
-                    <button type="button" class="timeline-clear-button" @onclick="ToggleColonyFilters">
-                        @(showColonyFilters ? "Hide filters" : "Show filters")
-                    </button>
-                    @if (showColonyFilters)
-                    {
-                        <label>
-                            Race
-                            <input list="colony-race-options"
-                                   placeholder="All races"
-                                   @bind="colonyRaceText"
-                                   @bind:event="oninput"
-                                   @bind:after="ApplyColonyRaceFilter" />
-                            <datalist id="colony-race-options">
-                                @foreach (var race in sectorRaces)
-                                {
-                                    <option value="@FormatRaceOption(race)" />
-                                }
-                            </datalist>
-                        </label>
-                        <label>
-                            Empire
-                            <input list="colony-empire-options"
-                                   placeholder="All empires"
-                                   @bind="colonyEmpireText"
-                                   @bind:event="oninput"
-                                   @bind:after="ApplyColonyEmpireFilter" />
-                            <datalist id="colony-empire-options">
-                                @foreach (var empire in sectorEmpires)
-                                {
-                                    <option value="@FormatEmpireOption(empire)" />
-                                }
-                            </datalist>
-                        </label>
-                        <label>
-                            Status
-                            <select @bind="colonyStatus" @bind:after="ResetColonyWindow">
-                                <option value="">All statuses</option>
-                                @foreach (var status in Enum.GetValues<ColonyPoliticalStatus>())
-                                {
-                                    <option value="@status.ToString()">@status</option>
-                                }
-                            </select>
-                        </label>
-                        <label>
-                            Class
-                            <input list="colony-class-options"
-                                   placeholder="All classes"
-                                   @bind="colonyClass"
-                                   @bind:event="oninput"
-                                   @bind:after="ResetColonyWindow" />
-                            <datalist id="colony-class-options">
-                                @foreach (var itemClass in sectorColonies.Select(item => item.Colony.ColonyClass).Distinct().OrderBy(item => item))
-                                {
-                                    <option value="@itemClass" />
-                                }
-                            </datalist>
-                        </label>
-                    }
-                    <button type="button" class="timeline-clear-button" @onclick="ClearColonyFilters">Clear filters</button>
-                </details>
-                @{
-                    var colonyWindow = GetFilteredColonies(sectionCache)
-                        .Take(colonyVisibleCount + 1)
-                        .ToList();
-                    var hasMoreColonies = colonyWindow.Count > colonyVisibleCount;
-                    var visibleColonies = colonyWindow.Take(colonyVisibleCount).ToList();
-                    colonyHasMoreRecords = hasMoreColonies;
-                }
-                <div class="timeline-count">Showing @visibleColonies.Count colon@(visibleColonies.Count == 1 ? "y" : "ies")@(hasMoreColonies ? "+" : string.Empty)</div>
-                @if (visibleColonies.Count == 0)
+    <div class="record-list colony-record-list">
+        <details class="record-filter-panel" open>
+            <summary class="record-filter-summary">Search</summary>
+            <label>
+                Search
+                <input placeholder="Name, allegiance, population..."
+                       @bind="colonyQuery"
+                       @bind:event="oninput"
+                       @bind:after="HandleColonyFiltersChangedAsync" />
+            </label>
+            <button type="button" class="timeline-clear-button" @onclick="ToggleColonyFilters">
+                @(showColonyFilters ? "Hide filters" : "Show filters")
+            </button>
+            @if (showColonyFilters)
+            {
+                <label>
+                    Race
+                    <input list="colony-race-options"
+                           placeholder="All races"
+                           @bind="colonyRaceText"
+                           @bind:event="oninput"
+                           @bind:after="ApplyColonyRaceFilterAsync" />
+                    <datalist id="colony-race-options">
+                        @foreach (var race in colonyFilterOptions.Races)
+                        {
+                            <option value="@FormatLookupOption(race)" />
+                        }
+                    </datalist>
+                </label>
+                <label>
+                    Empire
+                    <input list="colony-empire-options"
+                           placeholder="All empires"
+                           @bind="colonyEmpireText"
+                           @bind:event="oninput"
+                           @bind:after="ApplyColonyEmpireFilterAsync" />
+                    <datalist id="colony-empire-options">
+                        @foreach (var empire in colonyFilterOptions.Empires)
+                        {
+                            <option value="@FormatLookupOption(empire)" />
+                        }
+                    </datalist>
+                </label>
+                <label>
+                    Status
+                    <select @bind="colonyStatus" @bind:after="HandleColonyFiltersChangedAsync">
+                        <option value="">All statuses</option>
+                        @foreach (var status in Enum.GetValues<ColonyPoliticalStatus>())
+                        {
+                            <option value="@status.ToString()">@status</option>
+                        }
+                    </select>
+                </label>
+                <label>
+                    Class
+                    <input list="colony-class-options"
+                           placeholder="All classes"
+                           @bind="colonyClass"
+                           @bind:event="oninput"
+                           @bind:after="HandleColonyFiltersChangedAsync" />
+                    <datalist id="colony-class-options">
+                        @foreach (var itemClass in colonyFilterOptions.Classes)
+                        {
+                            <option value="@itemClass" />
+                        }
+                    </datalist>
+                </label>
+            }
+            <button type="button" class="timeline-clear-button" @onclick="HandleClearColonyFiltersAsync">Clear filters</button>
+        </details>
+        <div class="timeline-count">Showing @LoadedColonySummaries.Count colon@(LoadedColonySummaries.Count == 1 ? "y" : "ies")@(colonyHasMoreRecords ? "+" : string.Empty)</div>
+        @if (colonyListLoading && LoadedColonySummaries.Count == 0)
+        {
+            <article class="timeline-event-card">
+                <span class="timeline-century">Loading colonies</span>
+                <p>Querying colony records for the selected sector.</p>
+            </article>
+        }
+        else if (LoadedColonySummaries.Count == 0)
+        {
+            <article class="timeline-event-card">
+                <span class="timeline-century">No matches</span>
+                <p>Adjust the filters to widen the colony list.</p>
+            </article>
+        }
+        @foreach (var item in LoadedColonySummaries)
+        {
+            <button type="button" class="record-row @(selectedColony?.Id == item.ColonyId ? "active" : null)" @onclick="() => SelectColony(item.ColonyId)">
+                <strong>@item.ColonyName on @item.WorldName</strong>
+                <span>@item.AllegianceName; @DisplayPopulation(item.EstimatedPopulation)</span>
+            </button>
+        }
+        @if (colonyHasMoreRecords)
+        {
+            <div @ref="colonyLoadMoreElement" class="timeline-load-more">
+                <button type="button" @onclick="LoadMoreColonies">Load more</button>
+            </div>
+        }
+    </div>
+
+    @if (selectedColony is not null)
+    {
+        <article class="detail-panel">
+            <span class="panel-kicker">Colony record</span>
+            <EditableEntityName Name="@DisplayColonyName(selectedColony)"
+                                Label="Colony"
+                                NameSaved="name => SaveEntityNameAsync(EntityNoteTargetKind.Colony, selectedColony.Id, name)" />
+            <section class="entity-image-panel">
+                <div class="image-panel-header">
+                    <h4>Colony images</h4>
+                    <span>Multiple allowed</span>
+                </div>
+                @if (colonyImages.Count > 0)
                 {
-                    <article class="timeline-event-card">
-                        <span class="timeline-century">No matches</span>
-                        <p>Adjust the filters to widen the colony list.</p>
-                    </article>
-                }
-                @foreach (var item in visibleColonies)
-                {
-                    <button type="button" class="record-row @(selectedColony?.Id == item.Colony.Id ? "active" : null)" @onclick="() => SelectColony(item.Colony.Id)">
-                        <strong>@DisplayColonyName(item.Colony) on @item.World.Name</strong>
-                        <span>@item.Colony.AllegianceName; @DisplayPopulation(item.Colony.EstimatedPopulation)</span>
-                    </button>
-                }
-                @if (hasMoreColonies)
-                {
-                    <div @ref="colonyLoadMoreElement" class="timeline-load-more">
-                        <button type="button" @onclick="LoadMoreColonies">Load more</button>
+                    <div class="entity-image-grid">
+                        @foreach (var image in colonyImages)
+                        {
+                            <figure>
+                                <img src="@image.RelativePath" alt="@image.FileName" />
+                                <figcaption>@(image.IsPrimary ? "Primary" : image.FileName)</figcaption>
+                            </figure>
+                        }
                     </div>
                 }
-            </div>
-
-            @if (selectedColony is not null)
+                else
+                {
+                    <p>No image uploaded.</p>
+                }
+                <label class="image-upload-control">
+                    <span>Add image</span>
+                    <InputFile OnChange="@(args => UploadEntityImage(EntityImageTargetKind.Colony, selectedColony.Id, args))" accept="image/jpeg,image/png,image/gif,image/webp" />
+                </label>
+                @if (!string.IsNullOrWhiteSpace(imageUploadStatus))
+                {
+                    <small>@imageUploadStatus</small>
+                }
+            </section>
+            @if (selectedColonyWorld is not null)
             {
-                <article class="detail-panel">
-                    <span class="panel-kicker">Colony record</span>
-                    <EditableEntityName Name="@DisplayColonyName(selectedColony)"
-                                        Label="Colony"
-                                        NameSaved="name => SaveEntityNameAsync(EntityNoteTargetKind.Colony, selectedColony.Id, name)" />
-                    <section class="entity-image-panel">
-                        <div class="image-panel-header">
-                            <h4>Colony images</h4>
-                            <span>Multiple allowed</span>
-                        </div>
-                        @if (colonyImages.Count > 0)
-                        {
-                            <div class="entity-image-grid">
-                                @foreach (var image in colonyImages)
-                                {
-                                    <figure>
-                                        <img src="@image.RelativePath" alt="@image.FileName" />
-                                        <figcaption>@(image.IsPrimary ? "Primary" : image.FileName)</figcaption>
-                                    </figure>
-                                }
-                            </div>
-                        }
-                        else
-                        {
-                            <p>No image uploaded.</p>
-                        }
-                        <label class="image-upload-control">
-                            <span>Add image</span>
-                            <InputFile OnChange="@(args => UploadEntityImage(EntityImageTargetKind.Colony, selectedColony.Id, args))" accept="image/jpeg,image/png,image/gif,image/webp" />
-                        </label>
-                        @if (!string.IsNullOrWhiteSpace(imageUploadStatus))
-                        {
-                            <small>@imageUploadStatus</small>
-                        }
-                    </section>
-                    @if (selectedColonyWorld is not null)
-                    {
-                        <div class="parent-actions">
-                            <button type="button" @onclick="() => NavigateToWorld(selectedColonyWorld.Id)">Parent world: @selectedColonyWorld.Name</button>
-                        </div>
-                    }
-                    <dl class="field-grid">
-                        <div><dt>Colony id</dt><dd>@selectedColony.Id</dd></div>
-                        <div><dt>World id</dt><dd>@selectedColony.WorldId</dd></div>
-                        <div><dt>Race</dt><dd>@selectedColony.ColonistRaceName</dd></div>
-                        <div><dt>Allegiance</dt><dd>@selectedColony.AllegianceName</dd></div>
-                        <div><dt>Status</dt><dd>@selectedColony.PoliticalStatus</dd></div>
-                        <div><dt>Population</dt><dd>@DisplayPopulation(selectedColony.EstimatedPopulation)</dd></div>
-                        <div><dt>Natives</dt><dd>@selectedColony.NativePopulationPercent%</dd></div>
-                        <div><dt>Starport</dt><dd>@selectedColony.Starport</dd></div>
-                        <div><dt>GWP</dt><dd>@selectedColony.GrossWorldProductMcr MCr</dd></div>
-                        <div><dt>Military</dt><dd>@selectedColony.MilitaryPower</dd></div>
-                        <div><dt>Major export</dt><dd>@selectedColony.ExportResource</dd></div>
-                        <div><dt>Major import</dt><dd>@selectedColony.ImportResource</dd></div>
-                        <div><dt>Law</dt><dd>@selectedColony.Law</dd></div>
-                        <div><dt>Stability</dt><dd>@selectedColony.Stability</dd></div>
-                        <div><dt>Crime</dt><dd>@selectedColony.Crime</dd></div>
-                    </dl>
-
-                    <EntityNotesPanel TargetKind="EntityNoteTargetKind.Colony"
-                                      TargetId="selectedColony.Id"
-                                      Title="Colony notes" />
-
-                    <section class="relationship-section">
-                        <h3>Demographics</h3>
-                        <div class="demographic-list">
-                            @foreach (var demographic in selectedColony.Demographics.OrderByDescending(item => item.PopulationPercent))
-                            {
-                                <button type="button" class="demographic-row" @onclick="() => NavigateToRace(demographic.RaceId)">
-                                    <span>@demographic.RaceName</span>
-                                    <strong>@($"{demographic.PopulationPercent:0.#}%")</strong>
-                                    <em style="width: @($"{demographic.PopulationPercent:0.##}%")"></em>
-                                    <small>@DisplayPopulation(GetDemographicPopulation(selectedColony, demographic))</small>
-                                </button>
-                            }
-                        </div>
-                    </section>
-                </article>
+                <div class="parent-actions">
+                    <button type="button" @onclick="() => NavigateToWorld(selectedColonyWorld.Id)">Parent world: @selectedColonyWorld.Name</button>
+                </div>
             }
-        </section>
+            <dl class="field-grid">
+                <div><dt>Colony id</dt><dd>@selectedColony.Id</dd></div>
+                <div><dt>World id</dt><dd>@selectedColony.WorldId</dd></div>
+                <div><dt>Race</dt><dd>@selectedColony.ColonistRaceName</dd></div>
+                <div><dt>Allegiance</dt><dd>@selectedColony.AllegianceName</dd></div>
+                <div><dt>Status</dt><dd>@selectedColony.PoliticalStatus</dd></div>
+                <div><dt>Population</dt><dd>@DisplayPopulation(selectedColony.EstimatedPopulation)</dd></div>
+                <div><dt>Natives</dt><dd>@selectedColony.NativePopulationPercent%</dd></div>
+                <div><dt>Starport</dt><dd>@selectedColony.Starport</dd></div>
+                <div><dt>GWP</dt><dd>@selectedColony.GrossWorldProductMcr MCr</dd></div>
+                <div><dt>Military</dt><dd>@selectedColony.MilitaryPower</dd></div>
+                <div><dt>Major export</dt><dd>@selectedColony.ExportResource</dd></div>
+                <div><dt>Major import</dt><dd>@selectedColony.ImportResource</dd></div>
+                <div><dt>Law</dt><dd>@selectedColony.Law</dd></div>
+                <div><dt>Stability</dt><dd>@selectedColony.Stability</dd></div>
+                <div><dt>Crime</dt><dd>@selectedColony.Crime</dd></div>
+            </dl>
+
+            <EntityNotesPanel TargetKind="EntityNoteTargetKind.Colony"
+                              TargetId="selectedColony.Id"
+                              Title="Colony notes" />
+
+            <section class="relationship-section">
+                <h3>Demographics</h3>
+                <div class="demographic-list">
+                    @foreach (var demographic in selectedColony.Demographics.OrderByDescending(item => item.PopulationPercent))
+                    {
+                        <button type="button" class="demographic-row" @onclick="() => NavigateToRace(demographic.RaceId)">
+                            <span>@demographic.RaceName</span>
+                            <strong>@($"{demographic.PopulationPercent:0.#}%")</strong>
+                            <em style="width: @($"{demographic.PopulationPercent:0.##}%")"></em>
+                            <small>@DisplayPopulation(GetDemographicPopulation(selectedColony, demographic))</small>
+                        </button>
+                    }
+                </div>
+            </section>
+        </article>
+    }
+</section>

--- a/StarWin.Web/Components/Pages/Colonies.razor
+++ b/StarWin.Web/Components/Pages/Colonies.razor
@@ -211,5 +211,12 @@
             </section>
         </article>
     }
+    else
+    {
+        <article class="detail-panel">
+            <span class="panel-kicker">Colony record</span>
+            <p class="alien-empty-state">Select a colony to load its details.</p>
+        </article>
+    }
 </section>
 </SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Colonies.razor.cs
+++ b/StarWin.Web/Components/Pages/Colonies.razor.cs
@@ -325,7 +325,6 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: preferredSectorId,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 

--- a/StarWin.Web/Components/Pages/Colonies.razor.cs
+++ b/StarWin.Web/Components/Pages/Colonies.razor.cs
@@ -69,6 +69,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     private bool browserSessionReady;
     private bool browserSessionRestored;
     private int loadedColonySectorId;
+    private int loadedColonyDetailId;
     private string lastLoadedImageKey = string.Empty;
     private ElementReference colonyLoadMoreElement;
     private DotNetObjectReference<Colonies>? dotNetReference;
@@ -107,6 +108,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         var sector = GetSelectedSector();
         selectedSystemId = await ResolveRequestedSystemIdAsync(sector);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await EnsureSelectedColonySummaryVisibleAsync();
         await EnsureSelectedColonyDetailAsync();
     }
 
@@ -334,11 +336,8 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         {
             loadedColonySummaries.Clear();
             colonyHasMoreRecords = false;
-            selectedColonyId = 0;
-            selectedColonyDetail = null;
+            ClearSelectedColonyDetail();
             colonyFilterOptions = new([], [], []);
-            entityImages = [];
-            lastLoadedImageKey = string.Empty;
             return;
         }
 
@@ -348,6 +347,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
             loadedColonySectorId = selectedSectorId;
             colonyHasMoreRecords = false;
             colonyObserverConfigured = false;
+            ClearSelectedColonyDetail();
             colonyFilterOptions = await ExplorerQueryService.LoadColonyFilterOptionsAsync(selectedSectorId, cancellationToken);
             await LoadMoreColoniesAsync(cancellationToken);
         }
@@ -387,17 +387,6 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
             }
 
             colonyHasMoreRecords = page.HasMore;
-            if (selectedColonyId == 0 && loadedColonySummaries.Count > 0)
-            {
-                selectedColonyId = loadedColonySummaries[0].ColonyId;
-            }
-            else if (selectedColonyId > 0 && loadedColonySummaries.All(item => item.ColonyId != selectedColonyId))
-            {
-                selectedColonyId = loadedColonySummaries.FirstOrDefault()?.ColonyId ?? 0;
-            }
-
-            await EnsureSelectedColonySummaryVisibleAsync(cancellationToken);
-            await EnsureSelectedColonyDetailAsync(cancellationToken);
             await InvokeAsync(StateHasChanged);
         }
         finally
@@ -444,19 +433,21 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         var targetColonyId = HasActiveColonyFilters()
             ? selectedColonyId
             : RequestedColonyId ?? selectedColonyId;
+
         if (targetColonyId <= 0)
         {
-            targetColonyId = loadedColonySummaries.FirstOrDefault()?.ColonyId ?? 0;
+            ClearSelectedColonyDetail();
+            return;
         }
 
-        if (targetColonyId <= 0 || colonyDetailLoading)
+        if (selectedColonyDetail?.Colony.Id == targetColonyId && loadedColonyDetailId == targetColonyId)
         {
-            if (targetColonyId <= 0)
-            {
-                selectedColonyId = 0;
-                selectedColonyDetail = null;
-            }
+            selectedColonyId = targetColonyId;
+            return;
+        }
 
+        if (colonyDetailLoading)
+        {
             return;
         }
 
@@ -464,14 +455,9 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         try
         {
             var detail = await ExplorerQueryService.LoadColonyDetailAsync(selectedSectorId, targetColonyId, cancellationToken);
-            if (detail is null && loadedColonySummaries.Count > 0)
-            {
-                targetColonyId = loadedColonySummaries[0].ColonyId;
-                detail = await ExplorerQueryService.LoadColonyDetailAsync(selectedSectorId, targetColonyId, cancellationToken);
-            }
-
             selectedColonyDetail = detail;
             selectedColonyId = detail?.Colony.Id ?? 0;
+            loadedColonyDetailId = selectedColonyId;
             if (detail?.World.StarSystemId is int systemId && systemId > 0)
             {
                 selectedSystemId = systemId;
@@ -484,6 +470,15 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         {
             colonyDetailLoading = false;
         }
+    }
+
+    private void ClearSelectedColonyDetail()
+    {
+        selectedColonyId = 0;
+        selectedColonyDetail = null;
+        loadedColonyDetailId = 0;
+        entityImages = [];
+        lastLoadedImageKey = string.Empty;
     }
 
     private async Task EnsureEntityImagesLoadedAsync(CancellationToken cancellationToken = default)

--- a/StarWin.Web/Components/Pages/Colonies.razor.cs
+++ b/StarWin.Web/Components/Pages/Colonies.razor.cs
@@ -12,13 +12,11 @@ namespace StarWin.Web.Components.Pages;
 
 public partial class Colonies : ComponentBase, IAsyncDisposable
 {
-    private const int ColonyBatchSize = 120;
+    private const int ExplorerListBatchSize = 120;
     private const int ComboAllFilterId = -1;
-    private const ExplorerSectorLoadSections DetailedSectorSections = ExplorerSectorLoadSections.Worlds
-        | ExplorerSectorLoadSections.Colonies
-        | ExplorerSectorLoadSections.ColonyDemographics;
+
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
+    [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
     [Inject] protected IStarWinEntityNameService EntityNameService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
@@ -40,10 +38,10 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     public int? RequestedEmpireId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
-    protected readonly Dictionary<int, World> WorldsById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
+    protected ExplorerColonyFilterOptions colonyFilterOptions = new([], [], []);
+    protected ExplorerColonyDetail? selectedColonyDetail;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
@@ -58,36 +56,38 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected int colonyEmpireId = ComboAllFilterId;
     protected string colonyStatus = string.Empty;
     protected string colonyClass = string.Empty;
-    protected int colonyVisibleCount = ColonyBatchSize;
     protected bool colonyHasMoreRecords;
     protected bool showColonyFilters;
-
-    private IReadOnlyList<EntityImage> entityImages = [];
-    private bool entityImagesLoaded;
-    private bool entityImagesLoading;
     protected string imageUploadStatus = string.Empty;
-    private ElementReference colonyLoadMoreElement;
-    private DotNetObjectReference<Colonies>? dotNetReference;
-    private IJSObjectReference? loadMoreScrollModule;
+
+    private readonly List<ExplorerColonyListItem> loadedColonySummaries = [];
+    private IReadOnlyList<EntityImage> entityImages = [];
+    private bool entityImagesLoading;
+    private bool colonyListLoading;
+    private bool colonyDetailLoading;
     private bool colonyObserverConfigured;
     private bool browserSessionReady;
     private bool browserSessionRestored;
+    private int loadedColonySectorId;
+    private string lastLoadedImageKey = string.Empty;
+    private ElementReference colonyLoadMoreElement;
+    private DotNetObjectReference<Colonies>? dotNetReference;
+    private IJSObjectReference? loadMoreScrollModule;
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<AlienRace> ExplorerAlienRaces => explorerContext.AlienRaces;
-    protected IReadOnlyList<Empire> ExplorerEmpires => explorerContext.Empires;
+    protected IReadOnlyList<ExplorerColonyListItem> LoadedColonySummaries => loadedColonySummaries;
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync(RequestedSectorId);
+        await RefreshExplorerShellAsync(RequestedSectorId);
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
+        selectedSystemId = await ResolveRequestedSystemIdAsync(initialSector);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
-        selectedColonyId = ResolveSelectedColonyId(initialSector);
+        await LoadColonyPageAsync(resetList: true);
     }
 
     protected override async Task OnParametersSetAsync()
@@ -101,13 +101,13 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await RefreshExplorerDataAsync(selectedSectorId);
+            await LoadColonyPageAsync(resetList: true);
         }
 
         var sector = GetSelectedSector();
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+        selectedSystemId = await ResolveRequestedSystemIdAsync(sector);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        selectedColonyId = ResolveSelectedColonyId(sector);
+        await EnsureSelectedColonyDetailAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -121,12 +121,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         }
 
         await ConfigureColonyObserverAsync();
-        _ = EnsureEntityImagesLoadedAsync(backgroundLoad: true);
     }
-
-    protected ExplorerSectorCache GetSectorCache(StarWinSector sector) => sectorCacheBuilder.Get(sector);
-
-    protected ExplorerSectorSummary GetSectorSummary(StarWinSector sector) => sectorCacheBuilder.GetSummary(sector);
 
     protected StarWinSector GetSelectedSector()
     {
@@ -156,12 +151,11 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await RefreshExplorerDataAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        selectedColonyId = ResolveSelectedColonyId(sector);
         ClearColonyFilters();
+        await LoadColonyPageAsync(resetList: true);
         await PersistExplorerSessionAsync();
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Colonies", selectedSectorId, selectedSystemId, colonyId: selectedColonyId));
     }
@@ -184,8 +178,31 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
+    }
+
+    private async Task<int> ResolveRequestedSystemIdAsync(StarWinSector sector, CancellationToken cancellationToken = default)
+    {
+        if (RequestedSystemId is int requestedSystemId
+            && sector.Systems.Any(system => system.Id == requestedSystemId))
+        {
+            return requestedSystemId;
+        }
+
+        if (RequestedColonyId is int requestedColonyId)
+        {
+            var resolvedSystemId = await ExplorerQueryService.ResolveSystemIdAsync(
+                sector.Id,
+                colonyId: requestedColonyId,
+                cancellationToken: cancellationToken);
+            if (resolvedSystemId is int requestedSelectionSystemId
+                && sector.Systems.Any(system => system.Id == requestedSelectionSystemId))
+            {
+                return requestedSelectionSystemId;
+            }
+        }
+
+        return ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -195,7 +212,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -205,13 +222,21 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
 
     protected void SelectColony(int colonyId)
     {
+        var item = loadedColonySummaries.FirstOrDefault(summary => summary.ColonyId == colonyId);
         selectedColonyId = colonyId;
+        if (item is not null && item.SystemId > 0)
+        {
+            selectedSystemId = item.SystemId;
+            selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
+        }
+
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Colonies", selectedSectorId, selectedSystemId, colonyId: colonyId), replace: true);
     }
 
     protected void NavigateToWorld(int worldId)
     {
-        NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Worlds", selectedSectorId, selectedSystemId, worldId: worldId, colonyId: selectedColonyId));
+        var targetSystemId = selectedColonyDetail?.World.StarSystemId ?? selectedSystemId;
+        NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Worlds", selectedSectorId, targetSystemId, worldId: worldId, colonyId: selectedColonyId));
     }
 
     protected void NavigateToRace(int raceId)
@@ -222,13 +247,45 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected async Task SaveEntityNameAsync(EntityNoteTargetKind targetKind, int targetId, string name)
     {
         await EntityNameService.SaveNameAsync(targetKind, targetId, name);
-        await RefreshExplorerDataAsync(selectedSectorId);
-        selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
+        await LoadColonyPageAsync(resetList: true);
     }
 
-    protected IEnumerable<(World World, Colony Colony)> GetFilteredColonies(ExplorerSectorCache sectorCache)
+    protected Task HandleColonyFiltersChangedAsync()
     {
-        return sectorCache.ColoniesByPopulation.Where(ColonyMatches);
+        ResetColonyWindow();
+        return LoadColonyPageAsync(resetList: true);
+    }
+
+    protected Task ApplyColonyRaceFilterAsync()
+    {
+        colonyRaceId = ParseComboId(colonyRaceText);
+        ResetColonyWindow();
+        return LoadColonyPageAsync(resetList: true);
+    }
+
+    protected Task ApplyColonyEmpireFilterAsync()
+    {
+        colonyEmpireId = ParseComboId(colonyEmpireText);
+        ResetColonyWindow();
+        return LoadColonyPageAsync(resetList: true);
+    }
+
+    protected void ToggleColonyFilters()
+    {
+        showColonyFilters = !showColonyFilters;
+    }
+
+    protected Task HandleClearColonyFiltersAsync()
+    {
+        ClearColonyFilters();
+        return LoadColonyPageAsync(resetList: true);
+    }
+
+    [JSInvokable]
+    public Task LoadMoreColonies()
+    {
+        colonyObserverConfigured = false;
+        return LoadMoreColoniesAsync();
     }
 
     protected IReadOnlyList<EntityImage> GetEntityImages(EntityImageTargetKind targetKind, int targetId)
@@ -264,104 +321,259 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
             : (long)Math.Round(colony.EstimatedPopulation * demographic.PopulationPercent / 100m);
     }
 
-    [JSInvokable]
-    public async Task LoadMoreColonies()
+    private async Task RefreshExplorerShellAsync(int? preferredSectorId = null, CancellationToken cancellationToken = default)
     {
-        if (loadMoreScrollModule is not null)
-        {
-            await loadMoreScrollModule.InvokeVoidAsync("disconnectColonyLoadMore");
-        }
-
-        colonyVisibleCount += ColonyBatchSize;
-        colonyObserverConfigured = false;
-        StateHasChanged();
+        explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: preferredSectorId,
+            includeReferenceData: false,
+            cancellationToken: cancellationToken);
     }
 
-    protected void ResetColonyWindow()
+    private async Task LoadColonyPageAsync(bool resetList, CancellationToken cancellationToken = default)
     {
-        colonyVisibleCount = ColonyBatchSize;
-        colonyObserverConfigured = false;
-    }
-
-    protected void ClearColonyFilters()
-    {
-        colonyQuery = string.Empty;
-        colonyRaceText = string.Empty;
-        colonyEmpireText = string.Empty;
-        colonyRaceId = ComboAllFilterId;
-        colonyEmpireId = ComboAllFilterId;
-        colonyStatus = string.Empty;
-        colonyClass = string.Empty;
-        showColonyFilters = false;
-        ResetColonyWindow();
-    }
-
-    protected void ToggleColonyFilters()
-    {
-        showColonyFilters = !showColonyFilters;
-    }
-
-    protected void ApplyColonyRaceFilter()
-    {
-        colonyRaceId = ParseComboId(colonyRaceText);
-        ResetColonyWindow();
-    }
-
-    protected void ApplyColonyEmpireFilter()
-    {
-        colonyEmpireId = ParseComboId(colonyEmpireText);
-        ResetColonyWindow();
-    }
-
-    private bool ColonyMatches((World World, Colony Colony) item)
-    {
-        if (colonyRaceId != ComboAllFilterId
-            && item.Colony.RaceId != colonyRaceId
-            && !item.Colony.Demographics.Any(demographic => demographic.RaceId == colonyRaceId))
+        if (selectedSectorId <= 0)
         {
-            return false;
+            loadedColonySummaries.Clear();
+            colonyHasMoreRecords = false;
+            selectedColonyId = 0;
+            selectedColonyDetail = null;
+            colonyFilterOptions = new([], [], []);
+            entityImages = [];
+            lastLoadedImageKey = string.Empty;
+            return;
         }
 
-        if (colonyEmpireId != ComboAllFilterId
-            && item.Colony.AllegianceId != colonyEmpireId
-            && item.Colony.ControllingEmpireId != colonyEmpireId
-            && item.Colony.FoundingEmpireId != colonyEmpireId
-            && item.Colony.ParentEmpireId != colonyEmpireId)
+        if (resetList || loadedColonySectorId != selectedSectorId)
         {
-            return false;
+            loadedColonySummaries.Clear();
+            loadedColonySectorId = selectedSectorId;
+            colonyHasMoreRecords = false;
+            colonyObserverConfigured = false;
+            colonyFilterOptions = await ExplorerQueryService.LoadColonyFilterOptionsAsync(selectedSectorId, cancellationToken);
+            await LoadMoreColoniesAsync(cancellationToken);
         }
 
-        if (!string.IsNullOrWhiteSpace(colonyStatus)
-            && !string.Equals(item.Colony.PoliticalStatus.ToString(), colonyStatus, StringComparison.OrdinalIgnoreCase))
+        await EnsureSelectedColonySummaryVisibleAsync(cancellationToken);
+        await EnsureSelectedColonyDetailAsync(cancellationToken);
+    }
+
+    private async Task LoadMoreColoniesAsync(CancellationToken cancellationToken = default)
+    {
+        if (colonyListLoading || selectedSectorId <= 0)
         {
-            return false;
+            return;
         }
 
-        if (!string.IsNullOrWhiteSpace(colonyClass)
-            && !string.Equals(item.Colony.ColonyClass, colonyClass, StringComparison.OrdinalIgnoreCase))
+        colonyListLoading = true;
+        try
         {
-            return false;
+            var page = await ExplorerQueryService.LoadColonyListPageAsync(
+                new ExplorerColonyListPageRequest(
+                    selectedSectorId,
+                    loadedColonySummaries.Count,
+                    ExplorerListBatchSize,
+                    string.IsNullOrWhiteSpace(colonyQuery) ? null : colonyQuery.Trim(),
+                    colonyRaceId == ComboAllFilterId ? null : colonyRaceId,
+                    colonyEmpireId == ComboAllFilterId ? null : colonyEmpireId,
+                    string.IsNullOrWhiteSpace(colonyStatus) ? null : colonyStatus.Trim(),
+                    string.IsNullOrWhiteSpace(colonyClass) ? null : colonyClass.Trim()),
+                cancellationToken);
+
+            foreach (var item in page.Items)
+            {
+                if (loadedColonySummaries.All(existing => existing.ColonyId != item.ColonyId))
+                {
+                    loadedColonySummaries.Add(item);
+                }
+            }
+
+            colonyHasMoreRecords = page.HasMore;
+            if (selectedColonyId == 0 && loadedColonySummaries.Count > 0)
+            {
+                selectedColonyId = loadedColonySummaries[0].ColonyId;
+            }
+            else if (selectedColonyId > 0 && loadedColonySummaries.All(item => item.ColonyId != selectedColonyId))
+            {
+                selectedColonyId = loadedColonySummaries.FirstOrDefault()?.ColonyId ?? 0;
+            }
+
+            await EnsureSelectedColonySummaryVisibleAsync(cancellationToken);
+            await EnsureSelectedColonyDetailAsync(cancellationToken);
+            await InvokeAsync(StateHasChanged);
+        }
+        finally
+        {
+            colonyListLoading = false;
+        }
+    }
+
+    private async Task EnsureSelectedColonySummaryVisibleAsync(CancellationToken cancellationToken = default)
+    {
+        if (HasActiveColonyFilters())
+        {
+            return;
         }
 
-        if (string.IsNullOrWhiteSpace(colonyQuery))
+        var targetColonyId = RequestedColonyId ?? selectedColonyId;
+        if (targetColonyId <= 0 || loadedColonySummaries.Any(item => item.ColonyId == targetColonyId))
         {
-            return true;
+            return;
         }
 
-        var query = colonyQuery.Trim();
-        return ContainsQuery(item.World.Name, query)
-            || ContainsQuery(item.World.WorldType, query)
-            || ContainsQuery(item.Colony.Id.ToString(), query)
-            || ContainsQuery(item.Colony.Name, query)
-            || ContainsQuery(item.Colony.WorldId.ToString(), query)
-            || ContainsQuery(item.Colony.ColonyClass, query)
-            || ContainsQuery(item.Colony.ColonistRaceName, query)
-            || ContainsQuery(item.Colony.AllegianceName, query)
-            || ContainsQuery(item.Colony.Starport, query)
-            || ContainsQuery(item.Colony.GovernmentType, query)
-            || ContainsQuery(item.Colony.ExportResource, query)
-            || ContainsQuery(item.Colony.ImportResource, query)
-            || item.Colony.Demographics.Any(demographic => ContainsQuery(demographic.RaceName, query));
+        var requestedItem = await ExplorerQueryService.LoadColonyListItemAsync(selectedSectorId, targetColonyId, cancellationToken);
+        if (requestedItem is null)
+        {
+            return;
+        }
+
+        loadedColonySummaries.Add(requestedItem);
+        loadedColonySummaries.Sort((left, right) =>
+        {
+            var populationComparison = right.EstimatedPopulation.CompareTo(left.EstimatedPopulation);
+            if (populationComparison != 0)
+            {
+                return populationComparison;
+            }
+
+            var worldComparison = string.Compare(left.WorldName, right.WorldName, StringComparison.OrdinalIgnoreCase);
+            return worldComparison != 0 ? worldComparison : left.ColonyId.CompareTo(right.ColonyId);
+        });
+    }
+
+    private async Task EnsureSelectedColonyDetailAsync(CancellationToken cancellationToken = default)
+    {
+        var targetColonyId = HasActiveColonyFilters()
+            ? selectedColonyId
+            : RequestedColonyId ?? selectedColonyId;
+        if (targetColonyId <= 0)
+        {
+            targetColonyId = loadedColonySummaries.FirstOrDefault()?.ColonyId ?? 0;
+        }
+
+        if (targetColonyId <= 0 || colonyDetailLoading)
+        {
+            if (targetColonyId <= 0)
+            {
+                selectedColonyId = 0;
+                selectedColonyDetail = null;
+            }
+
+            return;
+        }
+
+        colonyDetailLoading = true;
+        try
+        {
+            var detail = await ExplorerQueryService.LoadColonyDetailAsync(selectedSectorId, targetColonyId, cancellationToken);
+            if (detail is null && loadedColonySummaries.Count > 0)
+            {
+                targetColonyId = loadedColonySummaries[0].ColonyId;
+                detail = await ExplorerQueryService.LoadColonyDetailAsync(selectedSectorId, targetColonyId, cancellationToken);
+            }
+
+            selectedColonyDetail = detail;
+            selectedColonyId = detail?.Colony.Id ?? 0;
+            if (detail?.World.StarSystemId is int systemId && systemId > 0)
+            {
+                selectedSystemId = systemId;
+                selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
+            }
+
+            await EnsureEntityImagesLoadedAsync(cancellationToken);
+        }
+        finally
+        {
+            colonyDetailLoading = false;
+        }
+    }
+
+    private async Task EnsureEntityImagesLoadedAsync(CancellationToken cancellationToken = default)
+    {
+        var targets = selectedColonyDetail is null
+            ? []
+            : new List<EntityImageTarget> { new(EntityImageTargetKind.Colony, selectedColonyDetail.Colony.Id) };
+        var imageKey = string.Join('|', targets.Select(target => $"{(int)target.TargetKind}:{target.TargetId}"));
+        if (entityImagesLoading || imageKey == lastLoadedImageKey)
+        {
+            return;
+        }
+
+        entityImagesLoading = true;
+        try
+        {
+            entityImages = await ImageService.GetImagesAsync(targets, cancellationToken);
+            lastLoadedImageKey = imageKey;
+            explorerRenderError = string.Empty;
+            await InvokeAsync(StateHasChanged);
+        }
+        finally
+        {
+            entityImagesLoading = false;
+        }
+    }
+
+    private async Task RunSearchAsync()
+    {
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
+    }
+
+    private async Task RestoreExplorerSessionAsync()
+    {
+        if (browserSessionRestored || RequestedSectorId is not null)
+        {
+            return;
+        }
+
+        browserSessionRestored = true;
+        var storedSelection = await ExplorerPageState.RestoreSelectionAsync(JS, RequestedSectorId);
+        if (storedSelection is null)
+        {
+            return;
+        }
+
+        var sector = ExplorerSectors.FirstOrDefault(item => item.Id == storedSelection.SectorId);
+        if (sector is null)
+        {
+            return;
+        }
+
+        selectedSectorId = sector.Id;
+        selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
+            ? storedSelection.SystemId
+            : sector.Systems.FirstOrDefault()?.Id ?? 0;
+        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await LoadColonyPageAsync(resetList: true);
+        NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Colonies", selectedSectorId, selectedSystemId, colonyId: selectedColonyId), replace: true);
+    }
+
+    private async Task PersistExplorerSessionAsync()
+    {
+        if (!browserSessionReady)
+        {
+            return;
+        }
+
+        await ExplorerPageState.PersistSelectionAsync(
+            JS,
+            browserSessionReady,
+            new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Colonies")));
+    }
+
+    private async Task UploadEntityImage(EntityImageTargetKind targetKind, int targetId, InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        try
+        {
+            await using var stream = file.OpenReadStream(10 * 1024 * 1024);
+            await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
+            lastLoadedImageKey = string.Empty;
+            await EnsureEntityImagesLoadedAsync();
+            imageUploadStatus = $"{file.Name} uploaded.";
+        }
+        catch (Exception exception)
+        {
+            imageUploadStatus = exception.Message;
+        }
     }
 
     private async Task ConfigureColonyObserverAsync()
@@ -388,147 +600,31 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         colonyObserverConfigured = true;
     }
 
-    private async Task EnsureEntityImagesLoadedAsync(bool backgroundLoad = false)
+    private void ClearColonyFilters()
     {
-        if (entityImagesLoaded || entityImagesLoading)
-        {
-            return;
-        }
-
-        entityImagesLoading = true;
-        try
-        {
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
-            explorerRenderError = string.Empty;
-            if (backgroundLoad)
-            {
-                await InvokeAsync(StateHasChanged);
-            }
-            else
-            {
-                StateHasChanged();
-            }
-        }
-        finally
-        {
-            entityImagesLoading = false;
-        }
+        colonyQuery = string.Empty;
+        colonyRaceText = string.Empty;
+        colonyEmpireText = string.Empty;
+        colonyRaceId = ComboAllFilterId;
+        colonyEmpireId = ComboAllFilterId;
+        colonyStatus = string.Empty;
+        colonyClass = string.Empty;
+        showColonyFilters = false;
+        ResetColonyWindow();
     }
 
-    private async Task RefreshExplorerDataAsync(int? detailedSectorId = null, CancellationToken cancellationToken = default)
+    private void ResetColonyWindow()
     {
-        explorerContext = await ExplorerContextService.LoadShellAsync(
-            includeSavedRoutes: false,
-            includeReferenceData: true,
-            detailedSectorId: detailedSectorId,
-            detailedSectorSections: DetailedSectorSections,
-            cancellationToken: cancellationToken);
-
-        foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
-        {
-            sectorCacheBuilder.Invalidate(sectorId);
-        }
-        WorldsById.Clear();
-        foreach (var world in explorerContext.Sectors.SelectMany(sector => sector.Systems).SelectMany(system => system.Worlds))
-        {
-            WorldsById[world.Id] = world;
-        }
+        colonyObserverConfigured = false;
     }
 
-    private int ResolveSelectedColonyId(StarWinSector sector)
+    private bool HasActiveColonyFilters()
     {
-        if (RequestedColonyId is int requestedColonyId
-            && sector.Systems.SelectMany(system => system.Worlds).Any(world => world.Colony?.Id == requestedColonyId))
-        {
-            return requestedColonyId;
-        }
-
-        if (selectedColonyId > 0
-            && sector.Systems.SelectMany(system => system.Worlds).Any(world => world.Colony?.Id == selectedColonyId))
-        {
-            return selectedColonyId;
-        }
-
-        return sector.Systems.FirstOrDefault(system => system.Id == selectedSystemId)?.Worlds.FirstOrDefault()?.Colony?.Id
-            ?? sector.Systems.SelectMany(system => system.Worlds).FirstOrDefault(world => world.Colony is not null)?.Colony?.Id
-            ?? 0;
-    }
-
-    private void RunSearch()
-    {
-        var sector = GetSelectedSector();
-        var sectorSummary = GetSectorSummary(sector);
-
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.Type switch
-            {
-                StarWinSearchResultType.AlienRace => result.RaceId is int raceId && sectorSummary.RaceIds.Contains(raceId),
-                StarWinSearchResultType.Empire => result.EmpireId is int empireId && sectorSummary.EmpireIds.Contains(empireId),
-                _ => result.SectorId is null || result.SectorId == sector.Id
-            })
-            .ToList();
-    }
-
-    private async Task RestoreExplorerSessionAsync()
-    {
-        if (browserSessionRestored || RequestedSectorId is not null)
-        {
-            return;
-        }
-
-        browserSessionRestored = true;
-        var storedSelection = await ExplorerPageState.RestoreSelectionAsync(JS, RequestedSectorId);
-        if (storedSelection is null)
-        {
-            return;
-        }
-
-        var sector = ExplorerSectors.FirstOrDefault(item => item.Id == storedSelection.SectorId);
-        if (sector is null)
-        {
-            return;
-        }
-
-        selectedSectorId = sector.Id;
-        await RefreshExplorerDataAsync(selectedSectorId);
-        sector = GetSelectedSector();
-        selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
-            ? storedSelection.SystemId
-            : sector.Systems.FirstOrDefault()?.Id ?? 0;
-        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        selectedColonyId = ResolveSelectedColonyId(sector);
-        NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Colonies", selectedSectorId, selectedSystemId, colonyId: selectedColonyId), replace: true);
-    }
-
-    private async Task PersistExplorerSessionAsync()
-    {
-        if (!browserSessionReady)
-        {
-            return;
-        }
-
-        await ExplorerPageState.PersistSelectionAsync(
-            JS,
-            browserSessionReady,
-            new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Colonies")));
-    }
-
-    private async Task UploadEntityImage(EntityImageTargetKind targetKind, int targetId, InputFileChangeEventArgs args)
-    {
-        var file = args.File;
-        try
-        {
-            await using var stream = file.OpenReadStream(10 * 1024 * 1024);
-            await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
-            imageUploadStatus = $"{file.Name} uploaded.";
-        }
-        catch (Exception exception)
-        {
-            imageUploadStatus = exception.Message;
-        }
+        return !string.IsNullOrWhiteSpace(colonyQuery)
+            || colonyRaceId != ComboAllFilterId
+            || colonyEmpireId != ComboAllFilterId
+            || !string.IsNullOrWhiteSpace(colonyStatus)
+            || !string.IsNullOrWhiteSpace(colonyClass);
     }
 
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)
@@ -537,9 +633,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         return system is null ? string.Empty : $"{system.Id} - {system.Name}";
     }
 
-    private static string FormatRaceOption(AlienRace race) => $"{race.Id} - {race.Name}";
-
-    private static string FormatEmpireOption(Empire empire) => $"{empire.Id} - {empire.Name}";
+    private static string FormatLookupOption(ExplorerLookupOption option) => $"{option.Id} - {option.Name}";
 
     private static int ParseComboId(string value)
     {
@@ -551,11 +645,6 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         var separatorIndex = value.IndexOf(" - ", StringComparison.Ordinal);
         var idText = separatorIndex < 0 ? value : value[..separatorIndex];
         return int.TryParse(idText, out var id) ? id : ComboAllFilterId;
-    }
-
-    private static bool ContainsQuery(string? value, string query)
-    {
-        return value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     public async ValueTask DisposeAsync()

--- a/StarWin.Web/Components/Pages/Colonies.razor.cs
+++ b/StarWin.Web/Components/Pages/Colonies.razor.cs
@@ -14,6 +14,9 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
 {
     private const int ColonyBatchSize = 120;
     private const int ComboAllFilterId = -1;
+    private const ExplorerSectorLoadSections DetailedSectorSections = ExplorerSectorLoadSections.Worlds
+        | ExplorerSectorLoadSections.Colonies
+        | ExplorerSectorLoadSections.ColonyDemographics;
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
@@ -39,7 +42,6 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
     protected readonly Dictionary<int, World> WorldsById = [];
-    private readonly Dictionary<int, ExplorerSectorLoadSections> loadedSectorSectionsById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
@@ -77,14 +79,12 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync();
+        await RefreshExplorerDataAsync(RequestedSectorId);
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        initialSector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         selectedColonyId = ResolveSelectedColonyId(initialSector);
@@ -101,7 +101,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorDataLoadedAsync(selectedSectorId);
+            await RefreshExplorerDataAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
@@ -156,7 +156,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -222,8 +222,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
     protected async Task SaveEntityNameAsync(EntityNoteTargetKind targetKind, int targetId, string name)
     {
         await EntityNameService.SaveNameAsync(targetKind, targetId, name);
-        await RefreshExplorerDataAsync();
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
     }
 
@@ -417,59 +416,19 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         }
     }
 
-    private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
+    private async Task RefreshExplorerDataAsync(int? detailedSectorId = null, CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             includeSavedRoutes: false,
             includeReferenceData: true,
+            detailedSectorId: detailedSectorId,
+            detailedSectorSections: DetailedSectorSections,
             cancellationToken: cancellationToken);
 
-        loadedSectorSectionsById.Clear();
         foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
         {
             sectorCacheBuilder.Invalidate(sectorId);
         }
-        WorldsById.Clear();
-    }
-
-    private async Task EnsureSectorDataLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
-    {
-        if (sectorId <= 0)
-        {
-            return;
-        }
-
-        const ExplorerSectorLoadSections requiredSections = ExplorerSectorLoadSections.Worlds
-            | ExplorerSectorLoadSections.Colonies
-            | ExplorerSectorLoadSections.ColonyDemographics;
-
-        loadedSectorSectionsById.TryGetValue(sectorId, out var loadedSections);
-        if ((loadedSections & requiredSections) == requiredSections)
-        {
-            return;
-        }
-
-        var detailedSector = await ExplorerContextService.LoadSectorAsync(sectorId, requiredSections, cancellationToken);
-        if (detailedSector is null)
-        {
-            return;
-        }
-
-        var sectors = ExplorerSectors.ToList();
-        var sectorIndex = sectors.FindIndex(item => item.Id == detailedSector.Id);
-        if (sectorIndex >= 0)
-        {
-            sectors[sectorIndex] = detailedSector;
-        }
-
-        explorerContext = explorerContext with
-        {
-            Sectors = sectors,
-            CurrentSector = explorerContext.CurrentSector.Id == detailedSector.Id ? detailedSector : explorerContext.CurrentSector
-        };
-
-        loadedSectorSectionsById[sectorId] = loadedSections | requiredSections;
-        sectorCacheBuilder.Invalidate(sectorId);
         WorldsById.Clear();
         foreach (var world in explorerContext.Sectors.SelectMany(sector => sector.Systems).SelectMany(system => system.Worlds))
         {
@@ -532,7 +491,7 @@ public partial class Colonies : ComponentBase, IAsyncDisposable
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         sector = GetSelectedSector();
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/empires"
 @rendermode InteractiveServer
 
@@ -25,7 +25,7 @@
 }
 
 <PageTitle>Empires | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="content-grid">
             <div class="record-list">
@@ -413,3 +413,4 @@
                 </article>
             }
         </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -412,5 +412,12 @@
                     </div>
                 </article>
             }
+            else
+            {
+                <article class="detail-panel alien-detail-panel empire-detail-panel">
+                    <span class="panel-kicker">Empire profile</span>
+                    <p class="alien-empty-state">Select an empire to load its details.</p>
+                </article>
+            }
         </section>
 </SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -344,8 +344,6 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
-            includeSavedRoutes: false,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -107,6 +107,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         var sector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await EnsureSelectedEmpireSummaryVisibleAsync();
         await EnsureSelectedEmpireDetailAsync();
     }
 
@@ -400,8 +401,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         {
             loadedEmpireSummaries.Clear();
             empireHasMoreRecords = false;
-            selectedEmpireId = 0;
-            selectedEmpireDetail = null;
+            ClearSelectedEmpireDetail();
             empireFilterOptions = new([]);
             return;
         }
@@ -413,6 +413,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
             loadedEmpireSectorId = selectedSectorId;
             empireHasMoreRecords = false;
             empireObserverConfigured = false;
+            ClearSelectedEmpireDetail();
             if (sectorChanged || empireFilterOptions.Races.Count == 0)
             {
                 empireFilterOptions = await ExplorerQueryService.LoadEmpireFilterOptionsAsync(selectedSectorId, cancellationToken);
@@ -424,7 +425,6 @@ public partial class Empires : ComponentBase, IAsyncDisposable
             }
 
             await LoadMoreEmpireSummariesAsync(cancellationToken, requestVersion);
-            return;
         }
 
         await EnsureSelectedEmpireSummaryVisibleAsync(cancellationToken, requestVersion);
@@ -578,17 +578,6 @@ public partial class Empires : ComponentBase, IAsyncDisposable
             }
 
             empireHasMoreRecords = page.HasMore;
-            if (selectedEmpireId == 0 && loadedEmpireSummaries.Count > 0)
-            {
-                selectedEmpireId = loadedEmpireSummaries[0].EmpireId;
-            }
-            else if (selectedEmpireId > 0 && loadedEmpireSummaries.All(item => item.EmpireId != selectedEmpireId))
-            {
-                selectedEmpireId = loadedEmpireSummaries.FirstOrDefault()?.EmpireId ?? 0;
-            }
-
-            await EnsureSelectedEmpireSummaryVisibleAsync(cancellationToken, requestVersion);
-            await EnsureSelectedEmpireDetailAsync(cancellationToken, requestVersion);
             await InvokeAsync(StateHasChanged);
         }
         finally
@@ -634,15 +623,16 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         var targetEmpireId = HasActiveEmpireFilters()
             ? selectedEmpireId
             : RequestedEmpireId ?? selectedEmpireId;
-        if (targetEmpireId <= 0)
-        {
-            targetEmpireId = loadedEmpireSummaries.FirstOrDefault()?.EmpireId ?? 0;
-        }
 
         if (targetEmpireId <= 0)
         {
-            selectedEmpireId = 0;
-            selectedEmpireDetail = null;
+            ClearSelectedEmpireDetail();
+            return;
+        }
+
+        if (selectedEmpireDetail?.Empire.Id == targetEmpireId && loadedEmpireDetailId == targetEmpireId)
+        {
+            selectedEmpireId = targetEmpireId;
             return;
         }
 
@@ -656,11 +646,6 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         {
             var previousEmpireId = selectedEmpireDetail?.Empire.Id ?? 0;
             var detail = await ExplorerQueryService.LoadEmpireDetailAsync(selectedSectorId, targetEmpireId, cancellationToken);
-            if (detail is null && loadedEmpireSummaries.Count > 0)
-            {
-                targetEmpireId = loadedEmpireSummaries[0].EmpireId;
-                detail = await ExplorerQueryService.LoadEmpireDetailAsync(selectedSectorId, targetEmpireId, cancellationToken);
-            }
 
             if (IsStaleEmpireFilterRequest(requestVersion))
             {
@@ -686,6 +671,15 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         {
             empireDetailLoading = false;
         }
+    }
+
+    private void ClearSelectedEmpireDetail()
+    {
+        selectedEmpireId = 0;
+        selectedEmpireDetail = null;
+        loadedEmpireDetailId = 0;
+        entityImages = [];
+        lastLoadedEmpireImageTargetId = 0;
     }
 
     protected ExplorerEmpireColonyListing? GetCapitalColony(ExplorerEmpireDetail detail)

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -19,7 +19,6 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     private const int EmpireFilterDebounceMilliseconds = 250;
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
     [Inject] protected IStarWinEntityNameService EntityNameService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
@@ -60,8 +59,8 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     protected ExplorerEmpireFilterOptions empireFilterOptions = new([]);
 
     private IReadOnlyList<EntityImage> entityImages = [];
-    private bool entityImagesLoaded;
     private bool entityImagesLoading;
+    private int lastLoadedEmpireImageTargetId;
     private string imageUploadStatus = string.Empty;
     private ElementReference empireLoadMoreElement;
     private DotNetObjectReference<Empires>? dotNetReference;
@@ -180,8 +179,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -191,7 +189,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -307,7 +305,15 @@ public partial class Empires : ComponentBase, IAsyncDisposable
 
     private async Task EnsureEntityImagesLoadedAsync(bool backgroundLoad = false)
     {
-        if (entityImagesLoaded || entityImagesLoading)
+        var empireId = selectedEmpireDetail?.Empire.Id ?? 0;
+        if (empireId <= 0)
+        {
+            entityImages = [];
+            lastLoadedEmpireImageTargetId = 0;
+            return;
+        }
+
+        if (entityImagesLoading || lastLoadedEmpireImageTargetId == empireId)
         {
             return;
         }
@@ -315,8 +321,9 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         entityImagesLoading = true;
         try
         {
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
+            entityImages = await ImageService.GetImagesAsync(
+                [new EntityImageTarget(EntityImageTargetKind.Empire, empireId)]);
+            lastLoadedEmpireImageTargetId = empireId;
             explorerRenderError = string.Empty;
             if (backgroundLoad)
             {
@@ -336,16 +343,15 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
             includeSavedRoutes: false,
             includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 
-    private void RunSearch()
+    private async Task RunSearchAsync()
     {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private async Task RestoreExplorerSessionAsync()
@@ -650,6 +656,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         empireDetailLoading = true;
         try
         {
+            var previousEmpireId = selectedEmpireDetail?.Empire.Id ?? 0;
             var detail = await ExplorerQueryService.LoadEmpireDetailAsync(selectedSectorId, targetEmpireId, cancellationToken);
             if (detail is null && loadedEmpireSummaries.Count > 0)
             {
@@ -671,6 +678,11 @@ public partial class Empires : ComponentBase, IAsyncDisposable
 
             selectedEmpireDetail = detail;
             selectedEmpireId = detail?.Empire.Id ?? 0;
+            if (previousEmpireId != selectedEmpireId)
+            {
+                entityImages = [];
+                lastLoadedEmpireImageTargetId = 0;
+            }
         }
         finally
         {
@@ -718,8 +730,8 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         {
             await using var stream = file.OpenReadStream(10 * 1024 * 1024);
             await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
+            lastLoadedEmpireImageTargetId = 0;
+            await EnsureEntityImagesLoadedAsync();
             imageUploadStatus = $"{file.Name} uploaded.";
         }
         catch (Exception exception)

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/hyperlanes"
 @rendermode InteractiveServer
 
@@ -31,7 +31,7 @@
 }
 
 <PageTitle>Hyperlanes | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="hyperlane-layout">
             <article class="feature-panel hyperlane-list-panel">
@@ -179,3 +179,4 @@
                 }
             </article>
         </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor
@@ -5,15 +5,14 @@
 @{
     var sector = GetSelectedSector();
     var hasSavedHyperlanes = HasSavedHyperlanes;
-    var savedHyperlanes = hasSavedHyperlanes ? GetOrderedRoutes(sector) : Array.Empty<SectorSavedRoute>();
+    var savedHyperlanes = hasSavedHyperlanes ? GetOrderedRoutes() : Array.Empty<SectorSavedRoute>();
     var hyperlaneWindow = savedHyperlanes.Take(hyperlaneVisibleCount + 1).ToList();
     var hasMoreHyperlanes = hyperlaneWindow.Count > hyperlaneVisibleCount;
     var visibleHyperlanes = hyperlaneWindow.Take(hyperlaneVisibleCount).ToList();
-    var selectedHyperlane = hasSavedHyperlanes ? GetSelectedRoute(sector, savedHyperlanes) : null;
-    var savedHyperlaneReport = hasSavedHyperlanes ? GetSavedHyperlaneReport(sector) : global::StarWin.Domain.Services.SectorHyperlaneNetworkReport.Empty;
-    IReadOnlyList<ExplorerLookupOption> sectorEmpires = hasSavedHyperlanes
-        ? ExplorerEmpires.Where(empire => sectorEmpireIds.Contains(empire.Id)).OrderBy(empire => empire.Name).ToList()
-        : [];
+    var selectedHyperlane = hasSavedHyperlanes ? GetSelectedRoute(savedHyperlanes) : null;
+    var savedHyperlaneReport = hasSavedHyperlanes ? SavedHyperlaneReport : global::StarWin.Domain.Services.SectorHyperlaneNetworkReport.Empty;
+    IReadOnlyList<ExplorerLookupOption> sectorEmpires = hasSavedHyperlanes ? ExplorerEmpires : [];
+    IReadOnlyList<ExplorerHyperlaneSystem> editableSystems = hasSavedHyperlanes ? ExplorerHyperlaneSystems : [];
     var layoutState = new SectorExplorerLayoutState(
         null,
         ExplorerSectors,
@@ -78,7 +77,7 @@
                     <div><dt>Manual preserve</dt><dd>@savedHyperlanes.Count(route => route.IsUserPersisted) user-persisted route@(savedHyperlanes.Count(route => route.IsUserPersisted) == 1 ? string.Empty : "s")</dd></div>
                 </dl>
                 <div class="parent-actions">
-                    <button type="button" @onclick="() => BeginNewHyperlane(sector)">Add hyperlane</button>
+                    <button type="button" @onclick="BeginNewHyperlane">Add hyperlane</button>
                     <button type="button" @onclick="NavigateToConfiguration">Open sector configuration</button>
                 </div>
                 <p class="panel-note">Use Sector Configuration to regenerate the saved route cache and show the route-save progress window.</p>
@@ -92,12 +91,10 @@
                         <div class="timeline-count">Showing @visibleHyperlanes.Count saved hyperlane@(visibleHyperlanes.Count == 1 ? string.Empty : "s")@(hasMoreHyperlanes ? "+" : string.Empty)</div>
                         @foreach (var route in visibleHyperlanes)
                         {
-                            var sourceSystem = sector.Systems.FirstOrDefault(system => system.Id == route.SourceSystemId);
-                            var targetSystem = sector.Systems.FirstOrDefault(system => system.Id == route.TargetSystemId);
                             <button type="button"
                                     class="hyperlane-record @(route.Id == selectedHyperlaneId ? "active" : null)"
-                                    @onclick="() => SelectHyperlane(sector, route.Id)">
-                                <strong>@(sourceSystem?.Name ?? $"System {route.SourceSystemId}") <span aria-hidden="true">&#8596;</span> @(targetSystem?.Name ?? $"System {route.TargetSystemId}")</strong>
+                                    @onclick="() => SelectHyperlane(route.Id)">
+                                <strong>@GetSystemDisplayName(route.SourceSystemId) <span aria-hidden="true">&#8596;</span> @GetSystemDisplayName(route.TargetSystemId)</strong>
                                 <small>@($"TL{route.TechnologyLevel} {route.TierName} - {route.DistanceParsecs:0.###} pc - {FormatTravelTimeBreakdown(route.TravelTimeYears)}")</small>
                                 <small>@FormatHyperlaneOwnerSummary(route)</small>
                                 @if (route.IsUserPersisted)
@@ -124,18 +121,18 @@
                     <label>
                         Source system
                         <select @bind="hyperlaneSourceSystemId">
-                            @foreach (var system in sector.Systems.OrderBy(system => system.Name).ThenBy(system => system.Id))
+                            @foreach (var system in editableSystems)
                             {
-                                <option value="@system.Id">@system.Name (@system.Id)</option>
+                                <option value="@system.SystemId">@system.Name (@system.SystemId)</option>
                             }
                         </select>
                     </label>
                     <label>
                         Target system
                         <select @bind="hyperlaneTargetSystemId">
-                            @foreach (var system in sector.Systems.OrderBy(system => system.Name).ThenBy(system => system.Id))
+                            @foreach (var system in editableSystems)
                             {
-                                <option value="@system.Id">@system.Name (@system.Id)</option>
+                                <option value="@system.SystemId">@system.Name (@system.SystemId)</option>
                             }
                         </select>
                     </label>
@@ -187,7 +184,7 @@
                 </label>
                 <div class="parent-actions">
                     <button type="button" @onclick="SaveHyperlaneAsync">Save hyperlane</button>
-                    <button type="button" @onclick="() => BeginNewHyperlane(sector)">New draft</button>
+                    <button type="button" @onclick="BeginNewHyperlane">New draft</button>
                     <button type="button" @onclick="RecalculateHyperlaneTravelDefaults" disabled="@(hyperlaneSourceSystemId <= 0 || hyperlaneTargetSystemId <= 0)">Use sector travel defaults</button>
                     @if (selectedHyperlaneId > 0)
                     {

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor
@@ -4,13 +4,16 @@
 
 @{
     var sector = GetSelectedSector();
-    var savedHyperlanes = GetOrderedRoutes(sector);
+    var hasSavedHyperlanes = HasSavedHyperlanes;
+    var savedHyperlanes = hasSavedHyperlanes ? GetOrderedRoutes(sector) : Array.Empty<SectorSavedRoute>();
     var hyperlaneWindow = savedHyperlanes.Take(hyperlaneVisibleCount + 1).ToList();
     var hasMoreHyperlanes = hyperlaneWindow.Count > hyperlaneVisibleCount;
     var visibleHyperlanes = hyperlaneWindow.Take(hyperlaneVisibleCount).ToList();
-    var selectedHyperlane = GetSelectedRoute(sector, savedHyperlanes);
-    var savedHyperlaneReport = GetSavedHyperlaneReport(sector);
-    var sectorEmpires = ExplorerEmpires.Where(empire => sectorEmpireIds.Contains(empire.Id)).OrderBy(empire => empire.Name).ToList();
+    var selectedHyperlane = hasSavedHyperlanes ? GetSelectedRoute(sector, savedHyperlanes) : null;
+    var savedHyperlaneReport = hasSavedHyperlanes ? GetSavedHyperlaneReport(sector) : global::StarWin.Domain.Services.SectorHyperlaneNetworkReport.Empty;
+    IReadOnlyList<ExplorerLookupOption> sectorEmpires = hasSavedHyperlanes
+        ? ExplorerEmpires.Where(empire => sectorEmpireIds.Contains(empire.Id)).OrderBy(empire => empire.Name).ToList()
+        : [];
     var layoutState = new SectorExplorerLayoutState(
         null,
         ExplorerSectors,
@@ -34,6 +37,34 @@
 <SectorExplorerFrame State="layoutState">
 
 <section class="hyperlane-layout">
+        @if (!hasSavedHyperlanes)
+        {
+            <article class="feature-panel hyperlane-list-panel">
+                <span class="panel-kicker">Saved Hyperlanes</span>
+                <h2>@(hyperlaneSetupState?.SectorName ?? sector.Name)</h2>
+                <p>This page unlocks after you generate the saved hyperlane cache for this sector. Until then, use the generation controls below to build the initial route network.</p>
+                <div class="parent-actions">
+                    <button type="button" @onclick="GenerateHyperlanesAsync" disabled="@routeSaveLoadingVisible">Generate hyperlanes</button>
+                    <button type="button" @onclick="NavigateToConfiguration" disabled="@routeSaveLoadingVisible">Open sector configuration</button>
+                </div>
+                <p class="panel-note">If you need different generation behavior, update the sector route settings in Sector Configuration before you start.</p>
+                @if (!string.IsNullOrWhiteSpace(hyperlaneStatus))
+                {
+                    <p class="search-empty">@hyperlaneStatus</p>
+                }
+                <dl class="field-grid compact-field-grid hyperlane-network-summary">
+                    <div><dt>Connection cap</dt><dd>@HyperlaneConfiguration.Tl9AndBelowMaximumConnectionsPerSystem standard links plus @HyperlaneConfiguration.AdditionalCrossEmpireConnectionsPerSystem cross-empire bonus</dd></div>
+                    <div><dt>Off-lane distance</dt><dd>@($"{HyperlaneConfiguration.OffLaneMaximumDistanceParsecs:0.###} parsecs")</dd></div>
+                    <div><dt>TL6</dt><dd>@($"{HyperlaneConfiguration.Tl6HyperlaneName} up to {HyperlaneConfiguration.Tl6MaximumDistanceParsecs:0.###} pc")</dd></div>
+                    <div><dt>TL7</dt><dd>@($"{HyperlaneConfiguration.Tl7HyperlaneName} up to {HyperlaneConfiguration.Tl7MaximumDistanceParsecs:0.###} pc")</dd></div>
+                    <div><dt>TL8</dt><dd>@($"{HyperlaneConfiguration.Tl8HyperlaneName} up to {HyperlaneConfiguration.Tl8MaximumDistanceParsecs:0.###} pc")</dd></div>
+                    <div><dt>TL9</dt><dd>@($"{HyperlaneConfiguration.Tl9HyperlaneName} up to {HyperlaneConfiguration.Tl9MaximumDistanceParsecs:0.###} pc")</dd></div>
+                    <div><dt>TL10</dt><dd>@HyperlaneConfiguration.Tl10HyperlaneName @(HyperlaneConfiguration.Tl10MaximumDistanceParsecs < 0 ? "with uncapped distance" : $"up to {HyperlaneConfiguration.Tl10MaximumDistanceParsecs:0.###} pc")</dd></div>
+                </dl>
+            </article>
+        }
+        else
+        {
             <article class="feature-panel hyperlane-list-panel">
                 <span class="panel-kicker">Saved Hyperlanes</span>
                 <h2>@sector.Name</h2>
@@ -178,5 +209,25 @@
                     <p class="notes-empty">Save the hyperlane first if you want to attach notes to it.</p>
                 }
             </article>
-        </section>
+        }
+</section>
+
+<LoadingModal IsVisible="@routeSaveLoadingVisible"
+              AriaLabel="Generating hyperlanes"
+              Kicker="Generating hyperlanes"
+              Title="@routeSaveLoadingStatus"
+              Detail="@routeSaveLoadingDetail"
+              MeterClass="loading-meter import-progress-meter"
+              ProgressPercent="@routeSaveLoadingPercent"
+              Steps="@routeSaveLoadingSteps">
+    <BeforeMeterContent>
+        @if (routeSaveProcessedItems is int processedItems && routeSaveTotalItems is int totalItems && totalItems > 0)
+        {
+            <strong class="loading-progress-value">@processedItems / @totalItems systems processed</strong>
+        }
+    </BeforeMeterContent>
+    <AfterMeterContent>
+        <strong class="loading-progress-value">@routeSaveLoadingPercent%</strong>
+    </AfterMeterContent>
+</LoadingModal>
 </SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor
@@ -47,7 +47,7 @@
                     <div><dt>Manual preserve</dt><dd>@savedHyperlanes.Count(route => route.IsUserPersisted) user-persisted route@(savedHyperlanes.Count(route => route.IsUserPersisted) == 1 ? string.Empty : "s")</dd></div>
                 </dl>
                 <div class="parent-actions">
-                    <button type="button" @onclick="() => StartNewHyperlane(sector)">Add hyperlane</button>
+                    <button type="button" @onclick="() => BeginNewHyperlane(sector)">Add hyperlane</button>
                     <button type="button" @onclick="NavigateToConfiguration">Open sector configuration</button>
                 </div>
                 <p class="panel-note">Use Sector Configuration to regenerate the saved route cache and show the route-save progress window.</p>
@@ -156,7 +156,7 @@
                 </label>
                 <div class="parent-actions">
                     <button type="button" @onclick="SaveHyperlaneAsync">Save hyperlane</button>
-                    <button type="button" @onclick="() => StartNewHyperlane(sector)">New draft</button>
+                    <button type="button" @onclick="() => BeginNewHyperlane(sector)">New draft</button>
                     <button type="button" @onclick="RecalculateHyperlaneTravelDefaults" disabled="@(hyperlaneSourceSystemId <= 0 || hyperlaneTargetSystemId <= 0)">Use sector travel defaults</button>
                     @if (selectedHyperlaneId > 0)
                     {

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
@@ -28,8 +28,6 @@ public partial class Hyperlanes : ComponentBase
     public int? RequestedHyperlaneId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    private readonly Dictionary<int, ExplorerSectorLoadSections> loadedSectorSectionsById = [];
-
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
@@ -68,8 +66,6 @@ public partial class Hyperlanes : ComponentBase
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        initialSector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         LoadHyperlaneForm(initialSector, ResolveSelectedHyperlane(initialSector));
@@ -86,7 +82,6 @@ public partial class Hyperlanes : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorDataLoadedAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
@@ -133,7 +128,6 @@ public partial class Hyperlanes : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -378,7 +372,6 @@ public partial class Hyperlanes : ComponentBase
                 hyperlaneIsUserPersisted));
 
             await RefreshExplorerDataAsync();
-            await EnsureSectorDataLoadedAsync(sector.Id);
 
             var reloadedSector = GetSelectedSector();
             selectedSystemText = FormatSelectedSystem(reloadedSector, selectedSystemId);
@@ -410,7 +403,6 @@ public partial class Hyperlanes : ComponentBase
         {
             await SectorRouteService.DeleteSavedRouteAsync(sector.Id, selectedHyperlaneId);
             await RefreshExplorerDataAsync();
-            await EnsureSectorDataLoadedAsync(sector.Id);
 
             var reloadedSector = GetSelectedSector();
             selectedSystemText = FormatSelectedSystem(reloadedSector, selectedSystemId);
@@ -455,45 +447,6 @@ public partial class Hyperlanes : ComponentBase
             includeSavedRoutes: true,
             includeReferenceData: true,
             cancellationToken: cancellationToken);
-
-        loadedSectorSectionsById.Clear();
-    }
-
-    private async Task EnsureSectorDataLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
-    {
-        if (sectorId <= 0)
-        {
-            return;
-        }
-
-        const ExplorerSectorLoadSections requiredSections = ExplorerSectorLoadSections.SavedRoutes;
-
-        loadedSectorSectionsById.TryGetValue(sectorId, out var loadedSections);
-        if ((loadedSections & requiredSections) == requiredSections)
-        {
-            return;
-        }
-
-        var detailedSector = await ExplorerContextService.LoadSectorAsync(sectorId, requiredSections, cancellationToken);
-        if (detailedSector is null)
-        {
-            return;
-        }
-
-        var sectors = ExplorerSectors.ToList();
-        var sectorIndex = sectors.FindIndex(item => item.Id == detailedSector.Id);
-        if (sectorIndex >= 0)
-        {
-            sectors[sectorIndex] = detailedSector;
-        }
-
-        explorerContext = explorerContext with
-        {
-            Sectors = sectors,
-            CurrentSector = explorerContext.CurrentSector.Id == detailedSector.Id ? detailedSector : explorerContext.CurrentSector
-        };
-
-        loadedSectorSectionsById[sectorId] = loadedSections | requiredSections;
     }
 
     private SectorSavedRoute? ResolveSelectedHyperlane(StarWinSector sector)
@@ -539,8 +492,6 @@ public partial class Hyperlanes : ComponentBase
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        sector = GetSelectedSector();
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using StarWin.Application.Services;
-using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.StarMap;
 using StarWin.Domain.Services;
 using StarWin.Web.Components.Explorer;
@@ -13,7 +12,7 @@ public partial class Hyperlanes : ComponentBase
     private const int ExplorerListBatchSize = 120;
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
+    [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinSectorRouteService SectorRouteService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
     [Inject] protected IJSRuntime JS { get; set; } = default!;
@@ -29,6 +28,7 @@ public partial class Hyperlanes : ComponentBase
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
+    protected ExplorerHyperlaneWorkspace? selectedWorkspace;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
@@ -50,13 +50,14 @@ public partial class Hyperlanes : ComponentBase
 
     private bool browserSessionReady;
     private bool browserSessionRestored;
+    private StarWinSector? selectedSectorRecord;
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<Empire> ExplorerEmpires => explorerContext.Empires;
+    protected IReadOnlyList<ExplorerLookupOption> ExplorerEmpires => selectedWorkspace?.Empires ?? [];
     protected IReadOnlySet<int> sectorEmpireIds => GetSelectedSector().Systems.Select(system => (int)system.AllegianceId).Where(id => id > 0).ToHashSet();
 
-    private IReadOnlyDictionary<int, Empire> EmpiresById =>
-        ExplorerEmpires.ToDictionary(empire => empire.Id);
+    private IReadOnlyDictionary<int, string> EmpireNamesById =>
+        ExplorerEmpires.ToDictionary(empire => empire.Id, empire => empire.Name);
 
     protected override async Task OnInitializedAsync()
     {
@@ -82,6 +83,7 @@ public partial class Hyperlanes : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
+            await LoadSelectedWorkspaceAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
@@ -102,7 +104,9 @@ public partial class Hyperlanes : ComponentBase
 
     protected StarWinSector GetSelectedSector()
     {
-        return ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
+        return selectedSectorRecord?.Id == selectedSectorId
+            ? selectedSectorRecord
+            : ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
     }
 
     protected string BuildSectionRoute(string sectionName)
@@ -128,6 +132,7 @@ public partial class Hyperlanes : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
+        await LoadSelectedWorkspaceAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -160,8 +165,7 @@ public partial class Hyperlanes : ComponentBase
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -171,7 +175,7 @@ public partial class Hyperlanes : ComponentBase
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -198,9 +202,13 @@ public partial class Hyperlanes : ComponentBase
 
     protected SectorHyperlaneNetworkReport GetSavedHyperlaneReport(StarWinSector sector)
     {
+        if (selectedWorkspace is null)
+        {
+            return SectorHyperlaneNetworkReport.Empty;
+        }
+
         return SectorRoutePlanner.BuildHyperlaneNetworkReport(
-            sector,
-            EmpiresById,
+            selectedWorkspace.EligibleSystemIds,
             sector.SavedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
                 route.SourceSystemId,
                 route.TargetSystemId,
@@ -366,9 +374,9 @@ public partial class Hyperlanes : ComponentBase
                 (byte)hyperlaneTechnologyLevel,
                 hyperlaneTierName,
                 hyperlanePrimaryOwnerEmpireId > 0 ? hyperlanePrimaryOwnerEmpireId : null,
-                hyperlanePrimaryOwnerEmpireId > 0 && EmpiresById.TryGetValue(hyperlanePrimaryOwnerEmpireId, out var primaryOwner) ? primaryOwner.Name : string.Empty,
+                hyperlanePrimaryOwnerEmpireId > 0 && EmpireNamesById.TryGetValue(hyperlanePrimaryOwnerEmpireId, out var primaryOwnerName) ? primaryOwnerName : string.Empty,
                 hyperlaneSecondaryOwnerEmpireId > 0 ? hyperlaneSecondaryOwnerEmpireId : null,
-                hyperlaneSecondaryOwnerEmpireId > 0 && EmpiresById.TryGetValue(hyperlaneSecondaryOwnerEmpireId, out var secondaryOwner) ? secondaryOwner.Name : string.Empty,
+                hyperlaneSecondaryOwnerEmpireId > 0 && EmpireNamesById.TryGetValue(hyperlaneSecondaryOwnerEmpireId, out var secondaryOwnerName) ? secondaryOwnerName : string.Empty,
                 hyperlaneIsUserPersisted));
 
             await RefreshExplorerDataAsync();
@@ -444,9 +452,18 @@ public partial class Hyperlanes : ComponentBase
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
-            includeSavedRoutes: true,
-            includeReferenceData: true,
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
+            includeSavedRoutes: false,
+            includeReferenceData: false,
             cancellationToken: cancellationToken);
+
+        var workspaceSectorId = RequestedSectorId ?? selectedSectorId;
+        if (workspaceSectorId <= 0)
+        {
+            workspaceSectorId = explorerContext.CurrentSector.Id;
+        }
+
+        await LoadSelectedWorkspaceAsync(workspaceSectorId, cancellationToken);
     }
 
     private SectorSavedRoute? ResolveSelectedHyperlane(StarWinSector sector)
@@ -464,11 +481,9 @@ public partial class Hyperlanes : ComponentBase
         return sector.SavedRoutes.FirstOrDefault();
     }
 
-    private void RunSearch()
+    private async Task RunSearchAsync()
     {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private async Task RestoreExplorerSessionAsync()
@@ -513,6 +528,19 @@ public partial class Hyperlanes : ComponentBase
             new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Hyperlanes")));
     }
 
+    private async Task LoadSelectedWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        if (sectorId <= 0)
+        {
+            selectedWorkspace = null;
+            selectedSectorRecord = null;
+            return;
+        }
+
+        selectedWorkspace = await ExplorerQueryService.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
+        selectedSectorRecord = selectedWorkspace is null ? null : BuildSectorRecord(selectedWorkspace);
+    }
+
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)
     {
         var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
@@ -536,5 +564,35 @@ public partial class Hyperlanes : ComponentBase
         return sourceSystemId <= targetSystemId
             ? (sourceSystemId, targetSystemId)
             : (targetSystemId, sourceSystemId);
+    }
+
+    private static StarWinSector BuildSectorRecord(ExplorerHyperlaneWorkspace workspace)
+    {
+        var sector = new StarWinSector
+        {
+            Id = workspace.SectorId,
+            Name = workspace.SectorName,
+            Configuration = workspace.Configuration
+        };
+
+        foreach (var system in workspace.Systems)
+        {
+            sector.Systems.Add(new StarSystem
+            {
+                Id = system.SystemId,
+                LegacySystemId = system.LegacySystemId,
+                SectorId = workspace.SectorId,
+                Name = system.Name,
+                Coordinates = system.Coordinates,
+                AllegianceId = system.AllegianceId
+            });
+        }
+
+        foreach (var route in workspace.SavedRoutes)
+        {
+            sector.SavedRoutes.Add(route);
+        }
+
+        return sector;
     }
 }

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
@@ -453,8 +453,6 @@ public partial class Hyperlanes : ComponentBase
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
-            includeSavedRoutes: false,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
 
         var workspaceSectorId = RequestedSectorId ?? selectedSectorId;

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
@@ -51,6 +51,7 @@ public partial class Hyperlanes : ComponentBase
     private bool browserSessionReady;
     private bool browserSessionRestored;
     private StarWinSector? selectedSectorRecord;
+    private string pendingHyperlaneStatus = string.Empty;
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
     protected IReadOnlyList<ExplorerLookupOption> ExplorerEmpires => selectedWorkspace?.Empires ?? [];
@@ -83,6 +84,7 @@ public partial class Hyperlanes : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
+            selectedHyperlaneId = 0;
             await LoadSelectedWorkspaceAsync(selectedSectorId);
         }
 
@@ -90,6 +92,7 @@ public partial class Hyperlanes : ComponentBase
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        ApplyPendingHyperlaneStatus();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -132,12 +135,13 @@ public partial class Hyperlanes : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
+        selectedHyperlaneId = 0;
         await LoadSelectedWorkspaceAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         hyperlaneVisibleCount = ExplorerListBatchSize;
-        LoadHyperlaneForm(sector);
+        LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
         await PersistExplorerSessionAsync();
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId));
     }
@@ -156,7 +160,13 @@ public partial class Hyperlanes : ComponentBase
                 StartNewHyperlane(sector);
             }
 
-            NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId), replace: true);
+            NavigationManager.NavigateTo(
+                SectorExplorerRoutes.BuildSectionUri(
+                    "Hyperlanes",
+                    selectedSectorId,
+                    selectedSystemId,
+                    hyperlaneId: selectedHyperlaneId),
+                replace: true);
         }
 
         return PersistExplorerSessionAsync();
@@ -306,6 +316,13 @@ public partial class Hyperlanes : ComponentBase
         }
 
         LoadHyperlaneForm(sector, route);
+        NavigationManager.NavigateTo(
+            SectorExplorerRoutes.BuildSectionUri(
+                "Hyperlanes",
+                selectedSectorId,
+                selectedSystemId,
+                hyperlaneId: route.Id),
+            replace: true);
     }
 
     protected void StartNewHyperlane(StarWinSector sector)
@@ -327,6 +344,14 @@ public partial class Hyperlanes : ComponentBase
         hyperlaneSecondaryOwnerEmpireId = 0;
         hyperlaneIsUserPersisted = true;
         RecalculateHyperlaneTravelDefaults(sector);
+    }
+
+    protected void BeginNewHyperlane(StarWinSector sector)
+    {
+        StartNewHyperlane(sector);
+        NavigationManager.NavigateTo(
+            SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId),
+            replace: true);
     }
 
     protected void RecalculateHyperlaneTravelDefaults()
@@ -389,9 +414,16 @@ public partial class Hyperlanes : ComponentBase
                     == GetRouteKey(savedRoute.SourceSystemId, savedRoute.TargetSystemId));
 
             LoadHyperlaneForm(reloadedSector, reloadedRoute);
-            hyperlaneStatus = isUpdate
+            pendingHyperlaneStatus = isUpdate
                 ? "Saved hyperlane changes."
                 : "Created saved hyperlane.";
+            NavigationManager.NavigateTo(
+                SectorExplorerRoutes.BuildSectionUri(
+                    "Hyperlanes",
+                    selectedSectorId,
+                    selectedSystemId,
+                    hyperlaneId: selectedHyperlaneId),
+                replace: true);
         }
         catch (Exception ex)
         {
@@ -415,7 +447,10 @@ public partial class Hyperlanes : ComponentBase
             var reloadedSector = GetSelectedSector();
             selectedSystemText = FormatSelectedSystem(reloadedSector, selectedSystemId);
             LoadHyperlaneForm(reloadedSector);
-            hyperlaneStatus = "Deleted saved hyperlane.";
+            pendingHyperlaneStatus = "Deleted saved hyperlane.";
+            NavigationManager.NavigateTo(
+                SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId),
+                replace: true);
         }
         catch (Exception ex)
         {
@@ -428,8 +463,7 @@ public partial class Hyperlanes : ComponentBase
         var orderedRoutes = GetOrderedRoutes(sector);
         var routeToLoad = route
             ?? orderedRoutes.FirstOrDefault(item => item.Id == RequestedHyperlaneId)
-            ?? orderedRoutes.FirstOrDefault(item => item.Id == selectedHyperlaneId)
-            ?? orderedRoutes.FirstOrDefault();
+            ?? orderedRoutes.FirstOrDefault(item => item.Id == selectedHyperlaneId);
         if (routeToLoad is null)
         {
             StartNewHyperlane(sector);
@@ -476,7 +510,7 @@ public partial class Hyperlanes : ComponentBase
             return sector.SavedRoutes.FirstOrDefault(route => route.Id == selectedHyperlaneId);
         }
 
-        return sector.SavedRoutes.FirstOrDefault();
+        return null;
     }
 
     private async Task RunSearchAsync()
@@ -509,7 +543,7 @@ public partial class Hyperlanes : ComponentBase
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        LoadHyperlaneForm(sector);
+        LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId), replace: true);
     }
 
@@ -562,6 +596,17 @@ public partial class Hyperlanes : ComponentBase
         return sourceSystemId <= targetSystemId
             ? (sourceSystemId, targetSystemId)
             : (targetSystemId, sourceSystemId);
+    }
+
+    private void ApplyPendingHyperlaneStatus()
+    {
+        if (string.IsNullOrWhiteSpace(pendingHyperlaneStatus))
+        {
+            return;
+        }
+
+        hyperlaneStatus = pendingHyperlaneStatus;
+        pendingHyperlaneStatus = string.Empty;
     }
 
     private static StarWinSector BuildSectorRecord(ExplorerHyperlaneWorkspace workspace)

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
@@ -36,7 +36,7 @@ public partial class Hyperlanes : ComponentBase
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected ExplorerHyperlaneSetupState? hyperlaneSetupState;
-    protected ExplorerHyperlaneWorkspace? selectedWorkspace;
+    protected ExplorerHyperlanePageState? selectedHyperlaneState;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
@@ -64,12 +64,16 @@ public partial class Hyperlanes : ComponentBase
 
     private bool browserSessionReady;
     private bool browserSessionRestored;
-    private StarWinSector? selectedSectorRecord;
     private string pendingHyperlaneStatus = string.Empty;
+    private IReadOnlyList<SectorSavedRoute> orderedSavedRoutes = [];
+    private IReadOnlyDictionary<int, ExplorerHyperlaneSystem> hyperlaneSystemsById = new Dictionary<int, ExplorerHyperlaneSystem>();
+    private IReadOnlyDictionary<int, string> hyperlaneSystemNamesById = new Dictionary<int, string>();
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<ExplorerLookupOption> ExplorerEmpires => selectedWorkspace?.Empires ?? [];
-    protected IReadOnlySet<int> sectorEmpireIds => GetSelectedSector().Systems.Select(system => (int)system.AllegianceId).Where(id => id > 0).ToHashSet();
+    protected IReadOnlyList<ExplorerLookupOption> ExplorerEmpires => selectedHyperlaneState?.Empires ?? [];
+    protected IReadOnlyList<ExplorerHyperlaneSystem> ExplorerHyperlaneSystems => selectedHyperlaneState?.Systems ?? [];
+    protected IReadOnlyList<SectorSavedRoute> SavedHyperlanes => selectedHyperlaneState?.SavedRoutes ?? [];
+    protected SectorHyperlaneNetworkReport SavedHyperlaneReport => selectedHyperlaneState?.SavedRouteReport ?? SectorHyperlaneNetworkReport.Empty;
     protected bool HasSavedHyperlanes => (hyperlaneSetupState?.SavedRouteCount ?? 0) > 0;
     protected SectorConfigModel HyperlaneConfiguration => hyperlaneSetupState?.Configuration ?? new SectorConfigModel();
 
@@ -89,7 +93,7 @@ public partial class Hyperlanes : ComponentBase
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         if (HasSavedHyperlanes)
         {
-            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+            LoadHyperlaneForm(ResolveSelectedHyperlane());
         }
         else
         {
@@ -117,7 +121,7 @@ public partial class Hyperlanes : ComponentBase
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         if (HasSavedHyperlanes)
         {
-            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+            LoadHyperlaneForm(ResolveSelectedHyperlane());
         }
         else
         {
@@ -139,9 +143,7 @@ public partial class Hyperlanes : ComponentBase
 
     protected StarWinSector GetSelectedSector()
     {
-        return selectedSectorRecord?.Id == selectedSectorId
-            ? selectedSectorRecord
-            : ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
+        return ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
     }
 
     protected string BuildSectionRoute(string sectionName)
@@ -175,7 +177,7 @@ public partial class Hyperlanes : ComponentBase
         hyperlaneVisibleCount = ExplorerListBatchSize;
         if (HasSavedHyperlanes)
         {
-            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+            LoadHyperlaneForm(ResolveSelectedHyperlane());
         }
         else
         {
@@ -197,7 +199,7 @@ public partial class Hyperlanes : ComponentBase
             selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
             if (HasSavedHyperlanes && selectedHyperlaneId == 0)
             {
-                StartNewHyperlane(sector);
+                StartNewHyperlane();
             }
 
             NavigationManager.NavigateTo(
@@ -233,43 +235,15 @@ public partial class Hyperlanes : ComponentBase
         NavigationManager.NavigateTo(targetUri);
     }
 
-    protected IReadOnlyList<SectorSavedRoute> GetOrderedRoutes(StarWinSector sector)
+    protected IReadOnlyList<SectorSavedRoute> GetOrderedRoutes()
     {
-        var systemsById = sector.Systems.ToDictionary(system => system.Id);
-        return sector.SavedRoutes
-            .OrderBy(route => systemsById.TryGetValue(route.SourceSystemId, out var sourceSystem) ? sourceSystem.Name : string.Empty)
-            .ThenBy(route => systemsById.TryGetValue(route.TargetSystemId, out var targetSystem) ? targetSystem.Name : string.Empty)
-            .ThenBy(route => route.SourceSystemId)
-            .ThenBy(route => route.TargetSystemId)
-            .ToList();
+        return orderedSavedRoutes;
     }
 
-    protected SectorSavedRoute? GetSelectedRoute(StarWinSector sector, IReadOnlyList<SectorSavedRoute>? orderedRoutes = null)
+    protected SectorSavedRoute? GetSelectedRoute(IReadOnlyList<SectorSavedRoute>? orderedRoutes = null)
     {
-        orderedRoutes ??= GetOrderedRoutes(sector);
+        orderedRoutes ??= GetOrderedRoutes();
         return orderedRoutes.FirstOrDefault(route => route.Id == selectedHyperlaneId);
-    }
-
-    protected SectorHyperlaneNetworkReport GetSavedHyperlaneReport(StarWinSector sector)
-    {
-        if (selectedWorkspace is null)
-        {
-            return SectorHyperlaneNetworkReport.Empty;
-        }
-
-        return SectorRoutePlanner.BuildHyperlaneNetworkReport(
-            selectedWorkspace.EligibleSystemIds,
-            sector.SavedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
-                route.SourceSystemId,
-                route.TargetSystemId,
-                (double)route.DistanceParsecs,
-                (double)route.TravelTimeYears,
-                route.TechnologyLevel,
-                route.TierName,
-                route.PrimaryOwnerEmpireId,
-                route.PrimaryOwnerEmpireName,
-                route.SecondaryOwnerEmpireId,
-                route.SecondaryOwnerEmpireName)));
     }
 
     protected string FormatHyperlaneOwnerSummary(SectorSavedRoute route)
@@ -342,7 +316,7 @@ public partial class Hyperlanes : ComponentBase
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Configuration", selectedSectorId, selectedSystemId));
     }
 
-    protected void SelectHyperlane(StarWinSector sector, int routeId)
+    protected void SelectHyperlane(int routeId)
     {
         if (routeId <= 0)
         {
@@ -354,13 +328,13 @@ public partial class Hyperlanes : ComponentBase
             return;
         }
 
-        var route = sector.SavedRoutes.FirstOrDefault(item => item.Id == routeId);
+        var route = SavedHyperlanes.FirstOrDefault(item => item.Id == routeId);
         if (route is null)
         {
             return;
         }
 
-        LoadHyperlaneForm(sector, route);
+        LoadHyperlaneForm(route);
         NavigationManager.NavigateTo(
             SectorExplorerRoutes.BuildSectionUri(
                 "Hyperlanes",
@@ -370,30 +344,31 @@ public partial class Hyperlanes : ComponentBase
             replace: true);
     }
 
-    protected void StartNewHyperlane(StarWinSector sector)
+    protected void StartNewHyperlane()
     {
+        var systems = ExplorerHyperlaneSystems;
         selectedHyperlaneId = 0;
         hyperlaneStatus = string.Empty;
-        hyperlaneSourceSystemId = sector.Systems.Any(system => system.Id == selectedSystemId)
+        hyperlaneSourceSystemId = systems.Any(system => system.SystemId == selectedSystemId)
             ? selectedSystemId
-            : sector.Systems.FirstOrDefault()?.Id ?? 0;
-        hyperlaneTargetSystemId = sector.Systems
-            .Where(system => system.Id != hyperlaneSourceSystemId)
+            : systems.FirstOrDefault()?.SystemId ?? 0;
+        hyperlaneTargetSystemId = systems
+            .Where(system => system.SystemId != hyperlaneSourceSystemId)
             .OrderBy(system => system.Name)
-            .ThenBy(system => system.Id)
-            .Select(system => system.Id)
+            .ThenBy(system => system.SystemId)
+            .Select(system => system.SystemId)
             .FirstOrDefault();
         hyperlaneTechnologyLevel = 6;
-        hyperlaneTierName = SectorRoutePlanner.GetTierName(sector.Configuration, hyperlaneTechnologyLevel);
+        hyperlaneTierName = SectorRoutePlanner.GetTierName(HyperlaneConfiguration, hyperlaneTechnologyLevel);
         hyperlanePrimaryOwnerEmpireId = 0;
         hyperlaneSecondaryOwnerEmpireId = 0;
         hyperlaneIsUserPersisted = true;
-        RecalculateHyperlaneTravelDefaults(sector);
+        RecalculateHyperlaneTravelDefaults();
     }
 
-    protected void BeginNewHyperlane(StarWinSector sector)
+    protected void BeginNewHyperlane()
     {
-        StartNewHyperlane(sector);
+        StartNewHyperlane();
         NavigationManager.NavigateTo(
             SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId),
             replace: true);
@@ -447,7 +422,7 @@ public partial class Hyperlanes : ComponentBase
             hyperlaneVisibleCount = ExplorerListBatchSize;
             if (HasSavedHyperlanes)
             {
-                LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+                LoadHyperlaneForm(ResolveSelectedHyperlane());
             }
 
             hyperlaneStatus = result.ReplacedExistingRoutes
@@ -472,28 +447,26 @@ public partial class Hyperlanes : ComponentBase
 
     protected void RecalculateHyperlaneTravelDefaults()
     {
-        var sector = GetSelectedSector();
-        RecalculateHyperlaneTravelDefaults(sector);
-    }
-
-    protected void RecalculateHyperlaneTravelDefaults(StarWinSector sector)
-    {
         if (hyperlaneSourceSystemId <= 0 || hyperlaneTargetSystemId <= 0)
         {
             return;
         }
 
-        var source = sector.Systems.FirstOrDefault(system => system.Id == hyperlaneSourceSystemId);
-        var target = sector.Systems.FirstOrDefault(system => system.Id == hyperlaneTargetSystemId);
+        if (!hyperlaneSystemsById.TryGetValue(hyperlaneSourceSystemId, out var source)
+            || !hyperlaneSystemsById.TryGetValue(hyperlaneTargetSystemId, out var target))
+        {
+            return;
+        }
+
         if (source is null || target is null)
         {
             return;
         }
 
-        hyperlaneTierName = SectorRoutePlanner.GetTierName(sector.Configuration, hyperlaneTechnologyLevel);
+        hyperlaneTierName = SectorRoutePlanner.GetTierName(HyperlaneConfiguration, hyperlaneTechnologyLevel);
         hyperlaneDistanceParsecs = decimal.Round((decimal)SectorRoutePlanner.CalculateParsecDistance(source.Coordinates, target.Coordinates), 3);
         hyperlaneTravelTimeYears = decimal.Round((decimal)SectorRoutePlanner.CalculateHyperlaneTravelTimeYears(
-            sector.Configuration,
+            HyperlaneConfiguration,
             hyperlaneTechnologyLevel,
             (double)hyperlaneDistanceParsecs), 6);
     }
@@ -524,12 +497,12 @@ public partial class Hyperlanes : ComponentBase
 
             var reloadedSector = GetSelectedSector();
             selectedSystemText = FormatSelectedSystem(reloadedSector, selectedSystemId);
-            var reloadedRoute = reloadedSector.SavedRoutes.FirstOrDefault(route => route.Id == savedRoute.Id)
-                ?? reloadedSector.SavedRoutes.FirstOrDefault(route =>
+            var reloadedRoute = SavedHyperlanes.FirstOrDefault(route => route.Id == savedRoute.Id)
+                ?? SavedHyperlanes.FirstOrDefault(route =>
                     GetRouteKey(route.SourceSystemId, route.TargetSystemId)
                     == GetRouteKey(savedRoute.SourceSystemId, savedRoute.TargetSystemId));
 
-            LoadHyperlaneForm(reloadedSector, reloadedRoute);
+            LoadHyperlaneForm(reloadedRoute);
             pendingHyperlaneStatus = isUpdate
                 ? "Saved hyperlane changes."
                 : "Created saved hyperlane.";
@@ -562,7 +535,7 @@ public partial class Hyperlanes : ComponentBase
 
             var reloadedSector = GetSelectedSector();
             selectedSystemText = FormatSelectedSystem(reloadedSector, selectedSystemId);
-            LoadHyperlaneForm(reloadedSector);
+            LoadHyperlaneForm();
             pendingHyperlaneStatus = "Deleted saved hyperlane.";
             NavigationManager.NavigateTo(
                 SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId),
@@ -574,15 +547,15 @@ public partial class Hyperlanes : ComponentBase
         }
     }
 
-    protected void LoadHyperlaneForm(StarWinSector sector, SectorSavedRoute? route = null)
+    protected void LoadHyperlaneForm(SectorSavedRoute? route = null)
     {
-        var orderedRoutes = GetOrderedRoutes(sector);
+        var orderedRoutes = GetOrderedRoutes();
         var routeToLoad = route
             ?? orderedRoutes.FirstOrDefault(item => item.Id == RequestedHyperlaneId)
             ?? orderedRoutes.FirstOrDefault(item => item.Id == selectedHyperlaneId);
         if (routeToLoad is null)
         {
-            StartNewHyperlane(sector);
+            StartNewHyperlane();
             return;
         }
 
@@ -614,16 +587,16 @@ public partial class Hyperlanes : ComponentBase
         await LoadSelectedHyperlaneDataAsync(workspaceSectorId, cancellationToken);
     }
 
-    private SectorSavedRoute? ResolveSelectedHyperlane(StarWinSector sector)
+    private SectorSavedRoute? ResolveSelectedHyperlane()
     {
         if (RequestedHyperlaneId is int requestedHyperlaneId)
         {
-            return sector.SavedRoutes.FirstOrDefault(route => route.Id == requestedHyperlaneId);
+            return SavedHyperlanes.FirstOrDefault(route => route.Id == requestedHyperlaneId);
         }
 
         if (selectedHyperlaneId > 0)
         {
-            return sector.SavedRoutes.FirstOrDefault(route => route.Id == selectedHyperlaneId);
+            return SavedHyperlanes.FirstOrDefault(route => route.Id == selectedHyperlaneId);
         }
 
         return null;
@@ -661,7 +634,7 @@ public partial class Hyperlanes : ComponentBase
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         if (HasSavedHyperlanes)
         {
-            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+            LoadHyperlaneForm(ResolveSelectedHyperlane());
         }
 
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId), replace: true);
@@ -685,21 +658,21 @@ public partial class Hyperlanes : ComponentBase
         if (sectorId <= 0)
         {
             hyperlaneSetupState = null;
-            selectedWorkspace = null;
-            selectedSectorRecord = null;
+            selectedHyperlaneState = null;
+            ApplyHyperlanePageState(null);
             return;
         }
 
         hyperlaneSetupState = await ExplorerQueryService.LoadHyperlaneSetupAsync(sectorId, cancellationToken);
         if (hyperlaneSetupState is null || hyperlaneSetupState.SavedRouteCount == 0)
         {
-            selectedWorkspace = null;
-            selectedSectorRecord = null;
+            selectedHyperlaneState = null;
+            ApplyHyperlanePageState(null);
             return;
         }
 
-        selectedWorkspace = await ExplorerQueryService.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
-        selectedSectorRecord = selectedWorkspace is null ? null : BuildSectorRecord(selectedWorkspace);
+        selectedHyperlaneState = await ExplorerQueryService.LoadHyperlanePageStateAsync(sectorId, cancellationToken);
+        ApplyHyperlanePageState(selectedHyperlaneState);
     }
 
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)
@@ -745,33 +718,34 @@ public partial class Hyperlanes : ComponentBase
         pendingHyperlaneStatus = string.Empty;
     }
 
-    private static StarWinSector BuildSectorRecord(ExplorerHyperlaneWorkspace workspace)
+    private void ApplyHyperlanePageState(ExplorerHyperlanePageState? state)
     {
-        var sector = new StarWinSector
+        if (state is null)
         {
-            Id = workspace.SectorId,
-            Name = workspace.SectorName,
-            Configuration = workspace.Configuration
-        };
-
-        foreach (var system in workspace.Systems)
-        {
-            sector.Systems.Add(new StarSystem
-            {
-                Id = system.SystemId,
-                LegacySystemId = system.LegacySystemId,
-                SectorId = workspace.SectorId,
-                Name = system.Name,
-                Coordinates = system.Coordinates,
-                AllegianceId = system.AllegianceId
-            });
+            orderedSavedRoutes = [];
+            hyperlaneSystemsById = new Dictionary<int, ExplorerHyperlaneSystem>();
+            hyperlaneSystemNamesById = new Dictionary<int, string>();
+            return;
         }
 
-        foreach (var route in workspace.SavedRoutes)
+        hyperlaneSystemsById = state.Systems.ToDictionary(system => system.SystemId);
+        hyperlaneSystemNamesById = state.Systems.ToDictionary(system => system.SystemId, system => system.Name);
+        orderedSavedRoutes = state.SavedRoutes
+            .OrderBy(route => hyperlaneSystemNamesById.TryGetValue(route.SourceSystemId, out var sourceName) ? sourceName : string.Empty)
+            .ThenBy(route => hyperlaneSystemNamesById.TryGetValue(route.TargetSystemId, out var targetName) ? targetName : string.Empty)
+            .ThenBy(route => route.SourceSystemId)
+            .ThenBy(route => route.TargetSystemId)
+            .ToList();
+    }
+
+    private string GetSystemDisplayName(int systemId)
+    {
+        if (hyperlaneSystemNamesById.TryGetValue(systemId, out var systemName))
         {
-            sector.SavedRoutes.Add(route);
+            return systemName;
         }
 
-        return sector;
+        var fallbackSystem = GetSelectedSector().Systems.FirstOrDefault(system => system.Id == systemId);
+        return fallbackSystem?.Name ?? $"System {systemId}";
     }
 }

--- a/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
+++ b/StarWin.Web/Components/Pages/Hyperlanes.razor.cs
@@ -4,12 +4,19 @@ using StarWin.Application.Services;
 using StarWin.Domain.Model.Entity.StarMap;
 using StarWin.Domain.Services;
 using StarWin.Web.Components.Explorer;
+using SectorConfigModel = StarWin.Domain.Model.Entity.StarMap.SectorConfiguration;
 
 namespace StarWin.Web.Components.Pages;
 
 public partial class Hyperlanes : ComponentBase
 {
     private const int ExplorerListBatchSize = 120;
+    private static readonly IReadOnlyList<string> routeSaveLoadingSteps =
+    [
+        "Load the current sector and empire data.",
+        "Generate exactly one route per system pair.",
+        "Write the refreshed route cache to the database."
+    ];
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
@@ -28,6 +35,7 @@ public partial class Hyperlanes : ComponentBase
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
+    protected ExplorerHyperlaneSetupState? hyperlaneSetupState;
     protected ExplorerHyperlaneWorkspace? selectedWorkspace;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
@@ -47,6 +55,12 @@ public partial class Hyperlanes : ComponentBase
     protected int hyperlaneSecondaryOwnerEmpireId;
     protected bool hyperlaneIsUserPersisted;
     protected string hyperlaneStatus = string.Empty;
+    protected bool routeSaveLoadingVisible;
+    protected string routeSaveLoadingStatus = string.Empty;
+    protected string routeSaveLoadingDetail = string.Empty;
+    protected int routeSaveLoadingPercent;
+    protected int? routeSaveProcessedItems;
+    protected int? routeSaveTotalItems;
 
     private bool browserSessionReady;
     private bool browserSessionRestored;
@@ -56,6 +70,8 @@ public partial class Hyperlanes : ComponentBase
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
     protected IReadOnlyList<ExplorerLookupOption> ExplorerEmpires => selectedWorkspace?.Empires ?? [];
     protected IReadOnlySet<int> sectorEmpireIds => GetSelectedSector().Systems.Select(system => (int)system.AllegianceId).Where(id => id > 0).ToHashSet();
+    protected bool HasSavedHyperlanes => (hyperlaneSetupState?.SavedRouteCount ?? 0) > 0;
+    protected SectorConfigModel HyperlaneConfiguration => hyperlaneSetupState?.Configuration ?? new SectorConfigModel();
 
     private IReadOnlyDictionary<int, string> EmpireNamesById =>
         ExplorerEmpires.ToDictionary(empire => empire.Id, empire => empire.Name);
@@ -68,9 +84,17 @@ public partial class Hyperlanes : ComponentBase
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
-        selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
-        LoadHyperlaneForm(initialSector, ResolveSelectedHyperlane(initialSector));
+        var sector = GetSelectedSector();
+        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        if (HasSavedHyperlanes)
+        {
+            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        }
+        else
+        {
+            ClearSelectedHyperlane();
+        }
     }
 
     protected override async Task OnParametersSetAsync()
@@ -85,13 +109,21 @@ public partial class Hyperlanes : ComponentBase
         {
             selectedSectorId = requestedSectorId;
             selectedHyperlaneId = 0;
-            await LoadSelectedWorkspaceAsync(selectedSectorId);
+            await LoadSelectedHyperlaneDataAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        if (HasSavedHyperlanes)
+        {
+            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        }
+        else
+        {
+            ClearSelectedHyperlane();
+        }
+
         ApplyPendingHyperlaneStatus();
     }
 
@@ -136,12 +168,20 @@ public partial class Hyperlanes : ComponentBase
     {
         selectedSectorId = sectorId;
         selectedHyperlaneId = 0;
-        await LoadSelectedWorkspaceAsync(selectedSectorId);
+        await LoadSelectedHyperlaneDataAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         hyperlaneVisibleCount = ExplorerListBatchSize;
-        LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        if (HasSavedHyperlanes)
+        {
+            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        }
+        else
+        {
+            ClearSelectedHyperlane();
+        }
+
         await PersistExplorerSessionAsync();
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId));
     }
@@ -155,7 +195,7 @@ public partial class Hyperlanes : ComponentBase
         {
             selectedSystemId = systemId;
             selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-            if (selectedHyperlaneId == 0)
+            if (HasSavedHyperlanes && selectedHyperlaneId == 0)
             {
                 StartNewHyperlane(sector);
             }
@@ -309,6 +349,11 @@ public partial class Hyperlanes : ComponentBase
             return;
         }
 
+        if (!HasSavedHyperlanes)
+        {
+            return;
+        }
+
         var route = sector.SavedRoutes.FirstOrDefault(item => item.Id == routeId);
         if (route is null)
         {
@@ -352,6 +397,77 @@ public partial class Hyperlanes : ComponentBase
         NavigationManager.NavigateTo(
             SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId),
             replace: true);
+    }
+
+    protected async Task GenerateHyperlanesAsync()
+    {
+        if (routeSaveLoadingVisible)
+        {
+            return;
+        }
+
+        routeSaveLoadingVisible = true;
+        routeSaveLoadingStatus = "Loading sector";
+        routeSaveLoadingDetail = "Preparing to generate the saved hyperlane cache for this sector.";
+        routeSaveLoadingPercent = 5;
+        routeSaveProcessedItems = null;
+        routeSaveTotalItems = null;
+        hyperlaneStatus = string.Empty;
+        StateHasChanged();
+        await Task.Yield();
+
+        var progress = new Progress<SectorRouteSaveProgress>(update =>
+        {
+            routeSaveLoadingStatus = update.Status;
+            routeSaveLoadingDetail = update.Detail;
+            routeSaveLoadingPercent = Math.Clamp(update.Percent, 0, 100);
+            routeSaveProcessedItems = update.ProcessedItems;
+            routeSaveTotalItems = update.TotalItems;
+            InvokeAsync(StateHasChanged);
+        });
+
+        try
+        {
+            var sectorId = selectedSectorId > 0
+                ? selectedSectorId
+                : hyperlaneSetupState?.SectorId ?? explorerContext.CurrentSector.Id;
+            var sectorName = hyperlaneSetupState?.SectorName ?? GetSelectedSector().Name;
+            var result = await SectorRouteService.SaveCurrentRoutesAsync(sectorId, progress);
+            routeSaveLoadingStatus = "Refreshing explorer";
+            routeSaveLoadingDetail = "Reloading the current sector so the generated hyperlanes are ready to use.";
+            routeSaveLoadingPercent = 100;
+            routeSaveProcessedItems = null;
+            routeSaveTotalItems = null;
+
+            await RefreshExplorerDataAsync();
+
+            var sector = GetSelectedSector();
+            selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+            selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+            hyperlaneVisibleCount = ExplorerListBatchSize;
+            if (HasSavedHyperlanes)
+            {
+                LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+            }
+
+            hyperlaneStatus = result.ReplacedExistingRoutes
+                ? $"Updated {result.RouteCount:N0} saved hyperlane segment{(result.RouteCount == 1 ? string.Empty : "s")} for {sectorName}. {result.GeneratedRouteCount:N0} regenerated, {result.PreservedUserRouteCount:N0} user-persisted kept, {result.NetworkReport.DistinctNetworkCount:N0} network{(result.NetworkReport.DistinctNetworkCount == 1 ? string.Empty : "s")}, {result.NetworkReport.StrandedSystemCount:N0} stranded system{(result.NetworkReport.StrandedSystemCount == 1 ? string.Empty : "s")}."
+                : $"Saved {result.RouteCount:N0} hyperlane segment{(result.RouteCount == 1 ? string.Empty : "s")} for {sectorName}. {result.NetworkReport.DistinctNetworkCount:N0} network{(result.NetworkReport.DistinctNetworkCount == 1 ? string.Empty : "s")} and {result.NetworkReport.StrandedSystemCount:N0} stranded system{(result.NetworkReport.StrandedSystemCount == 1 ? string.Empty : "s")}.";
+        }
+        catch (Exception ex)
+        {
+            hyperlaneStatus = $"Hyperlane generation failed: {ex.GetBaseException().Message}";
+        }
+        finally
+        {
+            routeSaveLoadingVisible = false;
+            routeSaveLoadingStatus = string.Empty;
+            routeSaveLoadingDetail = string.Empty;
+            routeSaveLoadingPercent = 0;
+            routeSaveProcessedItems = null;
+            routeSaveTotalItems = null;
+            StateHasChanged();
+        }
     }
 
     protected void RecalculateHyperlaneTravelDefaults()
@@ -495,7 +611,7 @@ public partial class Hyperlanes : ComponentBase
             workspaceSectorId = explorerContext.CurrentSector.Id;
         }
 
-        await LoadSelectedWorkspaceAsync(workspaceSectorId, cancellationToken);
+        await LoadSelectedHyperlaneDataAsync(workspaceSectorId, cancellationToken);
     }
 
     private SectorSavedRoute? ResolveSelectedHyperlane(StarWinSector sector)
@@ -543,7 +659,11 @@ public partial class Hyperlanes : ComponentBase
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        if (HasSavedHyperlanes)
+        {
+            LoadHyperlaneForm(sector, ResolveSelectedHyperlane(sector));
+        }
+
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Hyperlanes", selectedSectorId, selectedSystemId), replace: true);
     }
 
@@ -560,9 +680,18 @@ public partial class Hyperlanes : ComponentBase
             new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Hyperlanes")));
     }
 
-    private async Task LoadSelectedWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    private async Task LoadSelectedHyperlaneDataAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         if (sectorId <= 0)
+        {
+            hyperlaneSetupState = null;
+            selectedWorkspace = null;
+            selectedSectorRecord = null;
+            return;
+        }
+
+        hyperlaneSetupState = await ExplorerQueryService.LoadHyperlaneSetupAsync(sectorId, cancellationToken);
+        if (hyperlaneSetupState is null || hyperlaneSetupState.SavedRouteCount == 0)
         {
             selectedWorkspace = null;
             selectedSectorRecord = null;
@@ -606,6 +735,13 @@ public partial class Hyperlanes : ComponentBase
         }
 
         hyperlaneStatus = pendingHyperlaneStatus;
+        pendingHyperlaneStatus = string.Empty;
+    }
+
+    private void ClearSelectedHyperlane()
+    {
+        selectedHyperlaneId = 0;
+        hyperlaneStatus = string.Empty;
         pendingHyperlaneStatus = string.Empty;
     }
 

--- a/StarWin.Web/Components/Pages/Religions.razor
+++ b/StarWin.Web/Components/Pages/Religions.razor
@@ -145,5 +145,12 @@
             </section>
         </article>
     }
+    else
+    {
+        <article class="detail-panel">
+            <span class="panel-kicker">Religion profile</span>
+            <p class="alien-empty-state">Select a religion to load its details.</p>
+        </article>
+    }
 </section>
 </SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Religions.razor
+++ b/StarWin.Web/Components/Pages/Religions.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/religions"
 @rendermode InteractiveServer
 
@@ -25,7 +25,7 @@
 }
 
 <PageTitle>Religions | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="content-grid">
     <div class="record-list">
@@ -146,3 +146,4 @@
         </article>
     }
 </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Religions.razor.cs
+++ b/StarWin.Web/Components/Pages/Religions.razor.cs
@@ -12,7 +12,6 @@ public partial class Religions : ComponentBase, IAsyncDisposable
     private const int ExplorerListBatchSize = 30;
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
     [Inject] protected IJSRuntime JS { get; set; } = default!;
 
@@ -156,8 +155,7 @@ public partial class Religions : ComponentBase, IAsyncDisposable
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -167,7 +165,7 @@ public partial class Religions : ComponentBase, IAsyncDisposable
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -267,16 +265,15 @@ public partial class Religions : ComponentBase, IAsyncDisposable
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
             includeSavedRoutes: false,
             includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 
-    private void RunSearch()
+    private async Task RunSearchAsync()
     {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private async Task RestoreExplorerSessionAsync()

--- a/StarWin.Web/Components/Pages/Religions.razor.cs
+++ b/StarWin.Web/Components/Pages/Religions.razor.cs
@@ -266,8 +266,6 @@ public partial class Religions : ComponentBase, IAsyncDisposable
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
-            includeSavedRoutes: false,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 

--- a/StarWin.Web/Components/Pages/Religions.razor.cs
+++ b/StarWin.Web/Components/Pages/Religions.razor.cs
@@ -49,6 +49,7 @@ public partial class Religions : ComponentBase, IAsyncDisposable
     private bool browserSessionReady;
     private bool browserSessionRestored;
     private int loadedReligionSectorId;
+    private int loadedReligionDetailId;
     private readonly List<ExplorerReligionListItem> loadedReligionSummaries = [];
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
@@ -84,6 +85,7 @@ public partial class Religions : ComponentBase, IAsyncDisposable
         var sector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await EnsureSelectedReligionSummaryVisibleAsync();
         await EnsureSelectedReligionDetailAsync();
     }
 
@@ -322,8 +324,7 @@ public partial class Religions : ComponentBase, IAsyncDisposable
         {
             loadedReligionSummaries.Clear();
             religionHasMoreRecords = false;
-            selectedReligionId = 0;
-            selectedReligionDetail = null;
+            ClearSelectedReligionDetail();
             religionFilterOptions = new([]);
             return;
         }
@@ -334,6 +335,7 @@ public partial class Religions : ComponentBase, IAsyncDisposable
             loadedReligionSectorId = selectedSectorId;
             religionHasMoreRecords = false;
             religionObserverConfigured = false;
+            ClearSelectedReligionDetail();
             religionFilterOptions = await ExplorerQueryService.LoadReligionFilterOptionsAsync(selectedSectorId, cancellationToken);
             await LoadMoreReligionSummariesAsync(cancellationToken);
         }
@@ -370,17 +372,6 @@ public partial class Religions : ComponentBase, IAsyncDisposable
             }
 
             religionHasMoreRecords = page.HasMore;
-            if (selectedReligionId == 0 && loadedReligionSummaries.Count > 0)
-            {
-                selectedReligionId = loadedReligionSummaries[0].ReligionId;
-            }
-            else if (selectedReligionId > 0 && loadedReligionSummaries.All(item => item.ReligionId != selectedReligionId))
-            {
-                selectedReligionId = loadedReligionSummaries.FirstOrDefault()?.ReligionId ?? 0;
-            }
-
-            await EnsureSelectedReligionSummaryVisibleAsync(cancellationToken);
-            await EnsureSelectedReligionDetailAsync(cancellationToken);
             await InvokeAsync(StateHasChanged);
         }
         finally
@@ -421,15 +412,16 @@ public partial class Religions : ComponentBase, IAsyncDisposable
         var targetReligionId = HasActiveReligionFilters()
             ? selectedReligionId
             : RequestedReligionId ?? selectedReligionId;
-        if (targetReligionId <= 0)
-        {
-            targetReligionId = loadedReligionSummaries.FirstOrDefault()?.ReligionId ?? 0;
-        }
 
         if (targetReligionId <= 0)
         {
-            selectedReligionId = 0;
-            selectedReligionDetail = null;
+            ClearSelectedReligionDetail();
+            return;
+        }
+
+        if (selectedReligionDetail?.Religion.Id == targetReligionId && loadedReligionDetailId == targetReligionId)
+        {
+            selectedReligionId = targetReligionId;
             return;
         }
 
@@ -442,19 +434,21 @@ public partial class Religions : ComponentBase, IAsyncDisposable
         try
         {
             var detail = await ExplorerQueryService.LoadReligionDetailAsync(selectedSectorId, targetReligionId, cancellationToken);
-            if (detail is null && loadedReligionSummaries.Count > 0)
-            {
-                targetReligionId = loadedReligionSummaries[0].ReligionId;
-                detail = await ExplorerQueryService.LoadReligionDetailAsync(selectedSectorId, targetReligionId, cancellationToken);
-            }
-
             selectedReligionDetail = detail;
             selectedReligionId = detail?.Religion.Id ?? 0;
+            loadedReligionDetailId = selectedReligionId;
         }
         finally
         {
             religionDetailLoading = false;
         }
+    }
+
+    private void ClearSelectedReligionDetail()
+    {
+        selectedReligionId = 0;
+        selectedReligionDetail = null;
+        loadedReligionDetailId = 0;
     }
 
     private bool HasActiveReligionFilters()

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/configuration"
 @rendermode InteractiveServer
 @using StarWin.Domain.Services
@@ -27,7 +27,7 @@
 }
 
 <PageTitle>Sector Configuration | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="detail-panel">
             <span class="panel-kicker">Sector Configuration</span>
@@ -278,3 +278,4 @@
         <strong class="loading-progress-value">@routeSaveLoadingPercent%</strong>
     </AfterMeterContent>
 </LoadingModal>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor
@@ -6,7 +6,7 @@
 @{
     var sector = GetSelectedSector();
     var selectedSystem = sector.Systems.FirstOrDefault(system => system.Id == selectedSystemId) ?? sector.Systems.FirstOrDefault();
-    var savedHyperlaneReport = GetSavedHyperlaneReport(sector);
+    var savedHyperlaneReport = SavedRouteReport;
     var layoutState = new SectorExplorerLayoutState(
         null,
         ExplorerSectors,
@@ -86,7 +86,7 @@
                                 <div><dt>Route rule</dt><dd>Shared empires use the highest TL present in both systems; otherwise cross-empire routes use the best lower TL between endpoint empires.</dd></div>
                                 <div><dt>Connection cap</dt><dd>@tl9AndBelowMaximumConnectionsPerSystem standard links plus @additionalCrossEmpireConnectionsPerSystem cross-empire bonus</dd></div>
                                 <div><dt>Off-lane scope</dt><dd>Sector-wide today, with ship-specific overrides planned later.</dd></div>
-                                <div><dt>Current map routes</dt><dd>@GetConfigurationRouteSummary(sector, selectedSystem)</dd></div>
+                                <div><dt>Current map routes</dt><dd>@GetConfigurationRouteSummary(selectedSystem)</dd></div>
                             </dl>
                         </section>
 
@@ -96,10 +96,10 @@
                                 <h4>Saved route report</h4>
                             </div>
                             <dl class="field-grid compact-field-grid">
-                                <div><dt>Current saved routes</dt><dd>@sector.SavedRoutes.Count persisted hyperlane segments</dd></div>
+                                <div><dt>Current saved routes</dt><dd>@SavedRouteCount persisted hyperlane segments</dd></div>
                                 <div><dt>Hyperlane networks</dt><dd>@savedHyperlaneReport.DistinctNetworkCount distinct network@(savedHyperlaneReport.DistinctNetworkCount == 1 ? string.Empty : "s")</dd></div>
                                 <div><dt>Stranded systems</dt><dd>@savedHyperlaneReport.StrandedSystemCount TL6+ eligible system@(savedHyperlaneReport.StrandedSystemCount == 1 ? string.Empty : "s") still disconnected</dd></div>
-                                <div><dt>Last saved</dt><dd>@DisplayDateTime(sector.Configuration.UpdatedAtUtc)</dd></div>
+                                <div><dt>Last saved</dt><dd>@DisplayDateTime(selectedConfigurationState?.Configuration.UpdatedAtUtc)</dd></div>
                             </dl>
                         </section>
                     </div>
@@ -249,10 +249,10 @@
             <div class="parent-actions">
                 <button type="button" @onclick="SaveSectorConfigurationAsync">Save configuration</button>
                 <button type="button" @onclick="SaveCurrentRoutesAsync" disabled="@routeSaveLoadingVisible">
-                    @(sector.SavedRoutes.Count == 0 ? "Save Current Routes" : "Update Current Routes")
+                    @(SavedRouteCount == 0 ? "Save Current Routes" : "Update Current Routes")
                 </button>
                 <button type="button" @onclick="() => ConvertIndependentColoniesAsync(sector.Id)" disabled="@routeSaveLoadingVisible">Convert independent colonies</button>
-                <button type="button" @onclick="() => LoadSectorConfigurationForm(sector)">Reset form</button>
+                <button type="button" @onclick="() => LoadSectorConfigurationForm(selectedConfigurationState)">Reset form</button>
             </div>
             @if (!string.IsNullOrWhiteSpace(sectorConfigurationStatus))
             {

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using StarWin.Application.Services;
-using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.StarMap;
 using StarWin.Domain.Services;
 using StarWin.Web.Components.Explorer;
@@ -19,7 +18,7 @@ public partial class SectorConfiguration : ComponentBase
     ];
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
+    [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinSectorConfigurationService SectorConfigurationService { get; set; } = default!;
     [Inject] protected IStarWinSectorRouteService SectorRouteService { get; set; } = default!;
     [Inject] protected IStarWinIndependentColonyService IndependentColonyService { get; set; } = default!;
@@ -36,6 +35,7 @@ public partial class SectorConfiguration : ComponentBase
     protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
+    protected ExplorerHyperlaneWorkspace? selectedWorkspace;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
@@ -77,12 +77,9 @@ public partial class SectorConfiguration : ComponentBase
 
     private bool browserSessionReady;
     private bool browserSessionRestored;
+    private StarWinSector? selectedSectorRecord;
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<Empire> ExplorerEmpires => explorerContext.Empires;
-
-    private IReadOnlyDictionary<int, Empire> EmpiresById =>
-        ExplorerEmpires.ToDictionary(empire => empire.Id);
 
     protected override async Task OnInitializedAsync()
     {
@@ -108,6 +105,7 @@ public partial class SectorConfiguration : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
+            await LoadSelectedWorkspaceAsync(selectedSectorId);
             LoadSectorConfigurationForm(GetSelectedSector());
         }
 
@@ -137,7 +135,9 @@ public partial class SectorConfiguration : ComponentBase
 
     protected StarWinSector GetSelectedSector()
     {
-        return ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
+        return selectedSectorRecord?.Id == selectedSectorId
+            ? selectedSectorRecord
+            : ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
     }
 
     protected string DisplayResultType(StarWinSearchResultType type)
@@ -158,6 +158,7 @@ public partial class SectorConfiguration : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
+        await LoadSelectedWorkspaceAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -184,8 +185,7 @@ public partial class SectorConfiguration : ComponentBase
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -195,7 +195,7 @@ public partial class SectorConfiguration : ComponentBase
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -205,9 +205,10 @@ public partial class SectorConfiguration : ComponentBase
 
     protected SectorHyperlaneNetworkReport GetSavedHyperlaneReport(StarWinSector sector)
     {
-        return SectorRoutePlanner.BuildHyperlaneNetworkReport(
-            sector,
-            EmpiresById,
+        return selectedWorkspace is null
+            ? SectorHyperlaneNetworkReport.Empty
+            : SectorRoutePlanner.BuildHyperlaneNetworkReport(
+            selectedWorkspace.EligibleSystemIds,
             sector.SavedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
                 route.SourceSystemId,
                 route.TargetSystemId,
@@ -399,20 +400,27 @@ public partial class SectorConfiguration : ComponentBase
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
-            includeSavedRoutes: true,
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
+            includeSavedRoutes: false,
             includeReferenceData: false,
             cancellationToken: cancellationToken);
+
+        var workspaceSectorId = RequestedSectorId ?? selectedSectorId;
+        if (workspaceSectorId <= 0)
+        {
+            workspaceSectorId = explorerContext.CurrentSector.Id;
+        }
+
+        await LoadSelectedWorkspaceAsync(workspaceSectorId, cancellationToken);
         foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
         {
             sectorCacheBuilder.Invalidate(sectorId);
         }
     }
 
-    private void RunSearch()
+    private async Task RunSearchAsync()
     {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private async Task RestoreExplorerSessionAsync()
@@ -457,6 +465,19 @@ public partial class SectorConfiguration : ComponentBase
             new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Configuration")));
     }
 
+    private async Task LoadSelectedWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    {
+        if (sectorId <= 0)
+        {
+            selectedWorkspace = null;
+            selectedSectorRecord = null;
+            return;
+        }
+
+        selectedWorkspace = await ExplorerQueryService.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
+        selectedSectorRecord = selectedWorkspace is null ? null : BuildSectorRecord(selectedWorkspace);
+    }
+
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)
     {
         var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
@@ -473,5 +494,35 @@ public partial class SectorConfiguration : ComponentBase
         var separatorIndex = value.IndexOf(" - ", StringComparison.Ordinal);
         var idText = separatorIndex < 0 ? value : value[..separatorIndex];
         return int.TryParse(idText, out var id) ? id : 0;
+    }
+
+    private static StarWinSector BuildSectorRecord(ExplorerHyperlaneWorkspace workspace)
+    {
+        var sector = new StarWinSector
+        {
+            Id = workspace.SectorId,
+            Name = workspace.SectorName,
+            Configuration = workspace.Configuration
+        };
+
+        foreach (var system in workspace.Systems)
+        {
+            sector.Systems.Add(new StarSystem
+            {
+                Id = system.SystemId,
+                LegacySystemId = system.LegacySystemId,
+                SectorId = workspace.SectorId,
+                Name = system.Name,
+                Coordinates = system.Coordinates,
+                AllegianceId = system.AllegianceId
+            });
+        }
+
+        foreach (var route in workspace.SavedRoutes)
+        {
+            sector.SavedRoutes.Add(route);
+        }
+
+        return sector;
     }
 }

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
@@ -34,7 +34,6 @@ public partial class SectorConfiguration : ComponentBase
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
-    private readonly Dictionary<int, ExplorerSectorLoadSections> loadedSectorSectionsById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
@@ -93,8 +92,6 @@ public partial class SectorConfiguration : ComponentBase
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        initialSector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         LoadSectorConfigurationForm(initialSector);
@@ -111,7 +108,6 @@ public partial class SectorConfiguration : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorDataLoadedAsync(selectedSectorId);
             LoadSectorConfigurationForm(GetSelectedSector());
         }
 
@@ -162,7 +158,6 @@ public partial class SectorConfiguration : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -322,7 +317,6 @@ public partial class SectorConfiguration : ComponentBase
             });
 
         await RefreshExplorerDataAsync();
-        await EnsureSectorDataLoadedAsync(sector.Id);
         var reloadedSector = GetSelectedSector();
         LoadSectorConfigurationForm(reloadedSector);
         sectorConfigurationStatus = $"{savedSectorName} saved. Off-lane distance is {configuration.OffLaneMaximumDistanceParsecs:0.###} parsecs, and TL6-TL10 travel tiers now use the current sector configuration.";
@@ -364,7 +358,6 @@ public partial class SectorConfiguration : ComponentBase
             routeSaveProcessedItems = null;
             routeSaveTotalItems = null;
             await RefreshExplorerDataAsync();
-            await EnsureSectorDataLoadedAsync(sector.Id);
             LoadSectorConfigurationForm(GetSelectedSector());
             sectorConfigurationStatus = result.ReplacedExistingRoutes
                 ? $"Updated {result.RouteCount:N0} saved hyperlane segment{(result.RouteCount == 1 ? string.Empty : "s")} for {sector.Name}. {result.GeneratedRouteCount:N0} regenerated, {result.PreservedUserRouteCount:N0} user-persisted kept, {result.NetworkReport.DistinctNetworkCount:N0} network{(result.NetworkReport.DistinctNetworkCount == 1 ? string.Empty : "s")}, {result.NetworkReport.StrandedSystemCount:N0} stranded system{(result.NetworkReport.StrandedSystemCount == 1 ? string.Empty : "s")}."
@@ -393,7 +386,6 @@ public partial class SectorConfiguration : ComponentBase
         {
             var result = await IndependentColonyService.ConvertIndependentColoniesAsync(sectorId);
             await RefreshExplorerDataAsync();
-            await EnsureSectorDataLoadedAsync(sectorId);
             sectorConfigurationStatus = result.Assignments.Count == 0
                 ? "No independent colonies needed conversion."
                 : $"Created {result.CreatedEmpires.Count:N0} empire{(result.CreatedEmpires.Count == 1 ? string.Empty : "s")} and assigned {result.Assignments.Count:N0} colon{(result.Assignments.Count == 1 ? "y" : "ies")}.";
@@ -410,50 +402,10 @@ public partial class SectorConfiguration : ComponentBase
             includeSavedRoutes: true,
             includeReferenceData: false,
             cancellationToken: cancellationToken);
-
-        loadedSectorSectionsById.Clear();
         foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
         {
             sectorCacheBuilder.Invalidate(sectorId);
         }
-    }
-
-    private async Task EnsureSectorDataLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
-    {
-        if (sectorId <= 0)
-        {
-            return;
-        }
-
-        const ExplorerSectorLoadSections requiredSections = ExplorerSectorLoadSections.SavedRoutes;
-
-        loadedSectorSectionsById.TryGetValue(sectorId, out var loadedSections);
-        if ((loadedSections & requiredSections) == requiredSections)
-        {
-            return;
-        }
-
-        var detailedSector = await ExplorerContextService.LoadSectorAsync(sectorId, requiredSections, cancellationToken);
-        if (detailedSector is null)
-        {
-            return;
-        }
-
-        var sectors = ExplorerSectors.ToList();
-        var sectorIndex = sectors.FindIndex(item => item.Id == detailedSector.Id);
-        if (sectorIndex >= 0)
-        {
-            sectors[sectorIndex] = detailedSector;
-        }
-
-        explorerContext = explorerContext with
-        {
-            Sectors = sectors,
-            CurrentSector = explorerContext.CurrentSector.Id == detailedSector.Id ? detailedSector : explorerContext.CurrentSector
-        };
-
-        loadedSectorSectionsById[sectorId] = loadedSections | requiredSections;
-        sectorCacheBuilder.Invalidate(sectorId);
     }
 
     private void RunSearch()
@@ -484,8 +436,6 @@ public partial class SectorConfiguration : ComponentBase
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        sector = GetSelectedSector();
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
@@ -401,8 +401,6 @@ public partial class SectorConfiguration : ComponentBase
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
-            includeSavedRoutes: false,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
 
         var workspaceSectorId = RequestedSectorId ?? selectedSectorId;

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
@@ -32,10 +32,8 @@ public partial class SectorConfiguration : ComponentBase
     public int? RequestedSystemId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
-
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
-    protected ExplorerHyperlaneWorkspace? selectedWorkspace;
+    protected ExplorerSectorConfigurationState? selectedConfigurationState;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
@@ -77,13 +75,14 @@ public partial class SectorConfiguration : ComponentBase
 
     private bool browserSessionReady;
     private bool browserSessionRestored;
-    private StarWinSector? selectedSectorRecord;
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
+    protected int SavedRouteCount => selectedConfigurationState?.SavedRouteCount ?? 0;
+    protected SectorHyperlaneNetworkReport SavedRouteReport => selectedConfigurationState?.SavedRouteReport ?? SectorHyperlaneNetworkReport.Empty;
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync();
+        await RefreshExplorerShellAsync();
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
             : explorerContext.CurrentSector;
@@ -91,7 +90,8 @@ public partial class SectorConfiguration : ComponentBase
         selectedSectorId = initialSector.Id;
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
-        LoadSectorConfigurationForm(initialSector);
+        await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+        LoadSectorConfigurationForm(selectedConfigurationState);
     }
 
     protected override async Task OnParametersSetAsync()
@@ -101,17 +101,35 @@ public partial class SectorConfiguration : ComponentBase
             return;
         }
 
+        var sectorChanged = false;
+        var systemChanged = false;
+
         var requestedSectorId = RequestedSectorId ?? selectedSectorId;
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await LoadSelectedWorkspaceAsync(selectedSectorId);
-            LoadSectorConfigurationForm(GetSelectedSector());
+            sectorChanged = true;
         }
 
         var sector = GetSelectedSector();
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+        var resolvedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+        if (resolvedSystemId != selectedSystemId)
+        {
+            selectedSystemId = resolvedSystemId;
+            systemChanged = true;
+        }
+
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+
+        if (sectorChanged)
+        {
+            await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+            LoadSectorConfigurationForm(selectedConfigurationState);
+        }
+        else if (systemChanged)
+        {
+            await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -126,8 +144,6 @@ public partial class SectorConfiguration : ComponentBase
         StateHasChanged();
     }
 
-    protected ExplorerSectorCache GetSectorCache(StarWinSector sector) => sectorCacheBuilder.Get(sector);
-
     protected string BuildSectionRoute(string sectionName)
     {
         return SectorExplorerRoutes.BuildSectionUri(sectionName, selectedSectorId);
@@ -135,9 +151,7 @@ public partial class SectorConfiguration : ComponentBase
 
     protected StarWinSector GetSelectedSector()
     {
-        return selectedSectorRecord?.Id == selectedSectorId
-            ? selectedSectorRecord
-            : ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
+        return ExplorerSectors.FirstOrDefault(item => item.Id == selectedSectorId) ?? explorerContext.CurrentSector;
     }
 
     protected string DisplayResultType(StarWinSearchResultType type)
@@ -158,16 +172,16 @@ public partial class SectorConfiguration : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await LoadSelectedWorkspaceAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        LoadSectorConfigurationForm(sector);
+        await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+        LoadSectorConfigurationForm(selectedConfigurationState);
         await PersistExplorerSessionAsync();
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Configuration", selectedSectorId, selectedSystemId));
     }
 
-    protected Task HandleSelectedSystemTextChangedAsync(string value)
+    protected async Task HandleSelectedSystemTextChangedAsync(string value)
     {
         selectedSystemText = value;
         var sector = GetSelectedSector();
@@ -176,10 +190,11 @@ public partial class SectorConfiguration : ComponentBase
         {
             selectedSystemId = systemId;
             selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+            await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
             NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Configuration", selectedSectorId, selectedSystemId), replace: true);
         }
 
-        return PersistExplorerSessionAsync();
+        await PersistExplorerSessionAsync();
     }
 
     protected Task HandleSearchQueryChangedAsync(string value)
@@ -203,73 +218,60 @@ public partial class SectorConfiguration : ComponentBase
         NavigationManager.NavigateTo(targetUri);
     }
 
-    protected SectorHyperlaneNetworkReport GetSavedHyperlaneReport(StarWinSector sector)
-    {
-        return selectedWorkspace is null
-            ? SectorHyperlaneNetworkReport.Empty
-            : SectorRoutePlanner.BuildHyperlaneNetworkReport(
-            selectedWorkspace.EligibleSystemIds,
-            sector.SavedRoutes.Select(route => new SectorHyperlaneRouteDefinition(
-                route.SourceSystemId,
-                route.TargetSystemId,
-                (double)route.DistanceParsecs,
-                (double)route.TravelTimeYears,
-                route.TechnologyLevel,
-                route.TierName,
-                route.PrimaryOwnerEmpireId,
-                route.PrimaryOwnerEmpireName,
-                route.SecondaryOwnerEmpireId,
-                route.SecondaryOwnerEmpireName)));
-    }
-
-    protected string GetConfigurationRouteSummary(StarWinSector sector, StarSystem? focusedSystem)
+    protected string GetConfigurationRouteSummary(StarSystem? focusedSystem)
     {
         if (focusedSystem is null)
         {
             return "Select a system to preview connected hyperlanes.";
         }
 
-        if (sector.SavedRoutes.Count == 0)
+        if (SavedRouteCount == 0)
         {
             return "Preview available after saving routes for this sector.";
         }
 
-        var touchingRoutes = sector.SavedRoutes.Count(route =>
-            route.SourceSystemId == focusedSystem.Id || route.TargetSystemId == focusedSystem.Id);
+        var touchingRoutes = selectedConfigurationState?.SelectedSystemRouteCount ?? 0;
         return $"{touchingRoutes} saved hyperlane segment{(touchingRoutes == 1 ? string.Empty : "s")} touch the selected system.";
     }
 
-    protected static string DisplayDateTime(DateTime value)
+    protected static string DisplayDateTime(DateTime? value)
     {
-        return value.ToLocalTime().ToString("MMM d, yyyy h:mm tt");
+        return value is DateTime timestamp && timestamp != default
+            ? timestamp.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+            : "Not recorded";
     }
 
-    private void LoadSectorConfigurationForm(StarWinSector sector)
+    private void LoadSectorConfigurationForm(ExplorerSectorConfigurationState? state)
     {
-        sectorName = sector.Name;
-        offLaneMaximumDistanceParsecs = Math.Round(sector.Configuration.OffLaneMaximumDistanceParsecs, 3);
-        tl9AndBelowMaximumConnectionsPerSystem = sector.Configuration.Tl9AndBelowMaximumConnectionsPerSystem;
-        additionalCrossEmpireConnectionsPerSystem = sector.Configuration.AdditionalCrossEmpireConnectionsPerSystem;
-        tl6HyperlaneName = sector.Configuration.Tl6HyperlaneName;
-        tl6MaximumDistanceParsecs = Math.Round(sector.Configuration.Tl6MaximumDistanceParsecs, 3);
-        tl6OffLaneSpeedMultiplier = Math.Round(sector.Configuration.Tl6OffLaneSpeedMultiplier, 3);
-        tl6HyperlaneSpeedModifier = Math.Round(sector.Configuration.Tl6HyperlaneSpeedModifier, 3);
-        tl7HyperlaneName = sector.Configuration.Tl7HyperlaneName;
-        tl7MaximumDistanceParsecs = Math.Round(sector.Configuration.Tl7MaximumDistanceParsecs, 3);
-        tl7OffLaneSpeedMultiplier = Math.Round(sector.Configuration.Tl7OffLaneSpeedMultiplier, 3);
-        tl7HyperlaneSpeedModifier = Math.Round(sector.Configuration.Tl7HyperlaneSpeedModifier, 3);
-        tl8HyperlaneName = sector.Configuration.Tl8HyperlaneName;
-        tl8MaximumDistanceParsecs = Math.Round(sector.Configuration.Tl8MaximumDistanceParsecs, 3);
-        tl8OffLaneSpeedMultiplier = Math.Round(sector.Configuration.Tl8OffLaneSpeedMultiplier, 3);
-        tl8HyperlaneSpeedModifier = Math.Round(sector.Configuration.Tl8HyperlaneSpeedModifier, 3);
-        tl9HyperlaneName = sector.Configuration.Tl9HyperlaneName;
-        tl9MaximumDistanceParsecs = Math.Round(sector.Configuration.Tl9MaximumDistanceParsecs, 3);
-        tl9OffLaneSpeedMultiplier = Math.Round(sector.Configuration.Tl9OffLaneSpeedMultiplier, 3);
-        tl9HyperlaneSpeedModifier = Math.Round(sector.Configuration.Tl9HyperlaneSpeedModifier, 3);
-        tl10HyperlaneName = sector.Configuration.Tl10HyperlaneName;
-        tl10MaximumDistanceParsecs = Math.Round(sector.Configuration.Tl10MaximumDistanceParsecs, 3);
-        tl10OffLaneSpeedMultiplier = Math.Round(sector.Configuration.Tl10OffLaneSpeedMultiplier, 3);
-        tl10HyperlaneSpeedModifier = Math.Round(sector.Configuration.Tl10HyperlaneSpeedModifier, 3);
+        if (state is null)
+        {
+            return;
+        }
+
+        sectorName = state.SectorName;
+        offLaneMaximumDistanceParsecs = Math.Round(state.Configuration.OffLaneMaximumDistanceParsecs, 3);
+        tl9AndBelowMaximumConnectionsPerSystem = state.Configuration.Tl9AndBelowMaximumConnectionsPerSystem;
+        additionalCrossEmpireConnectionsPerSystem = state.Configuration.AdditionalCrossEmpireConnectionsPerSystem;
+        tl6HyperlaneName = state.Configuration.Tl6HyperlaneName;
+        tl6MaximumDistanceParsecs = Math.Round(state.Configuration.Tl6MaximumDistanceParsecs, 3);
+        tl6OffLaneSpeedMultiplier = Math.Round(state.Configuration.Tl6OffLaneSpeedMultiplier, 3);
+        tl6HyperlaneSpeedModifier = Math.Round(state.Configuration.Tl6HyperlaneSpeedModifier, 3);
+        tl7HyperlaneName = state.Configuration.Tl7HyperlaneName;
+        tl7MaximumDistanceParsecs = Math.Round(state.Configuration.Tl7MaximumDistanceParsecs, 3);
+        tl7OffLaneSpeedMultiplier = Math.Round(state.Configuration.Tl7OffLaneSpeedMultiplier, 3);
+        tl7HyperlaneSpeedModifier = Math.Round(state.Configuration.Tl7HyperlaneSpeedModifier, 3);
+        tl8HyperlaneName = state.Configuration.Tl8HyperlaneName;
+        tl8MaximumDistanceParsecs = Math.Round(state.Configuration.Tl8MaximumDistanceParsecs, 3);
+        tl8OffLaneSpeedMultiplier = Math.Round(state.Configuration.Tl8OffLaneSpeedMultiplier, 3);
+        tl8HyperlaneSpeedModifier = Math.Round(state.Configuration.Tl8HyperlaneSpeedModifier, 3);
+        tl9HyperlaneName = state.Configuration.Tl9HyperlaneName;
+        tl9MaximumDistanceParsecs = Math.Round(state.Configuration.Tl9MaximumDistanceParsecs, 3);
+        tl9OffLaneSpeedMultiplier = Math.Round(state.Configuration.Tl9OffLaneSpeedMultiplier, 3);
+        tl9HyperlaneSpeedModifier = Math.Round(state.Configuration.Tl9HyperlaneSpeedModifier, 3);
+        tl10HyperlaneName = state.Configuration.Tl10HyperlaneName;
+        tl10MaximumDistanceParsecs = Math.Round(state.Configuration.Tl10MaximumDistanceParsecs, 3);
+        tl10OffLaneSpeedMultiplier = Math.Round(state.Configuration.Tl10OffLaneSpeedMultiplier, 3);
+        tl10HyperlaneSpeedModifier = Math.Round(state.Configuration.Tl10HyperlaneSpeedModifier, 3);
         sectorConfigurationStatus = string.Empty;
     }
 
@@ -317,9 +319,9 @@ public partial class SectorConfiguration : ComponentBase
                 Tl10HyperlaneSpeedModifier = tl10HyperlaneSpeedModifier
             });
 
-        await RefreshExplorerDataAsync();
-        var reloadedSector = GetSelectedSector();
-        LoadSectorConfigurationForm(reloadedSector);
+        await RefreshExplorerShellAsync();
+        await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+        LoadSectorConfigurationForm(selectedConfigurationState);
         sectorConfigurationStatus = $"{savedSectorName} saved. Off-lane distance is {configuration.OffLaneMaximumDistanceParsecs:0.###} parsecs, and TL6-TL10 travel tiers now use the current sector configuration.";
     }
 
@@ -358,8 +360,9 @@ public partial class SectorConfiguration : ComponentBase
             routeSaveLoadingPercent = 100;
             routeSaveProcessedItems = null;
             routeSaveTotalItems = null;
-            await RefreshExplorerDataAsync();
-            LoadSectorConfigurationForm(GetSelectedSector());
+            await RefreshExplorerShellAsync();
+            await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+            LoadSectorConfigurationForm(selectedConfigurationState);
             sectorConfigurationStatus = result.ReplacedExistingRoutes
                 ? $"Updated {result.RouteCount:N0} saved hyperlane segment{(result.RouteCount == 1 ? string.Empty : "s")} for {sector.Name}. {result.GeneratedRouteCount:N0} regenerated, {result.PreservedUserRouteCount:N0} user-persisted kept, {result.NetworkReport.DistinctNetworkCount:N0} network{(result.NetworkReport.DistinctNetworkCount == 1 ? string.Empty : "s")}, {result.NetworkReport.StrandedSystemCount:N0} stranded system{(result.NetworkReport.StrandedSystemCount == 1 ? string.Empty : "s")}."
                 : $"Saved {result.RouteCount:N0} hyperlane segment{(result.RouteCount == 1 ? string.Empty : "s")} for {sector.Name}. {result.NetworkReport.DistinctNetworkCount:N0} network{(result.NetworkReport.DistinctNetworkCount == 1 ? string.Empty : "s")} and {result.NetworkReport.StrandedSystemCount:N0} stranded system{(result.NetworkReport.StrandedSystemCount == 1 ? string.Empty : "s")}.";
@@ -386,7 +389,8 @@ public partial class SectorConfiguration : ComponentBase
         try
         {
             var result = await IndependentColonyService.ConvertIndependentColoniesAsync(sectorId);
-            await RefreshExplorerDataAsync();
+            await RefreshExplorerShellAsync();
+            await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
             sectorConfigurationStatus = result.Assignments.Count == 0
                 ? "No independent colonies needed conversion."
                 : $"Created {result.CreatedEmpires.Count:N0} empire{(result.CreatedEmpires.Count == 1 ? string.Empty : "s")} and assigned {result.Assignments.Count:N0} colon{(result.Assignments.Count == 1 ? "y" : "ies")}.";
@@ -397,23 +401,11 @@ public partial class SectorConfiguration : ComponentBase
         }
     }
 
-    private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
+    private async Task RefreshExplorerShellAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
             cancellationToken: cancellationToken);
-
-        var workspaceSectorId = RequestedSectorId ?? selectedSectorId;
-        if (workspaceSectorId <= 0)
-        {
-            workspaceSectorId = explorerContext.CurrentSector.Id;
-        }
-
-        await LoadSelectedWorkspaceAsync(workspaceSectorId, cancellationToken);
-        foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
-        {
-            sectorCacheBuilder.Invalidate(sectorId);
-        }
     }
 
     private async Task RunSearchAsync()
@@ -446,7 +438,8 @@ public partial class SectorConfiguration : ComponentBase
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        LoadSectorConfigurationForm(sector);
+        await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+        LoadSectorConfigurationForm(selectedConfigurationState);
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Configuration", selectedSectorId, selectedSystemId), replace: true);
     }
 
@@ -463,17 +456,18 @@ public partial class SectorConfiguration : ComponentBase
             new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Configuration")));
     }
 
-    private async Task LoadSelectedWorkspaceAsync(int sectorId, CancellationToken cancellationToken = default)
+    private async Task LoadSelectedConfigurationStateAsync(int sectorId, int? systemId = null, CancellationToken cancellationToken = default)
     {
         if (sectorId <= 0)
         {
-            selectedWorkspace = null;
-            selectedSectorRecord = null;
+            selectedConfigurationState = null;
             return;
         }
 
-        selectedWorkspace = await ExplorerQueryService.LoadHyperlaneWorkspaceAsync(sectorId, cancellationToken);
-        selectedSectorRecord = selectedWorkspace is null ? null : BuildSectorRecord(selectedWorkspace);
+        selectedConfigurationState = await ExplorerQueryService.LoadSectorConfigurationStateAsync(
+            sectorId,
+            systemId,
+            cancellationToken);
     }
 
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)
@@ -494,33 +488,4 @@ public partial class SectorConfiguration : ComponentBase
         return int.TryParse(idText, out var id) ? id : 0;
     }
 
-    private static StarWinSector BuildSectorRecord(ExplorerHyperlaneWorkspace workspace)
-    {
-        var sector = new StarWinSector
-        {
-            Id = workspace.SectorId,
-            Name = workspace.SectorName,
-            Configuration = workspace.Configuration
-        };
-
-        foreach (var system in workspace.Systems)
-        {
-            sector.Systems.Add(new StarSystem
-            {
-                Id = system.SystemId,
-                LegacySystemId = system.LegacySystemId,
-                SectorId = workspace.SectorId,
-                Name = system.Name,
-                Coordinates = system.Coordinates,
-                AllegianceId = system.AllegianceId
-            });
-        }
-
-        foreach (var route in workspace.SavedRoutes)
-        {
-            sector.SavedRoutes.Add(route);
-        }
-
-        return sector;
-    }
 }

--- a/StarWin.Web/Components/Pages/SectorExplorer.razor
+++ b/StarWin.Web/Components/Pages/SectorExplorer.razor
@@ -4,7 +4,6 @@
 @inject IStarWinWorkspace Workspace
 @inject IStarWinExplorerContextService ExplorerContextService
 @inject IStarWinExplorerQueryService ExplorerQueryService
-@inject IStarWinSearchService SearchService
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @using Microsoft.AspNetCore.WebUtilities
@@ -24,11 +23,7 @@
         selectedSystemText,
         EventCallback.Factory.Create<string>(this, HandleSelectedSystemTextChanged),
         searchQuery,
-        EventCallback.Factory.Create<string>(this, value =>
-        {
-            searchQuery = value;
-            RunSearch();
-        }),
+        EventCallback.Factory.Create<string>(this, HandleSearchQueryChangedAsync),
         searchResults,
         EventCallback.Factory.Create<StarWinSearchResult>(this, NavigateToSearchResult),
         sections,
@@ -149,12 +144,12 @@ else
     {
         await RefreshExplorerDataAsync();
         var initialSector = GetSelectedSector();
-        ApplyRequestedSelection(initialSector);
+        await ApplyRequestedSelectionAsync(initialSector);
         await EnsureSectorSelectionAsync(selectedSectorId, selectedSystemId);
         lastAppliedRequest = GetCurrentRequest();
     }
 
-    protected override void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
         var currentRequest = GetCurrentRequest();
         if (currentRequest == lastAppliedRequest)
@@ -170,7 +165,7 @@ else
                 selectedSectorId = requestedSectorId;
             }
 
-            ApplyRequestedSelection(GetSelectedSector());
+            await ApplyRequestedSelectionAsync(GetSelectedSector());
         }
 
         lastAppliedRequest = currentRequest;
@@ -181,7 +176,9 @@ else
         var previousSectorId = selectedSectorId;
         var previousSystemId = selectedSystemId;
 
-        explorerContext = await ExplorerContextService.LoadShellAsync(cancellationToken: cancellationToken);
+        explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
+            cancellationToken: cancellationToken);
 
         if (ExplorerSectors.Count == 0)
         {
@@ -198,7 +195,7 @@ else
 
         if (!string.IsNullOrWhiteSpace(searchQuery))
         {
-            RunSearch();
+            await RunSearchAsync();
         }
     }
 
@@ -371,49 +368,34 @@ else
         }
     }
 
-    private void RunSearch()
+    private Task HandleSearchQueryChangedAsync(string value)
     {
-        var sector = GetSelectedSector();
-        var raceIds = sector.Systems
-            .SelectMany(system => system.Worlds)
-            .Select(world => world.Colony?.RaceId)
-            .Where(raceId => raceId is not null)
-            .Select(raceId => (int)raceId!.Value)
-            .ToHashSet();
-        var empireIds = sector.Systems
-            .SelectMany(system => system.Worlds)
-            .Select(world => world.Colony?.AllegianceId)
-            .Where(empireId => empireId is not null && empireId != ushort.MaxValue)
-            .Select(empireId => (int)empireId!.Value)
-            .ToHashSet();
+        searchQuery = value;
+        return RunSearchAsync();
+    }
 
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.Type switch
-            {
-                StarWinSearchResultType.AlienRace => result.RaceId is int raceId && raceIds.Contains(raceId),
-                StarWinSearchResultType.Empire => result.EmpireId is int empireId && empireIds.Contains(empireId),
-                _ => true
-            })
-            .ToList();
+    private async Task RunSearchAsync()
+    {
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private void NavigateToSearchResult(StarWinSearchResult result)
     {
         var sectionName = sections.Contains(result.Tab) ? result.Tab : OverviewSectionName;
         var sectorId = result.SectorId ?? selectedSectorId;
-        var systemId = result.SystemId ?? ResolveSystemIdFromSearchResult(result, sectorId);
+        var systemId = result.SystemId ?? 0;
 
         searchQuery = result.Title;
         searchResults = [];
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri(
-            sectionName,
-            sectorId,
-            systemId,
-            result.WorldId ?? 0,
-            0,
-            result.SpaceHabitatId ?? 0,
-            result.RaceId ?? 0,
-            result.EmpireId ?? 0));
+             sectionName,
+             sectorId,
+             systemId,
+             result.WorldId ?? 0,
+             result.ColonyId ?? 0,
+             result.SpaceHabitatId ?? 0,
+             result.RaceId ?? 0,
+             result.EmpireId ?? 0));
     }
 
     private void SyncCurrentExplorerRoute(bool replaceHistory = false)
@@ -450,7 +432,7 @@ else
             RequestedEmpireId);
     }
 
-    private void ApplyRequestedSelection(StarWinSector sector)
+    private async Task ApplyRequestedSelectionAsync(StarWinSector sector, CancellationToken cancellationToken = default)
     {
         if (RequestedSystemId is int requestedSystemId
             && sector.Systems.Any(system => system.Id == requestedSystemId))
@@ -458,33 +440,11 @@ else
             selectedSystemId = requestedSystemId;
         }
 
-        if (RequestedWorldId is int requestedWorldId)
+        var resolvedSystemId = await ResolveRequestedSystemIdAsync(sector.Id, cancellationToken);
+        if (resolvedSystemId is int requestedSelectionSystemId
+            && sector.Systems.Any(system => system.Id == requestedSelectionSystemId))
         {
-            var worldSystem = sector.Systems.FirstOrDefault(system => system.Worlds.Any(world => world.Id == requestedWorldId));
-            if (worldSystem is not null)
-            {
-                selectedSystemId = worldSystem.Id;
-            }
-        }
-
-        if (RequestedColonyId is int requestedColonyId)
-        {
-            var colonyListing = sector.Systems
-                .SelectMany(system => system.Worlds.Select(world => new { system, world }))
-                .FirstOrDefault(item => item.world.Colony?.Id == requestedColonyId);
-            if (colonyListing is not null)
-            {
-                selectedSystemId = colonyListing.system.Id;
-            }
-        }
-
-        if (RequestedHabitatId is int requestedHabitatId)
-        {
-            var habitatSystem = sector.Systems.FirstOrDefault(system => system.SpaceHabitats.Any(habitat => habitat.Id == requestedHabitatId));
-            if (habitatSystem is not null)
-            {
-                selectedSystemId = habitatSystem.Id;
-            }
+            selectedSystemId = requestedSelectionSystemId;
         }
 
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -565,24 +525,33 @@ else
         }
     }
 
-    private int ResolveSystemIdFromSearchResult(StarWinSearchResult result, int sectorId)
+    private Task<int?> ResolveRequestedSystemIdAsync(int sectorId, CancellationToken cancellationToken = default)
     {
-        var sector = ExplorerSectors.FirstOrDefault(item => item.Id == sectorId) ?? GetSelectedSector();
-        if (result.WorldId is int worldId
-            && sector.Systems.FirstOrDefault(system => system.Worlds.Any(world => world.Id == worldId)) is { } worldSystem)
+        if (RequestedColonyId is int requestedColonyId)
         {
-            return worldSystem.Id;
+            return ExplorerQueryService.ResolveSystemIdAsync(
+                sectorId,
+                colonyId: requestedColonyId,
+                cancellationToken: cancellationToken);
         }
 
-        if (result.SpaceHabitatId is int habitatId
-            && sector.Systems.FirstOrDefault(system => system.SpaceHabitats.Any(habitat => habitat.Id == habitatId)) is { } habitatSystem)
+        if (RequestedHabitatId is int requestedHabitatId)
         {
-            return habitatSystem.Id;
+            return ExplorerQueryService.ResolveSystemIdAsync(
+                sectorId,
+                habitatId: requestedHabitatId,
+                cancellationToken: cancellationToken);
         }
 
-        return result.SystemId
-            ?? sector.Systems.FirstOrDefault()?.Id
-            ?? 0;
+        if (RequestedWorldId is int requestedWorldId)
+        {
+            return ExplorerQueryService.ResolveSystemIdAsync(
+                sectorId,
+                worldId: requestedWorldId,
+                cancellationToken: cancellationToken);
+        }
+
+        return Task.FromResult<int?>(null);
     }
 
     private sealed record ExplorerSessionSelection(int SectorId, int SystemId);

--- a/StarWin.Web/Components/Pages/SectorExplorer.razor
+++ b/StarWin.Web/Components/Pages/SectorExplorer.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer"
 @rendermode InteractiveServer
 @inject IStarWinWorkspace Workspace
@@ -34,7 +34,7 @@
 }
 
 <PageTitle>Sector Explorer | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 @if (overviewData is not null)
 {
@@ -98,6 +98,7 @@ else
                                     SystemId="selectedSystemId" />
     }
 </section>
+</SectorExplorerFrame>
 @code {
     private const string OverviewSectionName = "Overview";
     private const int ComboAllFilterId = -1;

--- a/StarWin.Web/Components/Pages/SectorExplorer.razor
+++ b/StarWin.Web/Components/Pages/SectorExplorer.razor
@@ -126,6 +126,7 @@ else
 
     private static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     private readonly Dictionary<int, ExplorerSectorOverviewData> sectorOverviewDataById = [];
+    private readonly Dictionary<int, Task<ExplorerSectorOverviewData>> sectorOverviewLoadTasksById = [];
     private StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     private (int? SectorId, int? SystemId, int? WorldId, int? ColonyId, int? HabitatId, int? RaceId, int? EmpireId) lastAppliedRequest;
     private bool overviewMapWorkspaceReady;
@@ -211,7 +212,25 @@ else
             return;
         }
 
-        sectorOverviewDataById[sectorId] = await ExplorerQueryService.LoadSectorOverviewAsync(sectorId, cancellationToken);
+        if (sectorOverviewDataById.ContainsKey(sectorId))
+        {
+            return;
+        }
+
+        if (!sectorOverviewLoadTasksById.TryGetValue(sectorId, out var loadTask))
+        {
+            loadTask = ExplorerQueryService.LoadSectorOverviewAsync(sectorId, cancellationToken);
+            sectorOverviewLoadTasksById[sectorId] = loadTask;
+        }
+
+        try
+        {
+            sectorOverviewDataById[sectorId] = await loadTask;
+        }
+        finally
+        {
+            sectorOverviewLoadTasksById.Remove(sectorId);
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/StarWin.Web/Components/Pages/Systems.razor
+++ b/StarWin.Web/Components/Pages/Systems.razor
@@ -4,9 +4,7 @@
 
 @{
     var sector = GetSelectedSector();
-    var sectionCache = GetSectorCache(sector);
-    var sectorEmpires = ExplorerEmpires.Where(empire => sectionCache.EmpireIds.Contains(empire.Id)).OrderBy(empire => empire.Name).ToList();
-    var selectedSystem = sector.Systems.FirstOrDefault(system => system.Id == selectedSystemId) ?? sector.Systems.FirstOrDefault();
+    var selectedSystem = selectedSystemDetail?.System;
     var layoutState = new SectorExplorerLayoutState(
         null,
         ExplorerSectors,
@@ -29,129 +27,187 @@
 <PageTitle>Systems | Starforged Atlas</PageTitle>
 <SectorExplorerLayoutSync State="layoutState" />
 
-<ExplorerSystemsSection SectorCache="sectionCache"
-                        Empires="sectorEmpires"
-                        SectorId="@sector.Id"
-                        SelectedSystemId="@(selectedSystem?.Id ?? 0)"
-                        SystemSelected="SelectSystem">
+<section class="content-grid">
+    <div class="record-list">
+        <details class="record-filter-panel" open>
+            <summary class="record-filter-summary">Search</summary>
+            <label>
+                Search
+                <input placeholder="Name, ID, coordinates..."
+                       @bind="systemQuery"
+                       @bind:event="oninput"
+                       @bind:after="HandleSystemFiltersChangedAsync" />
+            </label>
+            <button type="button" class="timeline-clear-button" @onclick="ToggleSystemFilters">
+                @(showSystemFilters ? "Hide filters" : "Show filters")
+            </button>
+            @if (showSystemFilters)
+            {
+                <label>
+                    Allegiance
+                    <input list="system-allegiance-options"
+                           placeholder="All allegiances"
+                           @bind="systemEmpireText"
+                           @bind:event="oninput"
+                           @bind:after="ApplySystemEmpireFilterAsync" />
+                    <datalist id="system-allegiance-options">
+                        @foreach (var empire in systemFilterOptions.Empires)
+                        {
+                            <option value="@FormatEmpireOption(empire)" />
+                        }
+                    </datalist>
+                </label>
+            }
+            <button type="button" class="timeline-clear-button" @onclick="HandleClearSystemFiltersAsync">Clear filters</button>
+        </details>
+        <div class="timeline-count">Showing @LoadedSystemSummaries.Count system@(LoadedSystemSummaries.Count == 1 ? string.Empty : "s")@(systemHasMoreRecords ? "+" : string.Empty)</div>
+        @if (systemListLoading && LoadedSystemSummaries.Count == 0)
+        {
+            <article class="timeline-event-card">
+                <span class="timeline-century">Loading systems</span>
+                <p>Querying systems for the selected sector.</p>
+            </article>
+        }
+        else if (LoadedSystemSummaries.Count == 0)
+        {
+            <article class="timeline-event-card">
+                <span class="timeline-century">No matches</span>
+                <p>Adjust the filters to widen the system list.</p>
+            </article>
+        }
+        @foreach (var system in LoadedSystemSummaries)
+        {
+            <button type="button" class="record-row @(selectedSystem?.Id == system.SystemId ? "active" : null)" @onclick="() => SelectSystem(system.SystemId)">
+                <strong>@system.Name</strong>
+                <span>@DisplayCoordinates(system.Coordinates)</span>
+            </button>
+        }
+        @if (systemHasMoreRecords)
+        {
+            <div @ref="systemLoadMoreElement" class="timeline-load-more">
+                <button type="button" @onclick="LoadMoreSystems">Load more</button>
+            </div>
+        }
+    </div>
+
     @if (selectedSystem is not null)
     {
         <article class="detail-panel">
-                    <span class="panel-kicker">System survey</span>
-                    <EditableEntityName Name="@selectedSystem.Name"
-                                        Label="System"
-                                        NameSaved="name => SaveEntityNameAsync(EntityNoteTargetKind.StarSystem, selectedSystem.Id, name)" />
-                    <dl class="field-grid">
-                        <div><dt>System id</dt><dd>@selectedSystem.Id</dd></div>
-                        <div><dt>Map code</dt><dd>@selectedSystem.MapCode</dd></div>
-                        <div><dt>Allegiance</dt><dd>@DisplayAllegiance(selectedSystem.AllegianceId)</dd></div>
-                        <div><dt>World count</dt><dd>@selectedSystem.Worlds.Count</dd></div>
-                    </dl>
+            <span class="panel-kicker">System survey</span>
+            <EditableEntityName Name="@selectedSystem.Name"
+                                Label="System"
+                                NameSaved="name => SaveEntityNameAsync(EntityNoteTargetKind.StarSystem, selectedSystem.Id, name)" />
+            <dl class="field-grid">
+                <div><dt>System id</dt><dd>@selectedSystem.Id</dd></div>
+                <div><dt>Map code</dt><dd>@selectedSystem.MapCode</dd></div>
+                <div><dt>Allegiance</dt><dd>@DisplayAllegiance(selectedSystem.AllegianceId)</dd></div>
+                <div><dt>World count</dt><dd>@selectedSystem.Worlds.Count</dd></div>
+            </dl>
 
-                    <EntityNotesPanel TargetKind="EntityNoteTargetKind.StarSystem"
-                                      TargetId="selectedSystem.Id"
-                                      Title="System notes" />
+            <EntityNotesPanel TargetKind="EntityNoteTargetKind.StarSystem"
+                              TargetId="selectedSystem.Id"
+                              Title="System notes" />
 
-                    <div class="stellar-grid">
-                        @foreach (var bodyItem in selectedSystem.AstralBodies.Select((body, index) => new { Body = body, Sequence = index }))
+            <div class="stellar-grid">
+                @foreach (var bodyItem in selectedSystem.AstralBodies.Select((body, index) => new { Body = body, Sequence = index }))
+                {
+                    var bodyImages = GetEntityImages(EntityImageTargetKind.AstralBody, bodyItem.Body.Id);
+
+                    <article class="stellar-card">
+                        @if (GetPrimaryEntityImage(EntityImageTargetKind.AstralBody, bodyItem.Body.Id) is { } primaryAstralImage)
                         {
-                            var bodyImages = GetEntityImages(EntityImageTargetKind.AstralBody, bodyItem.Body.Id);
-
-                            <article class="stellar-card">
-                                @if (GetPrimaryEntityImage(EntityImageTargetKind.AstralBody, bodyItem.Body.Id) is { } primaryAstralImage)
-                                {
-                                    <img class="@($"{GetAstralBodyOrbClass(bodyItem.Body)} entity-orb-image")"
-                                         src="@primaryAstralImage.RelativePath"
-                                         alt="@($"{bodyItem.Body.Role} {bodyItem.Body.Kind}")" />
-                                }
-                                else
-                                {
-                                    <div class="@GetAstralBodyOrbClass(bodyItem.Body)"></div>
-                                }
-
-                                <h3>@bodyItem.Body.Role</h3>
-                                <section class="entity-image-panel compact-empty">
-                                    <div class="image-panel-header">
-                                        <h4>Astral image</h4>
-                                        <span>Multiple allowed</span>
-                                    </div>
-                                    @if (bodyImages.Count > 0)
-                                    {
-                                        <div class="entity-image-grid">
-                                            @foreach (var image in bodyImages)
-                                            {
-                                                <figure>
-                                                    <img src="@image.RelativePath" alt="@image.FileName" />
-                                                    <figcaption>@(image.IsPrimary ? "Primary" : image.FileName)</figcaption>
-                                                </figure>
-                                            }
-                                        </div>
-                                    }
-                                    else
-                                    {
-                                        <p>No image uploaded.</p>
-                                    }
-                                    <label class="image-upload-control">
-                                        <span>Add image</span>
-                                        <InputFile OnChange="@(args => UploadEntityImage(EntityImageTargetKind.AstralBody, bodyItem.Body.Id, args))"
-                                                   accept="image/jpeg,image/png,image/gif,image/webp" />
-                                    </label>
-                                    @if (!string.IsNullOrWhiteSpace(imageUploadStatus))
-                                    {
-                                        <small>@imageUploadStatus</small>
-                                    }
-                                </section>
-                                <dl class="data-list">
-                                    <div><dt>Kind</dt><dd>@bodyItem.Body.Kind</dd></div>
-                                    <div><dt>Type</dt><dd>@bodyItem.Body.Classification</dd></div>
-                                    <div><dt>Luminosity</dt><dd>@Format(bodyItem.Body.Luminosity)</dd></div>
-                                    <div><dt>Mass</dt><dd>@Format(bodyItem.Body.SolarMasses)</dd></div>
-                                </dl>
-
-                                <div class="satellite-list">
-                                    <h4>Satellites</h4>
-                                    @foreach (var satellite in GetAstralBodySatellites(selectedSystem, bodyItem.Sequence))
-                                    {
-                                        if (satellite.World is not null)
-                                        {
-                                            <button type="button" class="satellite-link" @onclick="() => NavigateToWorld(satellite.World.Id)">
-                                                <span>@satellite.Kind</span>
-                                                <strong>@satellite.Name</strong>
-                                            </button>
-                                        }
-                                        else if (satellite.Habitat is not null)
-                                        {
-                                            <button type="button" class="satellite-link habitat" @onclick="() => NavigateToHabitat(satellite.Habitat.Id)">
-                                                <span>Habitat</span>
-                                                <strong>@satellite.Name</strong>
-                                            </button>
-                                        }
-                                    }
-                                    <div class="habitat-create-form">
-                                        <input placeholder="Habitat name"
-                                               @bind="spaceHabitatName"
-                                               maxlength="160" />
-                                        <select @bind="spaceHabitatEmpireId">
-                                            <option value="0">Empire</option>
-                                            @foreach (var empire in ExplorerEmpires.OrderBy(empire => empire.Name))
-                                            {
-                                                <option value="@empire.Id">@empire.Name</option>
-                                            }
-                                        </select>
-                                        <button type="button"
-                                                @onclick="() => CreateAstralBodySpaceHabitatAsync(selectedSystem, bodyItem.Sequence)"
-                                                disabled="@IsSpaceHabitatCreateDisabled">
-                                            Create habitat
-                                        </button>
-                                        @if (!string.IsNullOrWhiteSpace(spaceHabitatStatus))
-                                        {
-                                            <p>@spaceHabitatStatus</p>
-                                        }
-                                    </div>
-                                </div>
-                            </article>
+                            <img class="@($"{GetAstralBodyOrbClass(bodyItem.Body)} entity-orb-image")"
+                                 src="@primaryAstralImage.RelativePath"
+                                 alt="@($"{bodyItem.Body.Role} {bodyItem.Body.Kind}")" />
                         }
-                    </div>
+                        else
+                        {
+                            <div class="@GetAstralBodyOrbClass(bodyItem.Body)"></div>
+                        }
+
+                        <h3>@bodyItem.Body.Role</h3>
+                        <section class="entity-image-panel compact-empty">
+                            <div class="image-panel-header">
+                                <h4>Astral image</h4>
+                                <span>Multiple allowed</span>
+                            </div>
+                            @if (bodyImages.Count > 0)
+                            {
+                                <div class="entity-image-grid">
+                                    @foreach (var image in bodyImages)
+                                    {
+                                        <figure>
+                                            <img src="@image.RelativePath" alt="@image.FileName" />
+                                            <figcaption>@(image.IsPrimary ? "Primary" : image.FileName)</figcaption>
+                                        </figure>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <p>No image uploaded.</p>
+                            }
+                            <label class="image-upload-control">
+                                <span>Add image</span>
+                                <InputFile OnChange="@(args => UploadEntityImage(EntityImageTargetKind.AstralBody, bodyItem.Body.Id, args))"
+                                           accept="image/jpeg,image/png,image/gif,image/webp" />
+                            </label>
+                            @if (!string.IsNullOrWhiteSpace(imageUploadStatus))
+                            {
+                                <small>@imageUploadStatus</small>
+                            }
+                        </section>
+                        <dl class="data-list">
+                            <div><dt>Kind</dt><dd>@bodyItem.Body.Kind</dd></div>
+                            <div><dt>Type</dt><dd>@bodyItem.Body.Classification</dd></div>
+                            <div><dt>Luminosity</dt><dd>@Format(bodyItem.Body.Luminosity)</dd></div>
+                            <div><dt>Mass</dt><dd>@Format(bodyItem.Body.SolarMasses)</dd></div>
+                        </dl>
+
+                        <div class="satellite-list">
+                            <h4>Satellites</h4>
+                            @foreach (var satellite in GetAstralBodySatellites(selectedSystem, bodyItem.Sequence))
+                            {
+                                if (satellite.World is not null)
+                                {
+                                    <button type="button" class="satellite-link" @onclick="() => NavigateToWorld(satellite.World.Id)">
+                                        <span>@satellite.Kind</span>
+                                        <strong>@satellite.Name</strong>
+                                    </button>
+                                }
+                                else if (satellite.Habitat is not null)
+                                {
+                                    <button type="button" class="satellite-link habitat" @onclick="() => NavigateToHabitat(satellite.Habitat.Id)">
+                                        <span>Habitat</span>
+                                        <strong>@satellite.Name</strong>
+                                    </button>
+                                }
+                            }
+                            <div class="habitat-create-form">
+                                <input placeholder="Habitat name"
+                                       @bind="spaceHabitatName"
+                                       maxlength="160" />
+                                <select @bind="spaceHabitatEmpireId">
+                                    <option value="0">Empire</option>
+                                    @foreach (var empire in systemFilterOptions.Empires.OrderBy(empire => empire.Name))
+                                    {
+                                        <option value="@empire.Id">@empire.Name</option>
+                                    }
+                                </select>
+                                <button type="button"
+                                        @onclick="() => CreateAstralBodySpaceHabitatAsync(selectedSystem, bodyItem.Sequence)"
+                                        disabled="@IsSpaceHabitatCreateDisabled">
+                                    Create habitat
+                                </button>
+                                @if (!string.IsNullOrWhiteSpace(spaceHabitatStatus))
+                                {
+                                    <p>@spaceHabitatStatus</p>
+                                }
+                            </div>
+                        </div>
+                    </article>
+                }
+            </div>
         </article>
     }
-</ExplorerSystemsSection>
+</section>

--- a/StarWin.Web/Components/Pages/Systems.razor
+++ b/StarWin.Web/Components/Pages/Systems.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/systems"
 @rendermode InteractiveServer
 
@@ -25,7 +25,7 @@
 }
 
 <PageTitle>Systems | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="content-grid">
     <div class="record-list">
@@ -211,3 +211,4 @@
         </article>
     }
 </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Systems.razor
+++ b/StarWin.Web/Components/Pages/Systems.razor
@@ -210,5 +210,13 @@
             </div>
         </article>
     }
+    else
+    {
+        <article class="detail-panel">
+            <span class="panel-kicker">System record</span>
+            <h2>Select a system to load its details.</h2>
+            <p>Choose a star system from the list to inspect astral bodies, satellite records, images, and system notes.</p>
+        </article>
+    }
 </section>
 </SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Systems.razor.cs
+++ b/StarWin.Web/Components/Pages/Systems.razor.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.JSInterop;
 using StarWin.Application.Services;
-using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.Media;
 using StarWin.Domain.Model.Entity.Notes;
 using StarWin.Domain.Model.Entity.StarMap;
@@ -10,14 +9,13 @@ using StarWin.Web.Components.Explorer;
 
 namespace StarWin.Web.Components.Pages;
 
-public partial class Systems : ComponentBase
+public partial class Systems : ComponentBase, IAsyncDisposable
 {
-    private const ExplorerSectorLoadSections DetailedSectorSections = ExplorerSectorLoadSections.AstralBodies
-        | ExplorerSectorLoadSections.Worlds
-        | ExplorerSectorLoadSections.SpaceHabitats;
+    private const int ExplorerListBatchSize = 120;
+    private const int ComboAllFilterId = -1;
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
+    [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
     [Inject] protected IStarWinEntityNameService EntityNameService { get; set; } = default!;
     [Inject] protected IStarWinSpaceHabitatService SpaceHabitatService { get; set; } = default!;
@@ -31,43 +29,52 @@ public partial class Systems : ComponentBase
     public int? RequestedSystemId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
+    protected ExplorerSystemFilterOptions systemFilterOptions = new([]);
+    protected ExplorerSystemDetail? selectedSystemDetail;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
     protected string selectedSystemText = string.Empty;
     protected string searchQuery = string.Empty;
     protected IReadOnlyList<StarWinSearchResult> searchResults = [];
-    protected string imageUploadStatus = string.Empty;
-    protected string spaceHabitatName = string.Empty;
+    protected string systemQuery = string.Empty;
+    protected string systemEmpireText = string.Empty;
     protected int spaceHabitatEmpireId;
+    protected string spaceHabitatName = string.Empty;
     protected string spaceHabitatStatus = string.Empty;
-
-    private IReadOnlyList<EntityImage> entityImages = [];
-    private bool entityImagesLoaded;
-    private bool entityImagesLoading;
-    private bool browserSessionReady;
-    private bool browserSessionRestored;
-
-    protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<Empire> ExplorerEmpires => explorerContext.Empires;
+    protected string imageUploadStatus = string.Empty;
+    protected bool systemHasMoreRecords;
+    protected bool showSystemFilters;
     protected bool IsSpaceHabitatCreateDisabled => spaceHabitatEmpireId == 0;
 
-    private IReadOnlyDictionary<int, Empire> EmpiresById =>
-        ExplorerEmpires.ToDictionary(empire => empire.Id);
+    private readonly List<ExplorerSystemListItem> loadedSystemSummaries = [];
+    private IReadOnlyList<EntityImage> entityImages = [];
+    private bool entityImagesLoading;
+    private bool systemListLoading;
+    private bool systemDetailLoading;
+    private bool systemObserverConfigured;
+    private bool browserSessionReady;
+    private bool browserSessionRestored;
+    private int systemEmpireId = ComboAllFilterId;
+    private int loadedSystemSectorId;
+    private string lastLoadedImageKey = string.Empty;
+    private ElementReference systemLoadMoreElement;
+    private DotNetObjectReference<Systems>? dotNetReference;
+    private IJSObjectReference? loadMoreScrollModule;
+
+    protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
+    protected IReadOnlyList<ExplorerSystemListItem> LoadedSystemSummaries => loadedSystemSummaries;
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync(RequestedSectorId);
-        var initialSector = RequestedSectorId is int requestedSectorId
-            ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
-            : explorerContext.CurrentSector;
-
+        await RefreshExplorerShellAsync(RequestedSectorId);
+        var initialSector = GetInitialSector();
         selectedSectorId = initialSector.Id;
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
+        await LoadSystemPageAsync(resetList: true);
     }
 
     protected override async Task OnParametersSetAsync()
@@ -81,12 +88,14 @@ public partial class Systems : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await RefreshExplorerDataAsync(selectedSectorId);
+            selectedSystemId = 0;
+            await LoadSystemPageAsync(resetList: true);
         }
 
         var sector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await EnsureSelectedSystemDetailAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -99,10 +108,8 @@ public partial class Systems : ComponentBase
             return;
         }
 
-        _ = EnsureEntityImagesLoadedAsync(backgroundLoad: true);
+        await ConfigureSystemObserverAsync();
     }
-
-    protected ExplorerSectorCache GetSectorCache(StarWinSector sector) => sectorCacheBuilder.Get(sector);
 
     protected StarWinSector GetSelectedSector()
     {
@@ -132,11 +139,11 @@ public partial class Systems : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await RefreshExplorerDataAsync(selectedSectorId);
-        var sector = GetSelectedSector();
-        selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
-        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        selectedSystemId = 0;
+        selectedSystemText = string.Empty;
+        ClearSystemFilters();
         await PersistExplorerSessionAsync();
+        await LoadSystemPageAsync(resetList: true);
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Systems", selectedSectorId, selectedSystemId));
     }
 
@@ -149,7 +156,7 @@ public partial class Systems : ComponentBase
         {
             selectedSystemId = systemId;
             selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-            NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Systems", selectedSectorId, selectedSystemId), replace: true);
+            NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Systems", selectedSectorId, systemId), replace: true);
         }
 
         return PersistExplorerSessionAsync();
@@ -158,8 +165,7 @@ public partial class Systems : ComponentBase
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -169,7 +175,7 @@ public partial class Systems : ComponentBase
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -196,8 +202,39 @@ public partial class Systems : ComponentBase
     protected async Task SaveEntityNameAsync(EntityNoteTargetKind targetKind, int targetId, string name)
     {
         await EntityNameService.SaveNameAsync(targetKind, targetId, name);
-        await RefreshExplorerDataAsync(selectedSectorId);
-        selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
+        await RefreshExplorerShellAsync(selectedSectorId);
+        await LoadSystemPageAsync(resetList: true);
+    }
+
+    protected Task HandleSystemFiltersChangedAsync()
+    {
+        ResetSystemWindow();
+        return LoadSystemPageAsync(resetList: true);
+    }
+
+    protected Task ApplySystemEmpireFilterAsync()
+    {
+        systemEmpireId = ParseComboId(systemEmpireText);
+        ResetSystemWindow();
+        return LoadSystemPageAsync(resetList: true);
+    }
+
+    protected void ToggleSystemFilters()
+    {
+        showSystemFilters = !showSystemFilters;
+    }
+
+    protected Task HandleClearSystemFiltersAsync()
+    {
+        ClearSystemFilters();
+        return LoadSystemPageAsync(resetList: true);
+    }
+
+    [JSInvokable]
+    public Task LoadMoreSystems()
+    {
+        systemObserverConfigured = false;
+        return LoadMoreSystemsAsync();
     }
 
     protected IReadOnlyList<EntityImage> GetEntityImages(EntityImageTargetKind targetKind, int targetId)
@@ -219,23 +256,6 @@ public partial class Systems : ComponentBase
         return $"stellar-orb {body.Kind.ToString().ToLowerInvariant()}";
     }
 
-    protected static string Format(double? value)
-    {
-        return value?.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture) ?? "Unknown";
-    }
-
-    protected static string DisplayPopulation(long population)
-    {
-        return population >= 1_000_000_000
-            ? $"{population / 1_000_000_000m:0.#} billion"
-            : $"{population / 1_000_000m:0.#} million";
-    }
-
-    protected static string DisplayNullable<T>(T? value, string suffix = "") where T : struct
-    {
-        return value is null ? "Unknown" : $"{value}{suffix}";
-    }
-
     protected string DisplayAllegiance(ushort allegianceId)
     {
         if (allegianceId == ushort.MaxValue)
@@ -243,14 +263,17 @@ public partial class Systems : ComponentBase
             return "Independent";
         }
 
-        return EmpiresById.TryGetValue(allegianceId, out var empire) ? empire.Name : allegianceId.ToString();
+        return systemFilterOptions.Empires.FirstOrDefault(empire => empire.Id == allegianceId)?.Name ?? allegianceId.ToString();
     }
 
-    private string DisplayEmpire(int? empireId)
+    protected static string DisplayCoordinates(Coordinates coordinates)
     {
-        return empireId is null
-            ? "Unassigned"
-            : EmpiresById.TryGetValue(empireId.Value, out var empire) ? empire.Name : empireId.Value.ToString();
+        return $"{coordinates.XParsecs:0.#}, {coordinates.YParsecs:0.#}, {coordinates.ZParsecs:0.#}";
+    }
+
+    protected static string Format(double? value)
+    {
+        return value?.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture) ?? "Unknown";
     }
 
     private async Task CreateAstralBodySpaceHabitatAsync(StarSystem system, int astralBodySequence)
@@ -268,8 +291,10 @@ public partial class Systems : ComponentBase
                 astralBodySequence,
                 spaceHabitatEmpireId,
                 spaceHabitatName);
-            AddSpaceHabitatToWorkspace(system.Id, habitat);
-            CompleteSpaceHabitatCreate(system.Id, habitat.Name);
+
+            await LoadSystemDetailAsync(system.Id);
+            spaceHabitatName = string.Empty;
+            spaceHabitatStatus = $"{habitat.Name} created.";
             NavigateToHabitat(habitat.Id);
         }
         catch (InvalidOperationException ex)
@@ -278,32 +303,180 @@ public partial class Systems : ComponentBase
         }
     }
 
-    private void AddSpaceHabitatToWorkspace(int systemId, SpaceHabitat habitat)
+    private async Task RefreshExplorerShellAsync(int? preferredSectorId = null, CancellationToken cancellationToken = default)
     {
-        var sector = GetSelectedSector();
-        var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
-        if (system is null || system.SpaceHabitats.Any(item => item.Id == habitat.Id))
+        explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: preferredSectorId,
+            includeReferenceData: false,
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task LoadSystemPageAsync(bool resetList, CancellationToken cancellationToken = default)
+    {
+        if (selectedSectorId <= 0)
+        {
+            loadedSystemSummaries.Clear();
+            systemHasMoreRecords = false;
+            selectedSystemDetail = null;
+            selectedSystemId = 0;
+            entityImages = [];
+            systemFilterOptions = new([]);
+            return;
+        }
+
+        if (resetList || loadedSystemSectorId != selectedSectorId)
+        {
+            loadedSystemSummaries.Clear();
+            loadedSystemSectorId = selectedSectorId;
+            systemHasMoreRecords = false;
+            systemObserverConfigured = false;
+            systemFilterOptions = await ExplorerQueryService.LoadSystemFilterOptionsAsync(selectedSectorId, cancellationToken);
+            await LoadMoreSystemsAsync(cancellationToken);
+        }
+
+        await EnsureSelectedSystemSummaryVisibleAsync(cancellationToken);
+        await EnsureSelectedSystemDetailAsync(cancellationToken);
+    }
+
+    private async Task LoadMoreSystemsAsync(CancellationToken cancellationToken = default)
+    {
+        if (systemListLoading || selectedSectorId <= 0)
         {
             return;
         }
 
-        system.SpaceHabitats.Add(habitat);
-        sectorCacheBuilder.Invalidate(sector.Id);
+        systemListLoading = true;
+        try
+        {
+            var page = await ExplorerQueryService.LoadSystemListPageAsync(
+                new ExplorerSystemListPageRequest(
+                    selectedSectorId,
+                    loadedSystemSummaries.Count,
+                    ExplorerListBatchSize,
+                    string.IsNullOrWhiteSpace(systemQuery) ? null : systemQuery.Trim(),
+                    systemEmpireId == ComboAllFilterId ? null : systemEmpireId),
+                cancellationToken);
+
+            foreach (var item in page.Items)
+            {
+                if (loadedSystemSummaries.All(existing => existing.SystemId != item.SystemId))
+                {
+                    loadedSystemSummaries.Add(item);
+                }
+            }
+
+            systemHasMoreRecords = page.HasMore;
+            if (selectedSystemId == 0 && loadedSystemSummaries.Count > 0)
+            {
+                selectedSystemId = loadedSystemSummaries[0].SystemId;
+            }
+            else if (selectedSystemId > 0 && loadedSystemSummaries.All(item => item.SystemId != selectedSystemId))
+            {
+                selectedSystemId = loadedSystemSummaries.FirstOrDefault()?.SystemId ?? 0;
+            }
+
+            await EnsureSelectedSystemSummaryVisibleAsync(cancellationToken);
+            await EnsureSelectedSystemDetailAsync(cancellationToken);
+            await InvokeAsync(StateHasChanged);
+        }
+        finally
+        {
+            systemListLoading = false;
+        }
     }
 
-    private void CompleteSpaceHabitatCreate(int systemId, string habitatName)
+    private async Task EnsureSelectedSystemSummaryVisibleAsync(CancellationToken cancellationToken = default)
     {
-        selectedSystemId = systemId;
-        var sector = GetSelectedSector();
-        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        spaceHabitatName = string.Empty;
-        spaceHabitatStatus = $"{habitatName} created.";
-        _ = PersistExplorerSessionAsync();
+        if (HasActiveSystemFilters())
+        {
+            return;
+        }
+
+        var targetSystemId = RequestedSystemId ?? selectedSystemId;
+        if (targetSystemId <= 0 || loadedSystemSummaries.Any(item => item.SystemId == targetSystemId))
+        {
+            return;
+        }
+
+        var requestedItem = await ExplorerQueryService.LoadSystemListItemAsync(selectedSectorId, targetSystemId, cancellationToken);
+        if (requestedItem is null)
+        {
+            return;
+        }
+
+        loadedSystemSummaries.Add(requestedItem);
+        loadedSystemSummaries.Sort((left, right) =>
+        {
+            var nameComparison = string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase);
+            return nameComparison != 0 ? nameComparison : left.SystemId.CompareTo(right.SystemId);
+        });
     }
 
-    private async Task EnsureEntityImagesLoadedAsync(bool backgroundLoad = false)
+    private async Task EnsureSelectedSystemDetailAsync(CancellationToken cancellationToken = default)
     {
-        if (entityImagesLoaded || entityImagesLoading)
+        var targetSystemId = HasActiveSystemFilters()
+            ? selectedSystemId
+            : RequestedSystemId ?? selectedSystemId;
+        if (targetSystemId <= 0)
+        {
+            targetSystemId = loadedSystemSummaries.FirstOrDefault()?.SystemId ?? 0;
+        }
+
+        if (targetSystemId <= 0 || systemDetailLoading)
+        {
+            if (targetSystemId <= 0)
+            {
+                selectedSystemId = 0;
+                selectedSystemDetail = null;
+            }
+
+            return;
+        }
+
+        systemDetailLoading = true;
+        try
+        {
+            var detail = await ExplorerQueryService.LoadSystemDetailAsync(selectedSectorId, targetSystemId, cancellationToken);
+            if (detail is null && loadedSystemSummaries.Count > 0)
+            {
+                targetSystemId = loadedSystemSummaries[0].SystemId;
+                detail = await ExplorerQueryService.LoadSystemDetailAsync(selectedSectorId, targetSystemId, cancellationToken);
+            }
+
+            selectedSystemDetail = detail;
+            selectedSystemId = detail?.System.Id ?? 0;
+            selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
+            await EnsureEntityImagesLoadedAsync(cancellationToken);
+        }
+        finally
+        {
+            systemDetailLoading = false;
+        }
+    }
+
+    private async Task LoadSystemDetailAsync(int systemId, CancellationToken cancellationToken = default)
+    {
+        if (systemId <= 0)
+        {
+            selectedSystemDetail = null;
+            entityImages = [];
+            return;
+        }
+
+        selectedSystemDetail = await ExplorerQueryService.LoadSystemDetailAsync(selectedSectorId, systemId, cancellationToken);
+        await EnsureEntityImagesLoadedAsync(cancellationToken);
+    }
+
+    private async Task EnsureEntityImagesLoadedAsync(CancellationToken cancellationToken = default)
+    {
+        var targets = selectedSystemDetail?.System.AstralBodies
+            .Select(body => new EntityImageTarget(EntityImageTargetKind.AstralBody, body.Id))
+            .Distinct()
+            .ToList()
+            ?? [];
+
+        var imageKey = string.Join('|', targets.Select(target => $"{(int)target.TargetKind}:{target.TargetId}"));
+        if (entityImagesLoading || imageKey == lastLoadedImageKey)
         {
             return;
         }
@@ -311,17 +484,10 @@ public partial class Systems : ComponentBase
         entityImagesLoading = true;
         try
         {
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
+            entityImages = await ImageService.GetImagesAsync(targets, cancellationToken);
+            lastLoadedImageKey = imageKey;
             explorerRenderError = string.Empty;
-            if (backgroundLoad)
-            {
-                await InvokeAsync(StateHasChanged);
-            }
-            else
-            {
-                StateHasChanged();
-            }
+            await InvokeAsync(StateHasChanged);
         }
         finally
         {
@@ -329,26 +495,26 @@ public partial class Systems : ComponentBase
         }
     }
 
-    private async Task RefreshExplorerDataAsync(int? detailedSectorId = null, CancellationToken cancellationToken = default)
+    private async Task RunSearchAsync()
     {
-        explorerContext = await ExplorerContextService.LoadShellAsync(
-            includeSavedRoutes: false,
-            includeReferenceData: true,
-            detailedSectorId: detailedSectorId,
-            detailedSectorSections: DetailedSectorSections,
-            cancellationToken: cancellationToken);
-
-        foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
-        {
-            sectorCacheBuilder.Invalidate(sectorId);
-        }
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
-    private void RunSearch()
+    private async Task UploadEntityImage(EntityImageTargetKind targetKind, int targetId, InputFileChangeEventArgs args)
     {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
+        var file = args.File;
+        try
+        {
+            await using var stream = file.OpenReadStream(10 * 1024 * 1024);
+            await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
+            lastLoadedImageKey = string.Empty;
+            await EnsureEntityImagesLoadedAsync();
+            imageUploadStatus = $"{file.Name} uploaded.";
+        }
+        catch (Exception exception)
+        {
+            imageUploadStatus = exception.Message;
+        }
     }
 
     private async Task RestoreExplorerSessionAsync()
@@ -372,12 +538,11 @@ public partial class Systems : ComponentBase
         }
 
         selectedSectorId = sector.Id;
-        await RefreshExplorerDataAsync(selectedSectorId);
-        sector = GetSelectedSector();
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await LoadSystemPageAsync(resetList: true);
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Systems", selectedSectorId, selectedSystemId), replace: true);
     }
 
@@ -389,21 +554,78 @@ public partial class Systems : ComponentBase
             new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Systems")));
     }
 
-    private async Task UploadEntityImage(EntityImageTargetKind targetKind, int targetId, InputFileChangeEventArgs args)
+    private async Task ConfigureSystemObserverAsync()
     {
-        var file = args.File;
-        try
+        if (!systemHasMoreRecords)
         {
-            await using var stream = file.OpenReadStream(10 * 1024 * 1024);
-            await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
-            imageUploadStatus = $"{file.Name} uploaded.";
+            systemObserverConfigured = false;
+            if (loadMoreScrollModule is not null)
+            {
+                await loadMoreScrollModule.InvokeVoidAsync("disconnectLoadMore", "system");
+            }
+
+            return;
         }
-        catch (Exception exception)
+
+        if (systemObserverConfigured)
         {
-            imageUploadStatus = exception.Message;
+            return;
         }
+
+        loadMoreScrollModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/timelineInfiniteScroll.js");
+        dotNetReference ??= DotNetObjectReference.Create(this);
+        await loadMoreScrollModule.InvokeVoidAsync("observeLoadMore", "system", systemLoadMoreElement, dotNetReference, "LoadMoreSystems");
+        systemObserverConfigured = true;
+    }
+
+    private void ClearSystemFilters()
+    {
+        systemQuery = string.Empty;
+        systemEmpireText = string.Empty;
+        systemEmpireId = ComboAllFilterId;
+        showSystemFilters = false;
+        ResetSystemWindow();
+    }
+
+    private void ResetSystemWindow()
+    {
+        systemObserverConfigured = false;
+    }
+
+    private bool HasActiveSystemFilters()
+    {
+        return !string.IsNullOrWhiteSpace(systemQuery)
+            || systemEmpireId != ComboAllFilterId;
+    }
+
+    private static string FormatEmpireOption(ExplorerLookupOption empire)
+    {
+        return $"{empire.Id} - {empire.Name}";
+    }
+
+    private StarWinSector GetInitialSector()
+    {
+        return RequestedSectorId is int requestedSectorId
+            ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
+            : explorerContext.CurrentSector;
+    }
+
+    private static string FormatSelectedSystem(StarWinSector sector, int systemId)
+    {
+        var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
+        return system is null ? string.Empty : $"{system.Id} - {system.Name}";
+    }
+
+    private static int ParseComboId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ComboAllFilterId;
+        }
+
+        var separatorIndex = value.IndexOf(" - ", StringComparison.Ordinal);
+        var idText = separatorIndex < 0 ? value : value[..separatorIndex];
+        return int.TryParse(idText, out var id) ? id : ComboAllFilterId;
     }
 
     private static IEnumerable<OrbitalSatellite> GetAstralBodySatellites(StarSystem system, int astralBodySequence)
@@ -425,27 +647,21 @@ public partial class Systems : ComponentBase
         }
     }
 
-    private static bool ContainsQuery(string? value, string query)
+    public async ValueTask DisposeAsync()
     {
-        return value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true;
-    }
-
-    private static string FormatSelectedSystem(StarWinSector sector, int systemId)
-    {
-        var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
-        return system is null ? string.Empty : $"{system.Id} - {system.Name}";
-    }
-
-    private static int ParseComboId(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
+        if (loadMoreScrollModule is not null)
         {
-            return 0;
+            try
+            {
+                await loadMoreScrollModule.InvokeVoidAsync("disconnectLoadMore", "system");
+                await loadMoreScrollModule.DisposeAsync();
+            }
+            catch (JSDisconnectedException)
+            {
+            }
         }
 
-        var separatorIndex = value.IndexOf(" - ", StringComparison.Ordinal);
-        var idText = separatorIndex < 0 ? value : value[..separatorIndex];
-        return int.TryParse(idText, out var id) ? id : 0;
+        dotNetReference?.Dispose();
     }
 
     private sealed record OrbitalSatellite(string Name, string Kind, World? World, SpaceHabitat? Habitat)
@@ -460,5 +676,4 @@ public partial class Systems : ComponentBase
             return new OrbitalSatellite(habitat.Name, "Habitat", null, habitat);
         }
     }
-
 }

--- a/StarWin.Web/Components/Pages/Systems.razor.cs
+++ b/StarWin.Web/Components/Pages/Systems.razor.cs
@@ -307,7 +307,6 @@ public partial class Systems : ComponentBase, IAsyncDisposable
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: preferredSectorId,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 

--- a/StarWin.Web/Components/Pages/Systems.razor.cs
+++ b/StarWin.Web/Components/Pages/Systems.razor.cs
@@ -12,6 +12,9 @@ namespace StarWin.Web.Components.Pages;
 
 public partial class Systems : ComponentBase
 {
+    private const ExplorerSectorLoadSections DetailedSectorSections = ExplorerSectorLoadSections.AstralBodies
+        | ExplorerSectorLoadSections.Worlds
+        | ExplorerSectorLoadSections.SpaceHabitats;
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
@@ -29,7 +32,6 @@ public partial class Systems : ComponentBase
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
-    private readonly Dictionary<int, ExplorerSectorLoadSections> loadedSectorSectionsById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
@@ -58,14 +60,12 @@ public partial class Systems : ComponentBase
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync();
+        await RefreshExplorerDataAsync(RequestedSectorId);
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        initialSector = GetSelectedSector();
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
     }
@@ -81,7 +81,7 @@ public partial class Systems : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorDataLoadedAsync(selectedSectorId);
+            await RefreshExplorerDataAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
@@ -132,7 +132,7 @@ public partial class Systems : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -196,8 +196,7 @@ public partial class Systems : ComponentBase
     protected async Task SaveEntityNameAsync(EntityNoteTargetKind targetKind, int targetId, string name)
     {
         await EntityNameService.SaveNameAsync(targetKind, targetId, name);
-        await RefreshExplorerDataAsync();
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
     }
 
@@ -330,58 +329,19 @@ public partial class Systems : ComponentBase
         }
     }
 
-    private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
+    private async Task RefreshExplorerDataAsync(int? detailedSectorId = null, CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             includeSavedRoutes: false,
             includeReferenceData: true,
+            detailedSectorId: detailedSectorId,
+            detailedSectorSections: DetailedSectorSections,
             cancellationToken: cancellationToken);
 
-        loadedSectorSectionsById.Clear();
         foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
         {
             sectorCacheBuilder.Invalidate(sectorId);
         }
-    }
-
-    private async Task EnsureSectorDataLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
-    {
-        if (sectorId <= 0)
-        {
-            return;
-        }
-
-        const ExplorerSectorLoadSections requiredSections = ExplorerSectorLoadSections.AstralBodies
-            | ExplorerSectorLoadSections.Worlds
-            | ExplorerSectorLoadSections.SpaceHabitats;
-
-        loadedSectorSectionsById.TryGetValue(sectorId, out var loadedSections);
-        if ((loadedSections & requiredSections) == requiredSections)
-        {
-            return;
-        }
-
-        var detailedSector = await ExplorerContextService.LoadSectorAsync(sectorId, requiredSections, cancellationToken);
-        if (detailedSector is null)
-        {
-            return;
-        }
-
-        var sectors = ExplorerSectors.ToList();
-        var sectorIndex = sectors.FindIndex(item => item.Id == detailedSector.Id);
-        if (sectorIndex >= 0)
-        {
-            sectors[sectorIndex] = detailedSector;
-        }
-
-        explorerContext = explorerContext with
-        {
-            Sectors = sectors,
-            CurrentSector = explorerContext.CurrentSector.Id == detailedSector.Id ? detailedSector : explorerContext.CurrentSector
-        };
-
-        loadedSectorSectionsById[sectorId] = loadedSections | requiredSections;
-        sectorCacheBuilder.Invalidate(sectorId);
     }
 
     private void RunSearch()
@@ -412,7 +372,7 @@ public partial class Systems : ComponentBase
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         sector = GetSelectedSector();
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId

--- a/StarWin.Web/Components/Pages/Systems.razor.cs
+++ b/StarWin.Web/Components/Pages/Systems.razor.cs
@@ -59,6 +59,7 @@ public partial class Systems : ComponentBase, IAsyncDisposable
     private bool browserSessionRestored;
     private int systemEmpireId = ComboAllFilterId;
     private int loadedSystemSectorId;
+    private int loadedSystemDetailId;
     private string lastLoadedImageKey = string.Empty;
     private ElementReference systemLoadMoreElement;
     private DotNetObjectReference<Systems>? dotNetReference;
@@ -72,7 +73,7 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         await RefreshExplorerShellAsync(RequestedSectorId);
         var initialSector = GetInitialSector();
         selectedSectorId = initialSector.Id;
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
+        selectedSystemId = ResolveExplicitSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         await LoadSystemPageAsync(resetList: true);
     }
@@ -88,13 +89,14 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            selectedSystemId = 0;
+            ClearSelectedSystem();
             await LoadSystemPageAsync(resetList: true);
         }
 
         var sector = GetSelectedSector();
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+        selectedSystemId = ResolveExplicitSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await EnsureSelectedSystemSummaryVisibleAsync();
         await EnsureSelectedSystemDetailAsync();
     }
 
@@ -139,8 +141,7 @@ public partial class Systems : ComponentBase, IAsyncDisposable
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        selectedSystemId = 0;
-        selectedSystemText = string.Empty;
+        ClearSelectedSystem();
         ClearSystemFilters();
         await PersistExplorerSessionAsync();
         await LoadSystemPageAsync(resetList: true);
@@ -316,9 +317,7 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         {
             loadedSystemSummaries.Clear();
             systemHasMoreRecords = false;
-            selectedSystemDetail = null;
-            selectedSystemId = 0;
-            entityImages = [];
+            ClearSelectedSystem();
             systemFilterOptions = new([]);
             return;
         }
@@ -365,17 +364,13 @@ public partial class Systems : ComponentBase, IAsyncDisposable
             }
 
             systemHasMoreRecords = page.HasMore;
-            if (selectedSystemId == 0 && loadedSystemSummaries.Count > 0)
+            if (HasActiveSystemFilters()
+                && selectedSystemId > 0
+                && loadedSystemSummaries.All(item => item.SystemId != selectedSystemId))
             {
-                selectedSystemId = loadedSystemSummaries[0].SystemId;
-            }
-            else if (selectedSystemId > 0 && loadedSystemSummaries.All(item => item.SystemId != selectedSystemId))
-            {
-                selectedSystemId = loadedSystemSummaries.FirstOrDefault()?.SystemId ?? 0;
+                ClearSelectedSystem();
             }
 
-            await EnsureSelectedSystemSummaryVisibleAsync(cancellationToken);
-            await EnsureSelectedSystemDetailAsync(cancellationToken);
             await InvokeAsync(StateHasChanged);
         }
         finally
@@ -416,19 +411,18 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         var targetSystemId = HasActiveSystemFilters()
             ? selectedSystemId
             : RequestedSystemId ?? selectedSystemId;
-        if (targetSystemId <= 0)
-        {
-            targetSystemId = loadedSystemSummaries.FirstOrDefault()?.SystemId ?? 0;
-        }
-
         if (targetSystemId <= 0 || systemDetailLoading)
         {
             if (targetSystemId <= 0)
             {
-                selectedSystemId = 0;
-                selectedSystemDetail = null;
+                ClearSelectedSystem();
             }
 
+            return;
+        }
+
+        if (selectedSystemDetail?.System.Id == targetSystemId && loadedSystemDetailId == targetSystemId)
+        {
             return;
         }
 
@@ -436,14 +430,15 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         try
         {
             var detail = await ExplorerQueryService.LoadSystemDetailAsync(selectedSectorId, targetSystemId, cancellationToken);
-            if (detail is null && loadedSystemSummaries.Count > 0)
+            if (detail is null)
             {
-                targetSystemId = loadedSystemSummaries[0].SystemId;
-                detail = await ExplorerQueryService.LoadSystemDetailAsync(selectedSectorId, targetSystemId, cancellationToken);
+                ClearSelectedSystem();
+                return;
             }
 
             selectedSystemDetail = detail;
-            selectedSystemId = detail?.System.Id ?? 0;
+            selectedSystemId = detail.System.Id;
+            loadedSystemDetailId = detail.System.Id;
             selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
             await EnsureEntityImagesLoadedAsync(cancellationToken);
         }
@@ -457,12 +452,14 @@ public partial class Systems : ComponentBase, IAsyncDisposable
     {
         if (systemId <= 0)
         {
-            selectedSystemDetail = null;
-            entityImages = [];
+            ClearSelectedSystem();
             return;
         }
 
         selectedSystemDetail = await ExplorerQueryService.LoadSystemDetailAsync(selectedSectorId, systemId, cancellationToken);
+        selectedSystemId = selectedSystemDetail?.System.Id ?? 0;
+        loadedSystemDetailId = selectedSystemDetail?.System.Id ?? 0;
+        selectedSystemText = FormatSelectedSystem(GetSelectedSector(), selectedSystemId);
         await EnsureEntityImagesLoadedAsync(cancellationToken);
     }
 
@@ -539,7 +536,7 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         selectedSectorId = sector.Id;
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId
-            : sector.Systems.FirstOrDefault()?.Id ?? 0;
+            : 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         await LoadSystemPageAsync(resetList: true);
         NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Systems", selectedSectorId, selectedSystemId), replace: true);
@@ -609,6 +606,21 @@ public partial class Systems : ComponentBase, IAsyncDisposable
             : explorerContext.CurrentSector;
     }
 
+    private static int ResolveExplicitSelectedSystemId(StarWinSector sector, int? requestedSystemId, int currentSelectedSystemId)
+    {
+        if (requestedSystemId is int requestedId && sector.Systems.Any(system => system.Id == requestedId))
+        {
+            return requestedId;
+        }
+
+        if (currentSelectedSystemId > 0 && sector.Systems.Any(system => system.Id == currentSelectedSystemId))
+        {
+            return currentSelectedSystemId;
+        }
+
+        return 0;
+    }
+
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)
     {
         var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
@@ -625,6 +637,16 @@ public partial class Systems : ComponentBase, IAsyncDisposable
         var separatorIndex = value.IndexOf(" - ", StringComparison.Ordinal);
         var idText = separatorIndex < 0 ? value : value[..separatorIndex];
         return int.TryParse(idText, out var id) ? id : ComboAllFilterId;
+    }
+
+    private void ClearSelectedSystem()
+    {
+        selectedSystemId = 0;
+        selectedSystemText = string.Empty;
+        selectedSystemDetail = null;
+        loadedSystemDetailId = 0;
+        entityImages = [];
+        lastLoadedImageKey = string.Empty;
     }
 
     private static IEnumerable<OrbitalSatellite> GetAstralBodySatellites(StarSystem system, int astralBodySequence)

--- a/StarWin.Web/Components/Pages/Timeline.razor
+++ b/StarWin.Web/Components/Pages/Timeline.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/timeline"
 @rendermode InteractiveServer
 
@@ -24,7 +24,7 @@
 }
 
 <PageTitle>Timeline | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <ExplorerTimelineSection SectorId="@sector.Id"
                          SectorName="@sector.Name"
@@ -42,3 +42,4 @@
               Detail="The page will stay visible until the first chronology batch is ready."
               StartedAtUnixMs="@timelinePageLoadingStartedAtUnixMs"
               Steps="@timelineLoadingSteps" />
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Timeline.razor.cs
+++ b/StarWin.Web/Components/Pages/Timeline.razor.cs
@@ -19,6 +19,7 @@ public partial class Timeline : ComponentBase
     ];
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
+    [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
     [Inject] protected IJSRuntime JS { get; set; } = default!;
@@ -30,7 +31,7 @@ public partial class Timeline : ComponentBase
     public int? RequestedSystemId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    private readonly Dictionary<int, ExplorerSectorLoadSections> loadedSectorSectionsById = [];
+    private readonly Dictionary<int, ExplorerSectorEntityUsage> sectorEntityUsageById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
@@ -58,8 +59,7 @@ public partial class Timeline : ComponentBase
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        initialSector = GetSelectedSector();
+        await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         timelinePageLoadingVisible = true;
@@ -78,7 +78,7 @@ public partial class Timeline : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorDataLoadedAsync(selectedSectorId);
+            await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
@@ -127,7 +127,7 @@ public partial class Timeline : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -153,8 +153,7 @@ public partial class Timeline : ComponentBase
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -184,26 +183,32 @@ public partial class Timeline : ComponentBase
         return Task.CompletedTask;
     }
 
-    protected Task NavigateToColony(int colonyId)
+    protected Task NavigateToColony(ExplorerTimelineLinkTarget target)
     {
-        var sector = GetSelectedSector();
-        var listing = sector.Systems
-            .SelectMany(system => system.Worlds.Select(world => new { system, world }))
-            .FirstOrDefault(item => item.world.Colony?.Id == colonyId);
-        if (listing is not null)
+        if (target.ColonyId > 0)
         {
-            NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Colonies", selectedSectorId, listing.system.Id, listing.world.Id, colonyId));
+            NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri(
+                "Colonies",
+                selectedSectorId,
+                target.SystemId > 0 ? target.SystemId : selectedSystemId,
+                target.WorldId,
+                target.ColonyId));
         }
 
         return Task.CompletedTask;
     }
 
-    protected Task NavigateToWorld(int worldId)
+    protected Task NavigateToWorld(ExplorerTimelineLinkTarget target)
     {
-        var sector = GetSelectedSector();
-        var system = sector.Systems.FirstOrDefault(item => item.Worlds.Any(world => world.Id == worldId));
-        var systemId = system?.Id ?? selectedSystemId;
-        NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri("Worlds", selectedSectorId, systemId, worldId: worldId));
+        if (target.WorldId > 0)
+        {
+            NavigationManager.NavigateTo(SectorExplorerRoutes.BuildSectionUri(
+                "Worlds",
+                selectedSectorId,
+                target.SystemId > 0 ? target.SystemId : selectedSystemId,
+                worldId: target.WorldId));
+        }
+
         return Task.CompletedTask;
     }
 
@@ -273,73 +278,31 @@ public partial class Timeline : ComponentBase
             includeReferenceData: true,
             cancellationToken: cancellationToken);
 
-        loadedSectorSectionsById.Clear();
+        sectorEntityUsageById.Clear();
     }
 
-    private async Task EnsureSectorDataLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
+    private async Task EnsureSectorEntityUsageLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         if (sectorId <= 0)
         {
             return;
         }
 
-        const ExplorerSectorLoadSections requiredSections = ExplorerSectorLoadSections.Worlds
-            | ExplorerSectorLoadSections.Colonies
-            | ExplorerSectorLoadSections.ColonyDemographics;
-
-        loadedSectorSectionsById.TryGetValue(sectorId, out var loadedSections);
-        if ((loadedSections & requiredSections) == requiredSections)
+        if (sectorEntityUsageById.ContainsKey(sectorId))
         {
             return;
         }
 
-        var detailedSector = await ExplorerContextService.LoadSectorAsync(sectorId, requiredSections, cancellationToken);
-        if (detailedSector is null)
-        {
-            return;
-        }
-
-        var sectors = ExplorerSectors.ToList();
-        var sectorIndex = sectors.FindIndex(item => item.Id == detailedSector.Id);
-        if (sectorIndex >= 0)
-        {
-            sectors[sectorIndex] = detailedSector;
-        }
-
-        explorerContext = explorerContext with
-        {
-            Sectors = sectors,
-            CurrentSector = explorerContext.CurrentSector.Id == detailedSector.Id ? detailedSector : explorerContext.CurrentSector
-        };
-
-        loadedSectorSectionsById[sectorId] = loadedSections | requiredSections;
+        sectorEntityUsageById[sectorId] = await ExplorerQueryService.LoadSectorEntityUsageAsync(sectorId, cancellationToken);
     }
 
-    private void RunSearch()
+    private async Task RunSearchAsync()
     {
         var sector = GetSelectedSector();
-        var sectorRaceIds = sector.Systems
-            .SelectMany(system => system.Worlds)
-            .Where(world => world.Colony is not null)
-            .SelectMany(world => world.Colony!.Demographics.Select(demographic => demographic.RaceId))
-            .Concat(sector.Systems.SelectMany(system => system.Worlds)
-                .Where(world => world.Colony is not null)
-                .Select(world => (int)world.Colony!.RaceId))
-            .ToHashSet();
-        var sectorEmpireIds = sector.Systems
-            .Where(system => system.AllegianceId != ushort.MaxValue)
-            .Select(system => (int)system.AllegianceId)
-            .Concat(sector.Systems.SelectMany(system => system.Worlds)
-                .Where(world => world.Colony is not null)
-                .SelectMany(world => new[]
-                {
-                    world.Colony!.AllegianceId == ushort.MaxValue ? 0 : world.Colony.AllegianceId,
-                    world.Colony.ControllingEmpireId is > 0 ? world.Colony.ControllingEmpireId.Value : 0,
-                    world.Colony.FoundingEmpireId is > 0 ? world.Colony.FoundingEmpireId.Value : 0,
-                    world.Colony.ParentEmpireId is > 0 ? world.Colony.ParentEmpireId.Value : 0
-                }))
-            .Where(id => id > 0)
-            .ToHashSet();
+        await EnsureSectorEntityUsageLoadedAsync(sector.Id);
+        var sectorEntityUsage = sectorEntityUsageById.GetValueOrDefault(sector.Id);
+        var sectorRaceIds = sectorEntityUsage?.RaceIds.ToHashSet() ?? [];
+        var sectorEmpireIds = sectorEntityUsage?.EmpireIds.ToHashSet() ?? [];
 
         searchResults = SearchService.Search(searchQuery)
             .Where(result => result.Type switch
@@ -372,8 +335,7 @@ public partial class Timeline : ComponentBase
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
-        sector = GetSelectedSector();
+        await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;

--- a/StarWin.Web/Components/Pages/Timeline.razor.cs
+++ b/StarWin.Web/Components/Pages/Timeline.razor.cs
@@ -20,7 +20,6 @@ public partial class Timeline : ComponentBase
 
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
     [Inject] protected IJSRuntime JS { get; set; } = default!;
 
@@ -163,7 +162,7 @@ public partial class Timeline : ComponentBase
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -274,6 +273,7 @@ public partial class Timeline : ComponentBase
     private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: RequestedSectorId ?? selectedSectorId,
             includeSavedRoutes: false,
             includeReferenceData: true,
             cancellationToken: cancellationToken);
@@ -298,20 +298,7 @@ public partial class Timeline : ComponentBase
 
     private async Task RunSearchAsync()
     {
-        var sector = GetSelectedSector();
-        await EnsureSectorEntityUsageLoadedAsync(sector.Id);
-        var sectorEntityUsage = sectorEntityUsageById.GetValueOrDefault(sector.Id);
-        var sectorRaceIds = sectorEntityUsage?.RaceIds.ToHashSet() ?? [];
-        var sectorEmpireIds = sectorEntityUsage?.EmpireIds.ToHashSet() ?? [];
-
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.Type switch
-            {
-                StarWinSearchResultType.AlienRace => result.RaceId is int raceId && sectorRaceIds.Contains(raceId),
-                StarWinSearchResultType.Empire => result.EmpireId is int empireId && sectorEmpireIds.Contains(empireId),
-                _ => result.SectorId is null || result.SectorId == sector.Id
-            })
-            .ToList();
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
     }
 
     private async Task RestoreExplorerSessionAsync()

--- a/StarWin.Web/Components/Pages/Timeline.razor.cs
+++ b/StarWin.Web/Components/Pages/Timeline.razor.cs
@@ -274,7 +274,6 @@ public partial class Timeline : ComponentBase
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
-            includeSavedRoutes: false,
             includeReferenceData: true,
             cancellationToken: cancellationToken);
 

--- a/StarWin.Web/Components/Pages/Timeline.razor.cs
+++ b/StarWin.Web/Components/Pages/Timeline.razor.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using StarWin.Application.Services;
-using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.StarMap;
 using StarWin.Web.Components.Explorer;
 
@@ -30,7 +29,6 @@ public partial class Timeline : ComponentBase
     public int? RequestedSystemId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    private readonly Dictionary<int, ExplorerSectorEntityUsage> sectorEntityUsageById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
@@ -47,8 +45,6 @@ public partial class Timeline : ComponentBase
     private long timelinePageLoadingStartedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<AlienRace> ExplorerAlienRaces => explorerContext.AlienRaces;
-    protected IReadOnlyList<Empire> ExplorerEmpires => explorerContext.Empires;
 
     protected override async Task OnInitializedAsync()
     {
@@ -58,7 +54,6 @@ public partial class Timeline : ComponentBase
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(initialSector, RequestedSystemId, selectedSystemId);
         selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
         timelinePageLoadingVisible = true;
@@ -77,7 +72,6 @@ public partial class Timeline : ComponentBase
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         }
 
         var sector = GetSelectedSector();
@@ -126,7 +120,6 @@ public partial class Timeline : ComponentBase
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -276,23 +269,6 @@ public partial class Timeline : ComponentBase
             preferredSectorId: RequestedSectorId ?? selectedSectorId,
             includeReferenceData: true,
             cancellationToken: cancellationToken);
-
-        sectorEntityUsageById.Clear();
-    }
-
-    private async Task EnsureSectorEntityUsageLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
-    {
-        if (sectorId <= 0)
-        {
-            return;
-        }
-
-        if (sectorEntityUsageById.ContainsKey(sectorId))
-        {
-            return;
-        }
-
-        sectorEntityUsageById[sectorId] = await ExplorerQueryService.LoadSectorEntityUsageAsync(sectorId, cancellationToken);
     }
 
     private async Task RunSearchAsync()
@@ -321,7 +297,6 @@ public partial class Timeline : ComponentBase
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorEntityUsageLoadedAsync(selectedSectorId);
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId
             : sector.Systems.FirstOrDefault()?.Id ?? 0;

--- a/StarWin.Web/Components/Pages/Worlds.razor
+++ b/StarWin.Web/Components/Pages/Worlds.razor
@@ -4,7 +4,7 @@
 
 @{
     var sector = GetSelectedSector();
-    var selectedSystem = sector.Systems.FirstOrDefault(system => system.Id == selectedSystemId) ?? sector.Systems.FirstOrDefault();
+    var selectedSystem = GetSelectedSystemRecord();
     var selectedHabitat = selectedSystem?.SpaceHabitats.FirstOrDefault(habitat => habitat.Id == selectedHabitatId);
     var selectedWorld = selectedHabitat is null
         ? selectedSystem?.Worlds.FirstOrDefault(world => world.Id == selectedWorldId) ?? selectedSystem?.Worlds.FirstOrDefault()

--- a/StarWin.Web/Components/Pages/Worlds.razor
+++ b/StarWin.Web/Components/Pages/Worlds.razor
@@ -1,4 +1,4 @@
-@layout SectorExplorerLayout
+@layout MainLayout
 @page "/sector-explorer/worlds"
 @rendermode InteractiveServer
 
@@ -29,7 +29,7 @@
 }
 
 <PageTitle>Worlds | Starforged Atlas</PageTitle>
-<SectorExplorerLayoutSync State="layoutState" />
+<SectorExplorerFrame State="layoutState">
 
 <section class="content-grid">
             <div class="record-list">
@@ -331,3 +331,4 @@
                 </article>
             }
         </section>
+</SectorExplorerFrame>

--- a/StarWin.Web/Components/Pages/Worlds.razor
+++ b/StarWin.Web/Components/Pages/Worlds.razor
@@ -7,7 +7,7 @@
     var selectedSystem = GetSelectedSystemRecord();
     var selectedHabitat = selectedSystem?.SpaceHabitats.FirstOrDefault(habitat => habitat.Id == selectedHabitatId);
     var selectedWorld = selectedHabitat is null
-        ? selectedSystem?.Worlds.FirstOrDefault(world => world.Id == selectedWorldId) ?? selectedSystem?.Worlds.FirstOrDefault()
+        ? selectedSystem?.Worlds.FirstOrDefault(world => world.Id == selectedWorldId)
         : null;
     var layoutState = new SectorExplorerLayoutState(
         null,
@@ -328,6 +328,14 @@
                             }
                         </div>
                     </div>
+                </article>
+            }
+            else
+            {
+                <article class="detail-panel world-detail">
+                    <span class="panel-kicker">World record</span>
+                    <h2>Select a world or habitat to load its details.</h2>
+                    <p>Choose a world or orbital habitat from the list to inspect survey data, images, and linked colony records.</p>
                 </article>
             }
         </section>

--- a/StarWin.Web/Components/Pages/Worlds.razor.cs
+++ b/StarWin.Web/Components/Pages/Worlds.razor.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.JSInterop;
 using StarWin.Application.Services;
-using StarWin.Domain.Model.Entity.Civilization;
 using StarWin.Domain.Model.Entity.Media;
 using StarWin.Domain.Model.Entity.Notes;
 using StarWin.Domain.Model.Entity.StarMap;
@@ -14,13 +13,9 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
 {
     private const int ExplorerListBatchSize = 120;
     private const int ComboAllFilterId = -1;
-    private const ExplorerSectorLoadSections DetailedSectorSections = ExplorerSectorLoadSections.AstralBodies
-        | ExplorerSectorLoadSections.Worlds
-        | ExplorerSectorLoadSections.SpaceHabitats
-        | ExplorerSectorLoadSections.Colonies
-        | ExplorerSectorLoadSections.ColonyDemographics;
+
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
-    [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
+    [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
     [Inject] protected IStarWinEntityNameService EntityNameService { get; set; } = default!;
     [Inject] protected IStarWinSpaceHabitatService SpaceHabitatService { get; set; } = default!;
@@ -43,10 +38,9 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     public int? RequestedHabitatId { get; set; }
 
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
-    protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
-    protected readonly Dictionary<int, World> WorldsById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
+    protected ExplorerWorldsWorkspace? selectedWorldsWorkspace;
     protected string explorerRenderError = string.Empty;
     protected int selectedSectorId;
     protected int selectedSystemId;
@@ -58,7 +52,6 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected string worldQuery = string.Empty;
     protected string worldKind = string.Empty;
     protected string worldType = string.Empty;
-    protected int worldVisibleCount = ExplorerListBatchSize;
     protected bool worldHasMoreRecords;
     protected bool showWorldFilters;
     protected string imageUploadStatus = string.Empty;
@@ -68,7 +61,6 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected bool IsSpaceHabitatCreateDisabled => spaceHabitatEmpireId == 0;
 
     private IReadOnlyList<EntityImage> entityImages = [];
-    private bool entityImagesLoaded;
     private bool entityImagesLoading;
     private ElementReference worldLoadMoreElement;
     private DotNetObjectReference<Worlds>? dotNetReference;
@@ -76,22 +68,24 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     private bool worldObserverConfigured;
     private bool browserSessionReady;
     private bool browserSessionRestored;
+    private int worldVisibleCount = ExplorerListBatchSize;
+    private string lastLoadedImageKey = string.Empty;
 
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
-    protected IReadOnlyList<Empire> ExplorerEmpires => explorerContext.Empires;
-
-    private IReadOnlyDictionary<int, Empire> EmpiresById =>
-        ExplorerEmpires.ToDictionary(empire => empire.Id);
+    protected IReadOnlyList<ExplorerLookupOption> ExplorerEmpires => selectedWorldsWorkspace?.Empires ?? [];
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync(RequestedSectorId);
+        await RefreshExplorerShellAsync(RequestedSectorId);
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        ApplyRequestedSelection(GetSelectedSector());
+        selectedSystemId = await ResolveRequestedSystemIdAsync(initialSector);
+        selectedSystemText = FormatSelectedSystem(initialSector, selectedSystemId);
+        await LoadSelectedWorkspaceAsync();
+        await ApplyRequestedSelectionAsync();
     }
 
     protected override async Task OnParametersSetAsync()
@@ -105,10 +99,14 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await RefreshExplorerDataAsync(selectedSectorId);
+            selectedSystemId = 0;
         }
 
-        ApplyRequestedSelection(GetSelectedSector());
+        var sector = GetSelectedSector();
+        selectedSystemId = await ResolveRequestedSystemIdAsync(sector);
+        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await LoadSelectedWorkspaceAsync();
+        await ApplyRequestedSelectionAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -122,7 +120,6 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         }
 
         await ConfigureWorldObserverAsync();
-        _ = EnsureEntityImagesLoadedAsync(backgroundLoad: true);
     }
 
     protected StarWinSector GetSelectedSector()
@@ -153,17 +150,17 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await RefreshExplorerDataAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        SelectDefaultRecord(sector);
         ClearWorldFilters();
+        await LoadSelectedWorkspaceAsync();
+        SelectDefaultRecord(GetSelectedSystemRecord());
         await PersistExplorerSessionAsync();
         NavigateToCurrentSelection();
     }
 
-    protected Task HandleSelectedSystemTextChangedAsync(string value)
+    protected async Task HandleSelectedSystemTextChangedAsync(string value)
     {
         selectedSystemText = value;
         var sector = GetSelectedSector();
@@ -172,18 +169,18 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         {
             selectedSystemId = systemId;
             selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-            SelectDefaultRecord(sector);
+            await LoadSelectedWorkspaceAsync();
+            SelectDefaultRecord(GetSelectedSystemRecord());
             NavigateToCurrentSelection(replace: true);
         }
 
-        return PersistExplorerSessionAsync();
+        await PersistExplorerSessionAsync();
     }
 
     protected Task HandleSearchQueryChangedAsync(string value)
     {
         searchQuery = value;
-        RunSearch();
-        return Task.CompletedTask;
+        return RunSearchAsync();
     }
 
     protected void NavigateToSearchResult(StarWinSearchResult result)
@@ -193,7 +190,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
             result.SectorId ?? selectedSectorId,
             result.SystemId ?? 0,
             result.WorldId ?? 0,
-            result.Type == StarWinSearchResultType.Colony ? result.WorldId ?? 0 : 0,
+            result.ColonyId ?? 0,
             result.SpaceHabitatId ?? 0,
             result.RaceId ?? 0,
             result.EmpireId ?? 0);
@@ -203,42 +200,25 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
 
     protected void SelectWorld(int worldId)
     {
-        var sector = GetSelectedSector();
-        var system = sector.Systems.FirstOrDefault(item => item.Worlds.Any(world => world.Id == worldId));
-        if (system is not null)
-        {
-            selectedSystemId = system.Id;
-            selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        }
-
         selectedWorldId = worldId;
         selectedHabitatId = 0;
+        _ = EnsureEntityImagesLoadedAsync();
         NavigateToCurrentSelection(replace: true);
         _ = PersistExplorerSessionAsync();
     }
 
     protected void SelectHabitat(int habitatId)
     {
-        var sector = GetSelectedSector();
-        var system = sector.Systems.FirstOrDefault(item => item.SpaceHabitats.Any(habitat => habitat.Id == habitatId));
-        if (system is not null)
-        {
-            selectedSystemId = system.Id;
-            selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        }
-
         selectedHabitatId = habitatId;
         selectedWorldId = 0;
+        _ = EnsureEntityImagesLoadedAsync();
         NavigateToCurrentSelection(replace: true);
         _ = PersistExplorerSessionAsync();
     }
 
     protected void SelectParentOfHabitat(SpaceHabitat habitat)
     {
-        var sector = GetSelectedSector();
-        var system = sector.Systems.FirstOrDefault(item => item.SpaceHabitats.Any(spaceHabitat => spaceHabitat.Id == habitat.Id))
-            ?? sector.Systems.FirstOrDefault(item => item.Id == selectedSystemId);
-
+        var system = GetSelectedSystemRecord();
         if (habitat.OrbitTargetKind == OrbitTargetKind.World
             && system?.Worlds.FirstOrDefault(world => world.Id == habitat.OrbitTargetId) is World parentWorld)
         {
@@ -268,8 +248,8 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected async Task SaveEntityNameAsync(EntityNoteTargetKind targetKind, int targetId, string name)
     {
         await EntityNameService.SaveNameAsync(targetKind, targetId, name);
-        await RefreshExplorerDataAsync(selectedSectorId);
-        ApplyRequestedSelection(GetSelectedSector());
+        await LoadSelectedWorkspaceAsync();
+        await ApplyRequestedSelectionAsync();
     }
 
     protected IEnumerable<ExplorerWorldRecord> GetFilteredExplorerWorldRecords(StarSystem? system)
@@ -330,13 +310,13 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
                 spaceHabitatEmpireId,
                 spaceHabitatName);
 
-            if (world.StarSystemId is int systemId)
-            {
-                AddSpaceHabitatToWorkspace(systemId, habitat);
-            }
-
-            CompleteSpaceHabitatCreate(world.StarSystemId ?? selectedSystemId, habitat.Name);
-            SelectHabitat(habitat.Id);
+            await LoadSelectedWorkspaceAsync();
+            selectedHabitatId = habitat.Id;
+            selectedWorldId = 0;
+            spaceHabitatName = string.Empty;
+            spaceHabitatStatus = $"{habitat.Name} created.";
+            await EnsureEntityImagesLoadedAsync();
+            NavigateToCurrentSelection(replace: true);
         }
         catch (InvalidOperationException ex)
         {
@@ -362,7 +342,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     {
         return empireId is null
             ? "Unassigned"
-            : EmpiresById.TryGetValue(empireId.Value, out var empire) ? empire.Name : empireId.Value.ToString();
+            : ExplorerEmpires.FirstOrDefault(empire => empire.Id == empireId.Value)?.Name ?? empireId.Value.ToString();
     }
 
     protected static string DisplayPopulation(long population)
@@ -455,6 +435,275 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         }
     }
 
+    private async Task RefreshExplorerShellAsync(int? preferredSectorId = null, CancellationToken cancellationToken = default)
+    {
+        explorerContext = await ExplorerContextService.LoadShellAsync(
+            preferredSectorId: preferredSectorId,
+            includeReferenceData: false,
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task LoadSelectedWorkspaceAsync(CancellationToken cancellationToken = default)
+    {
+        if (selectedSectorId <= 0 || selectedSystemId <= 0)
+        {
+            selectedWorldsWorkspace = null;
+            entityImages = [];
+            lastLoadedImageKey = string.Empty;
+            return;
+        }
+
+        selectedWorldsWorkspace = await ExplorerQueryService.LoadWorldsWorkspaceAsync(selectedSectorId, selectedSystemId, cancellationToken);
+        await EnsureEntityImagesLoadedAsync(cancellationToken);
+    }
+
+    private async Task<int> ResolveRequestedSystemIdAsync(StarWinSector sector, CancellationToken cancellationToken = default)
+    {
+        if (RequestedSystemId is int requestedSystemId
+            && sector.Systems.Any(system => system.Id == requestedSystemId))
+        {
+            return requestedSystemId;
+        }
+
+        int? resolvedSystemId = null;
+        if (RequestedColonyId is int requestedColonyId)
+        {
+            resolvedSystemId = await ExplorerQueryService.ResolveSystemIdAsync(
+                sector.Id,
+                colonyId: requestedColonyId,
+                cancellationToken: cancellationToken);
+        }
+        else if (RequestedHabitatId is int requestedHabitatId)
+        {
+            resolvedSystemId = await ExplorerQueryService.ResolveSystemIdAsync(
+                sector.Id,
+                habitatId: requestedHabitatId,
+                cancellationToken: cancellationToken);
+        }
+        else if (RequestedWorldId is int requestedWorldId)
+        {
+            resolvedSystemId = await ExplorerQueryService.ResolveSystemIdAsync(
+                sector.Id,
+                worldId: requestedWorldId,
+                cancellationToken: cancellationToken);
+        }
+
+        if (resolvedSystemId is int requestedSelectionSystemId
+            && sector.Systems.Any(system => system.Id == requestedSelectionSystemId))
+        {
+            return requestedSelectionSystemId;
+        }
+
+        return ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
+    }
+
+    private async Task ApplyRequestedSelectionAsync()
+    {
+        var system = GetSelectedSystemRecord();
+        if (system is null)
+        {
+            selectedWorldId = 0;
+            selectedHabitatId = 0;
+            return;
+        }
+
+        if (RequestedColonyId is int requestedColonyId)
+        {
+            var colonyWorld = system.Worlds.FirstOrDefault(world => world.Colony?.Id == requestedColonyId);
+            if (colonyWorld is not null)
+            {
+                selectedWorldId = colonyWorld.Id;
+                selectedHabitatId = 0;
+                await EnsureEntityImagesLoadedAsync();
+                return;
+            }
+        }
+
+        if (RequestedHabitatId is int requestedHabitatId
+            && system.SpaceHabitats.FirstOrDefault(habitat => habitat.Id == requestedHabitatId) is SpaceHabitat habitat)
+        {
+            selectedHabitatId = habitat.Id;
+            selectedWorldId = 0;
+            await EnsureEntityImagesLoadedAsync();
+            return;
+        }
+
+        if (RequestedWorldId is int requestedWorldId
+            && system.Worlds.FirstOrDefault(world => world.Id == requestedWorldId) is World world)
+        {
+            selectedWorldId = world.Id;
+            selectedHabitatId = 0;
+            await EnsureEntityImagesLoadedAsync();
+            return;
+        }
+
+        if (selectedHabitatId > 0 && system.SpaceHabitats.Any(item => item.Id == selectedHabitatId))
+        {
+            selectedWorldId = 0;
+            await EnsureEntityImagesLoadedAsync();
+            return;
+        }
+
+        if (selectedWorldId > 0 && system.Worlds.Any(item => item.Id == selectedWorldId))
+        {
+            selectedHabitatId = 0;
+            await EnsureEntityImagesLoadedAsync();
+            return;
+        }
+
+        SelectDefaultRecord(system);
+        await EnsureEntityImagesLoadedAsync();
+    }
+
+    private async Task EnsureEntityImagesLoadedAsync(CancellationToken cancellationToken = default)
+    {
+        var targets = new List<EntityImageTarget>();
+        if (selectedWorldId > 0)
+        {
+            targets.Add(new EntityImageTarget(EntityImageTargetKind.World, selectedWorldId));
+        }
+
+        if (selectedHabitatId > 0)
+        {
+            targets.Add(new EntityImageTarget(EntityImageTargetKind.SpaceHabitat, selectedHabitatId));
+        }
+
+        var imageKey = string.Join('|', targets.Select(target => $"{(int)target.TargetKind}:{target.TargetId}"));
+        if (entityImagesLoading || imageKey == lastLoadedImageKey)
+        {
+            return;
+        }
+
+        entityImagesLoading = true;
+        try
+        {
+            entityImages = await ImageService.GetImagesAsync(targets, cancellationToken);
+            lastLoadedImageKey = imageKey;
+            explorerRenderError = string.Empty;
+            await InvokeAsync(StateHasChanged);
+        }
+        finally
+        {
+            entityImagesLoading = false;
+        }
+    }
+
+    private async Task RunSearchAsync()
+    {
+        searchResults = await ExplorerQueryService.SearchSectorAsync(selectedSectorId, searchQuery);
+    }
+
+    private async Task RestoreExplorerSessionAsync()
+    {
+        if (browserSessionRestored || RequestedSectorId is not null)
+        {
+            return;
+        }
+
+        browserSessionRestored = true;
+        var storedSelection = await ExplorerPageState.RestoreSelectionAsync(JS, RequestedSectorId);
+        if (storedSelection is null)
+        {
+            return;
+        }
+
+        var sector = ExplorerSectors.FirstOrDefault(item => item.Id == storedSelection.SectorId);
+        if (sector is null)
+        {
+            return;
+        }
+
+        selectedSectorId = sector.Id;
+        selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
+            ? storedSelection.SystemId
+            : sector.Systems.FirstOrDefault()?.Id ?? 0;
+        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+        await LoadSelectedWorkspaceAsync();
+        await ApplyRequestedSelectionAsync();
+        NavigateToCurrentSelection(replace: true);
+    }
+
+    private async Task PersistExplorerSessionAsync()
+    {
+        if (!browserSessionReady)
+        {
+            return;
+        }
+
+        await ExplorerPageState.PersistSelectionAsync(
+            JS,
+            browserSessionReady,
+            new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Worlds")));
+    }
+
+    private async Task UploadEntityImage(EntityImageTargetKind targetKind, int targetId, InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        try
+        {
+            await using var stream = file.OpenReadStream(10 * 1024 * 1024);
+            await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
+            lastLoadedImageKey = string.Empty;
+            await EnsureEntityImagesLoadedAsync();
+            imageUploadStatus = $"{file.Name} uploaded.";
+        }
+        catch (Exception exception)
+        {
+            imageUploadStatus = exception.Message;
+        }
+    }
+
+    private async Task ConfigureWorldObserverAsync()
+    {
+        if (!worldHasMoreRecords)
+        {
+            worldObserverConfigured = false;
+            if (loadMoreScrollModule is not null)
+            {
+                await loadMoreScrollModule.InvokeVoidAsync("disconnectLoadMore", "world");
+            }
+
+            return;
+        }
+
+        if (worldObserverConfigured)
+        {
+            return;
+        }
+
+        loadMoreScrollModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/timelineInfiniteScroll.js");
+        dotNetReference ??= DotNetObjectReference.Create(this);
+        await loadMoreScrollModule.InvokeVoidAsync("observeLoadMore", "world", worldLoadMoreElement, dotNetReference, "LoadMoreWorlds");
+        worldObserverConfigured = true;
+    }
+
+    private void NavigateToCurrentSelection(bool replace = false)
+    {
+        var targetUri = SectorExplorerRoutes.BuildSectionUri(
+            "Worlds",
+            selectedSectorId,
+            selectedSystemId,
+            selectedWorldId,
+            0,
+            selectedHabitatId);
+
+        NavigationManager.NavigateTo(targetUri, replace: replace);
+    }
+
+    private StarSystem? GetSelectedSystemRecord()
+    {
+        return selectedWorldsWorkspace?.System;
+    }
+
+    private void SelectDefaultRecord(StarSystem? system)
+    {
+        selectedSystemId = system?.Id ?? 0;
+        selectedWorldId = system?.Worlds.FirstOrDefault()?.Id ?? 0;
+        selectedHabitatId = selectedWorldId == 0
+            ? system?.SpaceHabitats.FirstOrDefault()?.Id ?? 0
+            : 0;
+    }
+
     private static IEnumerable<ExplorerWorldRecord> GetExplorerWorldRecords(StarSystem system)
     {
         foreach (var world in system.Worlds)
@@ -502,259 +751,6 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
             || ContainsQuery(record.World?.Colony?.ColonyClass, query)
             || ContainsQuery(record.World?.Colony?.AllegianceName, query)
             || ContainsQuery(DisplayEmpire(record.Habitat?.ControlledByEmpireId), query);
-    }
-
-    private async Task ConfigureWorldObserverAsync()
-    {
-        if (!worldHasMoreRecords)
-        {
-            worldObserverConfigured = false;
-            if (loadMoreScrollModule is not null)
-            {
-                await loadMoreScrollModule.InvokeVoidAsync("disconnectLoadMore", "world");
-            }
-
-            return;
-        }
-
-        if (worldObserverConfigured)
-        {
-            return;
-        }
-
-        loadMoreScrollModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/timelineInfiniteScroll.js");
-        dotNetReference ??= DotNetObjectReference.Create(this);
-        await loadMoreScrollModule.InvokeVoidAsync("observeLoadMore", "world", worldLoadMoreElement, dotNetReference, "LoadMoreWorlds");
-        worldObserverConfigured = true;
-    }
-
-    private void NavigateToCurrentSelection(bool replace = false)
-    {
-        var targetUri = SectorExplorerRoutes.BuildSectionUri(
-            "Worlds",
-            selectedSectorId,
-            selectedSystemId,
-            selectedWorldId,
-            0,
-            selectedHabitatId);
-
-        NavigationManager.NavigateTo(targetUri, replace: replace);
-    }
-
-    private void ApplyRequestedSelection(StarWinSector sector)
-    {
-        selectedSystemId = ExplorerPageState.ResolveSelectedSystemId(sector, RequestedSystemId, selectedSystemId);
-
-        if (RequestedHabitatId is int requestedHabitatId)
-        {
-            var habitatSystem = sector.Systems.FirstOrDefault(system => system.SpaceHabitats.Any(habitat => habitat.Id == requestedHabitatId));
-            if (habitatSystem is not null)
-            {
-                selectedSystemId = habitatSystem.Id;
-                selectedHabitatId = requestedHabitatId;
-                selectedWorldId = 0;
-                selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-                return;
-            }
-        }
-
-        if (RequestedColonyId is int requestedColonyId)
-        {
-            var colonyListing = sector.Systems
-                .SelectMany(system => system.Worlds.Select(world => new { system, world }))
-                .FirstOrDefault(item => item.world.Colony?.Id == requestedColonyId);
-            if (colonyListing is not null)
-            {
-                selectedSystemId = colonyListing.system.Id;
-                selectedWorldId = colonyListing.world.Id;
-                selectedHabitatId = 0;
-                selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-                return;
-            }
-        }
-
-        if (RequestedWorldId is int requestedWorldId)
-        {
-            var worldSystem = sector.Systems.FirstOrDefault(system => system.Worlds.Any(world => world.Id == requestedWorldId));
-            if (worldSystem is not null)
-            {
-                selectedSystemId = worldSystem.Id;
-                selectedWorldId = requestedWorldId;
-                selectedHabitatId = 0;
-                selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-                return;
-            }
-        }
-
-        if (selectedHabitatId > 0
-            && sector.Systems.FirstOrDefault(system => system.SpaceHabitats.Any(habitat => habitat.Id == selectedHabitatId)) is StarSystem existingHabitatSystem)
-        {
-            selectedSystemId = existingHabitatSystem.Id;
-            selectedWorldId = 0;
-            selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-            return;
-        }
-
-        if (selectedWorldId > 0
-            && sector.Systems.FirstOrDefault(system => system.Worlds.Any(world => world.Id == selectedWorldId)) is StarSystem existingWorldSystem)
-        {
-            selectedSystemId = existingWorldSystem.Id;
-            selectedHabitatId = 0;
-            selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-            return;
-        }
-
-        SelectDefaultRecord(sector);
-        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-    }
-
-    private void SelectDefaultRecord(StarWinSector sector)
-    {
-        var system = sector.Systems.FirstOrDefault(item => item.Id == selectedSystemId)
-            ?? sector.Systems.FirstOrDefault();
-        selectedSystemId = system?.Id ?? 0;
-        selectedWorldId = system?.Worlds.FirstOrDefault()?.Id ?? 0;
-        selectedHabitatId = selectedWorldId == 0
-            ? system?.SpaceHabitats.FirstOrDefault()?.Id ?? 0
-            : 0;
-    }
-
-    private void AddSpaceHabitatToWorkspace(int systemId, SpaceHabitat habitat)
-    {
-        var sector = GetSelectedSector();
-        var system = sector.Systems.FirstOrDefault(item => item.Id == systemId);
-        if (system is null || system.SpaceHabitats.Any(item => item.Id == habitat.Id))
-        {
-            return;
-        }
-
-        system.SpaceHabitats.Add(habitat);
-        sectorCacheBuilder.Invalidate(sector.Id);
-    }
-
-    private void CompleteSpaceHabitatCreate(int systemId, string habitatName)
-    {
-        selectedSystemId = systemId;
-        var sector = GetSelectedSector();
-        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        spaceHabitatName = string.Empty;
-        spaceHabitatStatus = $"{habitatName} created.";
-    }
-
-    private async Task EnsureEntityImagesLoadedAsync(bool backgroundLoad = false)
-    {
-        if (entityImagesLoaded || entityImagesLoading)
-        {
-            return;
-        }
-
-        entityImagesLoading = true;
-        try
-        {
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
-            explorerRenderError = string.Empty;
-            if (backgroundLoad)
-            {
-                await InvokeAsync(StateHasChanged);
-            }
-            else
-            {
-                StateHasChanged();
-            }
-        }
-        finally
-        {
-            entityImagesLoading = false;
-        }
-    }
-
-    private async Task RefreshExplorerDataAsync(int? detailedSectorId = null, CancellationToken cancellationToken = default)
-    {
-        explorerContext = await ExplorerContextService.LoadShellAsync(
-            includeSavedRoutes: false,
-            includeReferenceData: true,
-            detailedSectorId: detailedSectorId,
-            detailedSectorSections: DetailedSectorSections,
-            cancellationToken: cancellationToken);
-
-        foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
-        {
-            sectorCacheBuilder.Invalidate(sectorId);
-        }
-        WorldsById.Clear();
-        foreach (var world in explorerContext.Sectors.SelectMany(sector => sector.Systems).SelectMany(system => system.Worlds))
-        {
-            WorldsById[world.Id] = world;
-        }
-    }
-
-    private void RunSearch()
-    {
-        searchResults = SearchService.Search(searchQuery)
-            .Where(result => result.SectorId is null || result.SectorId == selectedSectorId)
-            .ToList();
-    }
-
-    private async Task RestoreExplorerSessionAsync()
-    {
-        if (browserSessionRestored || RequestedSectorId is not null)
-        {
-            return;
-        }
-
-        browserSessionRestored = true;
-        var storedSelection = await ExplorerPageState.RestoreSelectionAsync(JS, RequestedSectorId);
-        if (storedSelection is null)
-        {
-            return;
-        }
-
-        var sector = ExplorerSectors.FirstOrDefault(item => item.Id == storedSelection.SectorId);
-        if (sector is null)
-        {
-            return;
-        }
-
-        selectedSectorId = sector.Id;
-        await RefreshExplorerDataAsync(selectedSectorId);
-        sector = GetSelectedSector();
-        selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
-            ? storedSelection.SystemId
-            : sector.Systems.FirstOrDefault()?.Id ?? 0;
-        SelectDefaultRecord(sector);
-        selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
-        NavigateToCurrentSelection(replace: true);
-    }
-
-    private async Task PersistExplorerSessionAsync()
-    {
-        if (!browserSessionReady)
-        {
-            return;
-        }
-
-        await ExplorerPageState.PersistSelectionAsync(
-            JS,
-            browserSessionReady,
-            new ExplorerSessionSelection(selectedSectorId, selectedSystemId, false, SectorExplorerRoutes.GetSectionSlug("Worlds")));
-    }
-
-    private async Task UploadEntityImage(EntityImageTargetKind targetKind, int targetId, InputFileChangeEventArgs args)
-    {
-        var file = args.File;
-        try
-        {
-            await using var stream = file.OpenReadStream(10 * 1024 * 1024);
-            await ImageService.UploadImageAsync(targetKind, targetId, file.Name, file.ContentType, stream);
-            entityImages = await ImageService.GetImagesAsync();
-            entityImagesLoaded = true;
-            imageUploadStatus = $"{file.Name} uploaded.";
-        }
-        catch (Exception exception)
-        {
-            imageUploadStatus = exception.Message;
-        }
     }
 
     private static string FormatSelectedSystem(StarWinSector sector, int systemId)

--- a/StarWin.Web/Components/Pages/Worlds.razor.cs
+++ b/StarWin.Web/Components/Pages/Worlds.razor.cs
@@ -14,6 +14,11 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
 {
     private const int ExplorerListBatchSize = 120;
     private const int ComboAllFilterId = -1;
+    private const ExplorerSectorLoadSections DetailedSectorSections = ExplorerSectorLoadSections.AstralBodies
+        | ExplorerSectorLoadSections.Worlds
+        | ExplorerSectorLoadSections.SpaceHabitats
+        | ExplorerSectorLoadSections.Colonies
+        | ExplorerSectorLoadSections.ColonyDemographics;
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinSearchService SearchService { get; set; } = default!;
     [Inject] protected IStarWinImageService ImageService { get; set; } = default!;
@@ -40,7 +45,6 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected static readonly IReadOnlyList<string> sections = SectorExplorerSections.All;
     protected readonly ExplorerSectorCacheBuilder sectorCacheBuilder = new();
     protected readonly Dictionary<int, World> WorldsById = [];
-    private readonly Dictionary<int, ExplorerSectorLoadSections> loadedSectorSectionsById = [];
 
     protected StarWinExplorerContext explorerContext = StarWinExplorerContext.Empty;
     protected string explorerRenderError = string.Empty;
@@ -81,13 +85,12 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshExplorerDataAsync();
+        await RefreshExplorerDataAsync(RequestedSectorId);
         var initialSector = RequestedSectorId is int requestedSectorId
             ? ExplorerSectors.FirstOrDefault(sector => sector.Id == requestedSectorId) ?? explorerContext.CurrentSector
             : explorerContext.CurrentSector;
 
         selectedSectorId = initialSector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
         ApplyRequestedSelection(GetSelectedSector());
     }
 
@@ -102,7 +105,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         if (requestedSectorId != selectedSectorId && ExplorerSectors.Any(sector => sector.Id == requestedSectorId))
         {
             selectedSectorId = requestedSectorId;
-            await EnsureSectorDataLoadedAsync(selectedSectorId);
+            await RefreshExplorerDataAsync(selectedSectorId);
         }
 
         ApplyRequestedSelection(GetSelectedSector());
@@ -150,7 +153,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected async Task HandleSectorChangedAsync(int sectorId)
     {
         selectedSectorId = sectorId;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         var sector = GetSelectedSector();
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
@@ -265,8 +268,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     protected async Task SaveEntityNameAsync(EntityNoteTargetKind targetKind, int targetId, string name)
     {
         await EntityNameService.SaveNameAsync(targetKind, targetId, name);
-        await RefreshExplorerDataAsync();
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         ApplyRequestedSelection(GetSelectedSector());
     }
 
@@ -667,61 +669,19 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         }
     }
 
-    private async Task RefreshExplorerDataAsync(CancellationToken cancellationToken = default)
+    private async Task RefreshExplorerDataAsync(int? detailedSectorId = null, CancellationToken cancellationToken = default)
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             includeSavedRoutes: false,
             includeReferenceData: true,
+            detailedSectorId: detailedSectorId,
+            detailedSectorSections: DetailedSectorSections,
             cancellationToken: cancellationToken);
 
-        loadedSectorSectionsById.Clear();
         foreach (var sectorId in ExplorerSectors.Select(sector => sector.Id))
         {
             sectorCacheBuilder.Invalidate(sectorId);
         }
-        WorldsById.Clear();
-    }
-
-    private async Task EnsureSectorDataLoadedAsync(int sectorId, CancellationToken cancellationToken = default)
-    {
-        if (sectorId <= 0)
-        {
-            return;
-        }
-
-        const ExplorerSectorLoadSections requiredSections = ExplorerSectorLoadSections.AstralBodies
-            | ExplorerSectorLoadSections.Worlds
-            | ExplorerSectorLoadSections.SpaceHabitats
-            | ExplorerSectorLoadSections.Colonies
-            | ExplorerSectorLoadSections.ColonyDemographics;
-
-        loadedSectorSectionsById.TryGetValue(sectorId, out var loadedSections);
-        if ((loadedSections & requiredSections) == requiredSections)
-        {
-            return;
-        }
-
-        var detailedSector = await ExplorerContextService.LoadSectorAsync(sectorId, requiredSections, cancellationToken);
-        if (detailedSector is null)
-        {
-            return;
-        }
-
-        var sectors = ExplorerSectors.ToList();
-        var sectorIndex = sectors.FindIndex(item => item.Id == detailedSector.Id);
-        if (sectorIndex >= 0)
-        {
-            sectors[sectorIndex] = detailedSector;
-        }
-
-        explorerContext = explorerContext with
-        {
-            Sectors = sectors,
-            CurrentSector = explorerContext.CurrentSector.Id == detailedSector.Id ? detailedSector : explorerContext.CurrentSector
-        };
-
-        loadedSectorSectionsById[sectorId] = loadedSections | requiredSections;
-        sectorCacheBuilder.Invalidate(sectorId);
         WorldsById.Clear();
         foreach (var world in explorerContext.Sectors.SelectMany(sector => sector.Systems).SelectMany(system => system.Worlds))
         {
@@ -757,7 +717,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         }
 
         selectedSectorId = sector.Id;
-        await EnsureSectorDataLoadedAsync(selectedSectorId);
+        await RefreshExplorerDataAsync(selectedSectorId);
         sector = GetSelectedSector();
         selectedSystemId = sector.Systems.Any(system => system.Id == storedSelection.SystemId)
             ? storedSelection.SystemId

--- a/StarWin.Web/Components/Pages/Worlds.razor.cs
+++ b/StarWin.Web/Components/Pages/Worlds.razor.cs
@@ -439,7 +439,6 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
     {
         explorerContext = await ExplorerContextService.LoadShellAsync(
             preferredSectorId: preferredSectorId,
-            includeReferenceData: false,
             cancellationToken: cancellationToken);
     }
 

--- a/StarWin.Web/Components/Pages/Worlds.razor.cs
+++ b/StarWin.Web/Components/Pages/Worlds.razor.cs
@@ -154,8 +154,8 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         selectedSystemId = sector.Systems.FirstOrDefault()?.Id ?? 0;
         selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
         ClearWorldFilters();
+        ClearSelectedRecord();
         await LoadSelectedWorkspaceAsync();
-        SelectDefaultRecord(GetSelectedSystemRecord());
         await PersistExplorerSessionAsync();
         NavigateToCurrentSelection();
     }
@@ -169,8 +169,8 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         {
             selectedSystemId = systemId;
             selectedSystemText = FormatSelectedSystem(sector, selectedSystemId);
+            ClearSelectedRecord();
             await LoadSelectedWorkspaceAsync();
-            SelectDefaultRecord(GetSelectedSystemRecord());
             NavigateToCurrentSelection(replace: true);
         }
 
@@ -447,13 +447,11 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         if (selectedSectorId <= 0 || selectedSystemId <= 0)
         {
             selectedWorldsWorkspace = null;
-            entityImages = [];
-            lastLoadedImageKey = string.Empty;
+            ClearSelectedRecord();
             return;
         }
 
         selectedWorldsWorkspace = await ExplorerQueryService.LoadWorldsWorkspaceAsync(selectedSectorId, selectedSystemId, cancellationToken);
-        await EnsureEntityImagesLoadedAsync(cancellationToken);
     }
 
     private async Task<int> ResolveRequestedSystemIdAsync(StarWinSector sector, CancellationToken cancellationToken = default)
@@ -501,8 +499,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         var system = GetSelectedSystemRecord();
         if (system is null)
         {
-            selectedWorldId = 0;
-            selectedHabitatId = 0;
+            ClearSelectedRecord();
             return;
         }
 
@@ -550,8 +547,7 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
             return;
         }
 
-        SelectDefaultRecord(system);
-        await EnsureEntityImagesLoadedAsync();
+        ClearSelectedRecord();
     }
 
     private async Task EnsureEntityImagesLoadedAsync(CancellationToken cancellationToken = default)
@@ -694,13 +690,12 @@ public partial class Worlds : ComponentBase, IAsyncDisposable
         return selectedWorldsWorkspace?.System;
     }
 
-    private void SelectDefaultRecord(StarSystem? system)
+    private void ClearSelectedRecord()
     {
-        selectedSystemId = system?.Id ?? 0;
-        selectedWorldId = system?.Worlds.FirstOrDefault()?.Id ?? 0;
-        selectedHabitatId = selectedWorldId == 0
-            ? system?.SpaceHabitats.FirstOrDefault()?.Id ?? 0
-            : 0;
+        selectedWorldId = 0;
+        selectedHabitatId = 0;
+        entityImages = [];
+        lastLoadedImageKey = string.Empty;
     }
 
     private static IEnumerable<ExplorerWorldRecord> GetExplorerWorldRecords(StarSystem system)

--- a/StarWin.Web/Components/Routes.razor
+++ b/StarWin.Web/Components/Routes.razor
@@ -1,6 +1,6 @@
 ﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
-        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        <FocusOnNavigate RouteData="routeData" Selector=".site-main" />
     </Found>
 </Router>

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -859,6 +859,24 @@ dd {
     line-height: 1.6;
 }
 
+.route-cache-note {
+    display: grid;
+    gap: 10px;
+    border: 1px solid rgba(56, 189, 248, 0.24);
+    border-radius: 8px;
+    background: rgba(14, 165, 233, 0.12);
+    padding: 12px 14px;
+}
+
+.route-cache-note p {
+    color: #d9e8f5;
+}
+
+.route-cache-action {
+    width: fit-content;
+    text-decoration: none;
+}
+
 .inline-loading-modal-backdrop {
     position: absolute;
     inset: 0;
@@ -1022,6 +1040,16 @@ dd {
 .map-hud small {
     color: var(--muted);
     font-size: 0.78rem;
+}
+
+.route-cache-note-compact {
+    gap: 8px;
+    padding: 10px;
+}
+
+.map-hud .route-cache-note p {
+    font-size: 0.78rem;
+    line-height: 1.45;
 }
 
 .map-distance-control {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -859,24 +859,6 @@ dd {
     line-height: 1.6;
 }
 
-.route-cache-note {
-    display: grid;
-    gap: 10px;
-    border: 1px solid rgba(56, 189, 248, 0.24);
-    border-radius: 8px;
-    background: rgba(14, 165, 233, 0.12);
-    padding: 12px 14px;
-}
-
-.route-cache-note p {
-    color: #d9e8f5;
-}
-
-.route-cache-action {
-    width: fit-content;
-    text-decoration: none;
-}
-
 .inline-loading-modal-backdrop {
     position: absolute;
     inset: 0;
@@ -1040,16 +1022,6 @@ dd {
 .map-hud small {
     color: var(--muted);
     font-size: 0.78rem;
-}
-
-.route-cache-note-compact {
-    gap: 8px;
-    padding: 10px;
-}
-
-.map-hud .route-cache-note p {
-    font-size: 0.78rem;
-    line-height: 1.45;
 }
 
 .map-distance-control {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -104,6 +104,8 @@ dd {
 
 .explorer-hero {
     position: relative;
+    z-index: 0;
+    isolation: isolate;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     gap: 28px;
@@ -125,6 +127,7 @@ dd {
 .about-hero::before {
     position: absolute;
     inset: 0;
+    z-index: 0;
     border-radius: inherit;
     content: "";
     background:

--- a/StarWin.Web/wwwroot/js/navigationLoading.js
+++ b/StarWin.Web/wwwroot/js/navigationLoading.js
@@ -65,6 +65,21 @@
         sessionStorage.removeItem(sectionLoadingStartedAtKey);
     }
 
+    function postDesktopTrace(eventName, payload) {
+        try {
+            const webview = window.chrome && window.chrome.webview;
+            if (webview && typeof webview.postMessage === "function") {
+                webview.postMessage({
+                    source: "explorer-navigation",
+                    eventName: eventName,
+                    payload: payload || {}
+                });
+            }
+        }
+        catch {
+        }
+    }
+
     function showOverlay(overlayId, startedAtUnixMs) {
         const overlay = getOverlay(overlayId);
         if (!overlay) {
@@ -123,8 +138,28 @@
                 event.preventDefault();
             }
 
+            console.info("[ExplorerNav] section click", {
+                sectionName: sectionName || "section",
+                url: url || "",
+                startedAtUnixMs: Date.now()
+            });
+            postDesktopTrace("section-click", {
+                sectionName: sectionName || "section",
+                url: url || "",
+                startedAtUnixMs: Date.now()
+            });
             this.showSectionLoading(sectionName);
             window.setTimeout(function () {
+                console.info("[ExplorerNav] section route assign", {
+                    sectionName: sectionName || "section",
+                    url: url || "",
+                    assignedAtUnixMs: Date.now()
+                });
+                postDesktopTrace("section-route-assign", {
+                    sectionName: sectionName || "section",
+                    url: url || "",
+                    assignedAtUnixMs: Date.now()
+                });
                 window.location.assign(url);
             }, 60);
             return false;

--- a/StarforgedAtlas.PortableLauncher/StarforgedAtlas.PortableLauncher.csproj
+++ b/StarforgedAtlas.PortableLauncher/StarforgedAtlas.PortableLauncher.csproj
@@ -10,6 +10,11 @@
     <AssemblyTitle>Starforged Atlas Portable Launcher</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>..\StarWin.Desktop\Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
+    <AssemblyVersion>2026.4.30.0</AssemblyVersion>
+    <FileVersion>2026.4.30.0</FileVersion>
+    <Version>2026.4.30.0</Version>
+    <InformationalVersion>2026-04-30.0-developer-preview</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
## Release
- 2026-04-30.0 Developer Preview

## Summary
- promote the current `dev` branch to `master`
- include the desktop and portable launcher version stamp `2026-04-30.0-developer-preview`
- ship the explorer loading and navigation optimizations from issue `#92`, including the query-driven Explorer refactor and the Hyperlanes/Configuration performance work
- include the home-page focus and overlay fixes plus the dev-promotion workflow updates already merged into `dev`

## Issues included
- #92

## Verification
- `dotnet test "Slipstream Map.sln" -nologo -m:1`
