### PR TITLE
Codex - Explorer tab order should move Configuration to the end of the section list

### DIFF
--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -18,6 +18,29 @@ namespace StarWin.Web.Tests.Pages;
 public sealed class SectorExplorerPageTests : BunitContext
 {
     [Fact]
+    public void OverviewRendersConfigurationAsFinalExplorerTab()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var sector = CreateSector();
+        var workspace = new FakeWorkspace(sector);
+        ConfigureServices(sector, workspace);
+
+        var cut = Render<SectorExplorer>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var sectionTabs = cut.FindAll(".section-tabs a")
+                .Select(link => link.TextContent.Trim())
+                .ToArray();
+
+            Assert.Equal(
+                ["Overview", "Timeline", "Hyperlanes", "Systems", "Worlds", "Colonies", "Aliens", "Religions", "Empires", "Configuration"],
+                sectionTabs);
+        });
+    }
+
+    [Fact]
     public void OverviewDefersMapWorkspaceUntilAfterInitialRender()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;

--- a/StarWin.Web/Components/Explorer/SectorExplorerSections.cs
+++ b/StarWin.Web/Components/Explorer/SectorExplorerSections.cs
@@ -6,13 +6,13 @@ internal static class SectorExplorerSections
     [
         "Overview",
         "Timeline",
-        "Configuration",
         "Hyperlanes",
         "Systems",
         "Worlds",
         "Colonies",
         "Aliens",
         "Religions",
-        "Empires"
+        "Empires",
+        "Configuration"
     ];
 }


### PR DESCRIPTION
Codex - Explorer tab order should move Configuration to the end of the section list

Issues included
- Closes #70

Summary of changes
- Move the shared explorer section ordering so `Configuration` renders after `Empires` across the extracted explorer pages.
- Add a regression test that verifies the overview page renders the updated tab order.
- Validate the change with targeted explorer tests and browser UAT on port `10070`.
