### PR TITLE
Codex - Issue #71 - Prioritize Explorer tabs in responsive layout

### DIFF
--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -41,18 +41,19 @@ public sealed class AppCssTests
     }
 
     [Fact]
-    public void ExplorerControlStripPromotesTabsAboveSelectorsAtResponsiveBreakpoint()
+    public void ExplorerControlStripDefaultsToTabFirstLayoutAndOnlySplitsAtVeryWideBreakpoint()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
         var css = File.ReadAllText(cssPath);
 
+        Assert.Contains("grid-template-columns: minmax(0, 1fr);", css);
         Assert.Contains(".control-strip-fields {", css);
         Assert.Contains(".control-strip-tabs {", css);
-        Assert.Contains("@media (max-width: 1280px) {", css);
-        Assert.Contains(".control-strip-fields .archive-search {", css);
-        Assert.Contains("grid-column: 1 / -1;", css);
         Assert.Contains("order: -1;", css);
+        Assert.Contains("@media (min-width: 1900px) {", css);
+        Assert.Contains("grid-template-columns: minmax(0, 760px) minmax(0, 1fr);", css);
+        Assert.Contains("order: 0;", css);
     }
 
     [Fact]

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -41,7 +41,7 @@ public sealed class AppCssTests
     }
 
     [Fact]
-    public void ExplorerControlStripDefaultsToTabFirstLayoutAndOnlySplitsAtVeryWideBreakpoint()
+    public void ExplorerControlStripUsesWideGridPlacementWithoutVisualReordering()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
@@ -50,10 +50,10 @@ public sealed class AppCssTests
         Assert.Contains("grid-template-columns: minmax(0, 1fr);", css);
         Assert.Contains(".control-strip-fields {", css);
         Assert.Contains(".control-strip-tabs {", css);
-        Assert.Contains("order: -1;", css);
         Assert.Contains("@media (min-width: 1900px) {", css);
         Assert.Contains("grid-template-columns: minmax(0, 760px) minmax(0, 1fr);", css);
-        Assert.Contains("order: 0;", css);
+        Assert.Contains("grid-column: 2;", css);
+        Assert.Contains("grid-row: 1;", css);
     }
 
     [Fact]

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -51,8 +51,8 @@ public sealed class AppCssTests
         Assert.Contains(".control-strip-fields {", css);
         Assert.Contains(".control-strip-tabs {", css);
         Assert.Contains("@media (min-width: 1900px) {", css);
-        Assert.Contains("grid-template-columns: minmax(0, 760px) minmax(0, 1fr);", css);
-        Assert.Contains("grid-column: 2;", css);
+        Assert.Contains("grid-template-columns: minmax(0, 1fr) minmax(0, 760px);", css);
+        Assert.Contains("grid-column: 1;", css);
         Assert.Contains("grid-row: 1;", css);
     }
 

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -41,6 +41,21 @@ public sealed class AppCssTests
     }
 
     [Fact]
+    public void ExplorerControlStripPromotesTabsAboveSelectorsAtResponsiveBreakpoint()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
+        var css = File.ReadAllText(cssPath);
+
+        Assert.Contains(".control-strip-fields {", css);
+        Assert.Contains(".control-strip-tabs {", css);
+        Assert.Contains("@media (max-width: 1280px) {", css);
+        Assert.Contains(".control-strip-fields .archive-search {", css);
+        Assert.Contains("grid-column: 1 / -1;", css);
+        Assert.Contains("order: -1;", css);
+    }
+
+    [Fact]
     public void NavigationFocusTargetsMainContentInsteadOfHeading()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));

--- a/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
+++ b/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
@@ -1,0 +1,47 @@
+using Bunit;
+using StarWin.Domain.Model.Entity.StarMap;
+using StarWin.Web.Components.Explorer;
+
+namespace StarWin.Web.Tests.Components;
+
+public sealed class SectorExplorerShellTests : BunitContext
+{
+    [Fact]
+    public void GroupsTabsSeparatelyFromExplorerSelectorsAndSearch()
+    {
+        var sector = new StarWinSector
+        {
+            Id = 7,
+            Name = "Del Corra"
+        };
+        var system = new StarSystem
+        {
+            Id = 11,
+            SectorId = sector.Id,
+            Name = "Helios"
+        };
+        sector.Systems.Add(system);
+
+        var cut = Render<SectorExplorerShell>(parameters => parameters
+            .Add(component => component.Sectors, [sector])
+            .Add(component => component.Systems, [system])
+            .Add(component => component.SelectedSectorId, sector.Id)
+            .Add(component => component.SelectedSystemText, "11 - Helios")
+            .Add(component => component.Sections, ["Overview", "Systems"])
+            .Add(component => component.ActiveSection, "Overview")
+            .Add(component => component.SectionHrefFactory, section => $"/sector-explorer/{section.ToLowerInvariant()}"));
+
+        var fieldGroup = cut.Find(".control-strip-fields");
+        var tabGroup = cut.Find(".control-strip-tabs");
+
+        Assert.Single(fieldGroup.GetElementsByClassName("sector-field"));
+        Assert.Single(fieldGroup.GetElementsByClassName("system-field"));
+        Assert.Single(fieldGroup.GetElementsByClassName("archive-search"));
+
+        var sectionLinks = tabGroup.QuerySelectorAll(".section-tabs a")
+            .Select(link => link.TextContent.Trim())
+            .ToArray();
+
+        Assert.Equal(["Overview", "Systems"], sectionLinks);
+    }
+}

--- a/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
+++ b/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
@@ -31,9 +31,12 @@ public sealed class SectorExplorerShellTests : BunitContext
             .Add(component => component.ActiveSection, "Overview")
             .Add(component => component.SectionHrefFactory, section => $"/sector-explorer/{section.ToLowerInvariant()}"));
 
+        var controlStrip = cut.Find(".control-strip");
         var fieldGroup = cut.Find(".control-strip-fields");
         var tabGroup = cut.Find(".control-strip-tabs");
 
+        Assert.Contains("control-strip-tabs", controlStrip.Children[0].ClassName);
+        Assert.Contains("control-strip-fields", controlStrip.Children[1].ClassName);
         Assert.Single(fieldGroup.GetElementsByClassName("sector-field"));
         Assert.Single(fieldGroup.GetElementsByClassName("system-field"));
         Assert.Single(fieldGroup.GetElementsByClassName("archive-search"));

--- a/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
@@ -7,6 +7,15 @@
 }
 
 <section class="control-strip">
+    <div class="control-strip-tabs">
+        <ExplorerSectionTabs Sections="Sections"
+                             ActiveSection="@ActiveSection"
+                             IsLoading="@IsLoading"
+                             LoadingTarget="@LoadingTarget"
+                             LoadingStatus="@LoadingStatus"
+                             SectionHrefFactory="SectionHrefFactory" />
+    </div>
+
     <div class="control-strip-fields">
         <label class="control-field sector-field">
             Sector
@@ -57,15 +66,6 @@
                 <p class="search-empty">No matching systems, worlds, races, colonies, empires, habitats, or history.</p>
             }
         </div>
-    </div>
-
-    <div class="control-strip-tabs">
-        <ExplorerSectionTabs Sections="Sections"
-                             ActiveSection="@ActiveSection"
-                             IsLoading="@IsLoading"
-                             LoadingTarget="@LoadingTarget"
-                             LoadingStatus="@LoadingStatus"
-                             SectionHrefFactory="SectionHrefFactory" />
     </div>
 </section>
 

--- a/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
@@ -7,62 +7,66 @@
 }
 
 <section class="control-strip">
-    <label class="control-field sector-field">
-        Sector
-        <select value="@SelectedSectorId" @onchange="HandleSectorChanged">
-            @foreach (var item in Sectors)
-            {
-                <option value="@item.Id">@item.Name</option>
-            }
-        </select>
-    </label>
-
-    <label class="control-field system-field">
-        System
-        <input list="sector-system-options"
-               placeholder="Select system..."
-               value="@SelectedSystemText"
-               @onchange="HandleSystemTextChanged" />
-        <datalist id="sector-system-options">
-            @foreach (var system in Systems)
-            {
-                <option value="@FormatSystemOption(system)" />
-            }
-        </datalist>
-    </label>
-
-    <div class="archive-search">
-        <label for="archive-search-input">Archive search</label>
-        <input id="archive-search-input"
-               placeholder="System, world, colony, race, empire..."
-               value="@SearchQuery"
-               @oninput="HandleSearchQueryInput" />
-
-        @if (SearchResults.Count > 0)
-        {
-            <div class="search-results">
-                @foreach (var result in SearchResults)
+    <div class="control-strip-fields">
+        <label class="control-field sector-field">
+            Sector
+            <select value="@SelectedSectorId" @onchange="HandleSectorChanged">
+                @foreach (var item in Sectors)
                 {
-                    <button type="button" class="search-result" @onclick="() => SearchResultSelected.InvokeAsync(result)">
-                        <span>@DisplayResultType(result.Type)</span>
-                        <strong>@result.Title</strong>
-                        <small>@result.Subtitle</small>
-                    </button>
+                    <option value="@item.Id">@item.Name</option>
                 }
-            </div>
-        }
-        else if (!string.IsNullOrWhiteSpace(SearchQuery))
-        {
-            <p class="search-empty">No matching systems, worlds, races, colonies, empires, habitats, or history.</p>
-        }
+            </select>
+        </label>
+
+        <label class="control-field system-field">
+            System
+            <input list="sector-system-options"
+                   placeholder="Select system..."
+                   value="@SelectedSystemText"
+                   @onchange="HandleSystemTextChanged" />
+            <datalist id="sector-system-options">
+                @foreach (var system in Systems)
+                {
+                    <option value="@FormatSystemOption(system)" />
+                }
+            </datalist>
+        </label>
+
+        <div class="archive-search">
+            <label for="archive-search-input">Archive search</label>
+            <input id="archive-search-input"
+                   placeholder="System, world, colony, race, empire..."
+                   value="@SearchQuery"
+                   @oninput="HandleSearchQueryInput" />
+
+            @if (SearchResults.Count > 0)
+            {
+                <div class="search-results">
+                    @foreach (var result in SearchResults)
+                    {
+                        <button type="button" class="search-result" @onclick="() => SearchResultSelected.InvokeAsync(result)">
+                            <span>@DisplayResultType(result.Type)</span>
+                            <strong>@result.Title</strong>
+                            <small>@result.Subtitle</small>
+                        </button>
+                    }
+                </div>
+            }
+            else if (!string.IsNullOrWhiteSpace(SearchQuery))
+            {
+                <p class="search-empty">No matching systems, worlds, races, colonies, empires, habitats, or history.</p>
+            }
+        </div>
     </div>
 
-    <ExplorerSectionTabs Sections="Sections"
-                         ActiveSection="@ActiveSection"
-                         IsLoading="@IsLoading"
-                         LoadingTarget="@LoadingTarget"
-                         LoadingStatus="@LoadingStatus"
-                         SectionHrefFactory="SectionHrefFactory" />
+    <div class="control-strip-tabs">
+        <ExplorerSectionTabs Sections="Sections"
+                             ActiveSection="@ActiveSection"
+                             IsLoading="@IsLoading"
+                             LoadingTarget="@LoadingTarget"
+                             LoadingStatus="@LoadingStatus"
+                             SectionHrefFactory="SectionHrefFactory" />
+    </div>
 </section>
 
 @if (!string.IsNullOrWhiteSpace(ErrorMessage))

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -304,9 +304,9 @@ dd {
 
 .control-strip {
     display: grid;
-    grid-template-columns: minmax(0, 1.9fr) minmax(320px, 1.15fr);
+    grid-template-columns: minmax(0, 1fr);
     gap: 14px 18px;
-    align-items: end;
+    align-items: stretch;
     border: 1px solid var(--line);
     border-radius: 8px;
     background: var(--surface);
@@ -316,18 +316,19 @@ dd {
 
 .control-strip-fields {
     display: grid;
-    grid-template-columns: minmax(160px, 220px) minmax(220px, 360px) minmax(260px, 420px);
+    grid-template-columns: minmax(160px, 180px) minmax(220px, 260px) minmax(240px, 1fr);
     gap: 14px;
     align-items: end;
     min-width: 0;
 }
 
 .control-strip-tabs {
+    order: -1;
     min-width: 0;
 }
 
 .control-strip-tabs .section-tabs {
-    justify-content: flex-end;
+    justify-content: flex-start;
 }
 
 .control-strip label,
@@ -377,26 +378,18 @@ dd {
     box-shadow: 0 0 18px rgba(56, 189, 248, 0.18);
 }
 
-@media (max-width: 1280px) {
+@media (min-width: 1900px) {
     .control-strip {
-        grid-template-columns: 1fr;
-        align-items: stretch;
-    }
-
-    .control-strip-fields {
-        grid-template-columns: minmax(180px, 240px) minmax(220px, 1fr);
-    }
-
-    .control-strip-fields .archive-search {
-        grid-column: 1 / -1;
+        grid-template-columns: minmax(0, 760px) minmax(0, 1fr);
+        align-items: end;
     }
 
     .control-strip-tabs {
-        order: -1;
+        order: 0;
     }
 
     .control-strip-tabs .section-tabs {
-        justify-content: flex-start;
+        justify-content: flex-end;
     }
 }
 

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -379,22 +379,22 @@ dd {
 
 @media (min-width: 1900px) {
     .control-strip {
-        grid-template-columns: minmax(0, 760px) minmax(0, 1fr);
+        grid-template-columns: minmax(0, 1fr) minmax(0, 760px);
         align-items: end;
     }
 
     .control-strip-tabs {
-        grid-column: 2;
-        grid-row: 1;
-    }
-
-    .control-strip-fields {
         grid-column: 1;
         grid-row: 1;
     }
 
+    .control-strip-fields {
+        grid-column: 2;
+        grid-row: 1;
+    }
+
     .control-strip-tabs .section-tabs {
-        justify-content: flex-end;
+        justify-content: flex-start;
     }
 }
 

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -304,14 +304,30 @@ dd {
 
 .control-strip {
     display: grid;
-    grid-template-columns: minmax(180px, 240px) minmax(260px, 420px) minmax(260px, 460px) 1fr;
-    gap: 14px;
+    grid-template-columns: minmax(0, 1.9fr) minmax(320px, 1.15fr);
+    gap: 14px 18px;
     align-items: end;
     border: 1px solid var(--line);
     border-radius: 8px;
     background: var(--surface);
     padding: 14px;
     box-shadow: var(--shadow);
+}
+
+.control-strip-fields {
+    display: grid;
+    grid-template-columns: minmax(160px, 220px) minmax(220px, 360px) minmax(260px, 420px);
+    gap: 14px;
+    align-items: end;
+    min-width: 0;
+}
+
+.control-strip-tabs {
+    min-width: 0;
+}
+
+.control-strip-tabs .section-tabs {
+    justify-content: flex-end;
 }
 
 .control-strip label,
@@ -359,6 +375,39 @@ dd {
     background: linear-gradient(135deg, rgba(14, 165, 233, 0.34), rgba(124, 58, 237, 0.24));
     color: #f8fbff;
     box-shadow: 0 0 18px rgba(56, 189, 248, 0.18);
+}
+
+@media (max-width: 1280px) {
+    .control-strip {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+    }
+
+    .control-strip-fields {
+        grid-template-columns: minmax(180px, 240px) minmax(220px, 1fr);
+    }
+
+    .control-strip-fields .archive-search {
+        grid-column: 1 / -1;
+    }
+
+    .control-strip-tabs {
+        order: -1;
+    }
+
+    .control-strip-tabs .section-tabs {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 900px) {
+    .control-strip-fields {
+        grid-template-columns: 1fr;
+    }
+
+    .control-strip-fields .archive-search {
+        grid-column: auto;
+    }
 }
 
 .loading-modal-backdrop {
@@ -4375,7 +4424,6 @@ dd {
 @media (max-width: 1100px) {
     .explorer-hero,
     .about-grid,
-    .control-strip,
     .overview-layout,
     .timeline-layout,
     .hyperlane-layout,

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -323,7 +323,6 @@ dd {
 }
 
 .control-strip-tabs {
-    order: -1;
     min-width: 0;
 }
 
@@ -385,7 +384,13 @@ dd {
     }
 
     .control-strip-tabs {
-        order: 0;
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .control-strip-fields {
+        grid-column: 1;
+        grid-row: 1;
     }
 
     .control-strip-tabs .section-tabs {


### PR DESCRIPTION
Affected issues
- #71 Explorer control strip should prioritize horizontal tabs and move sector/system/search below on smaller screens

Summary
- Refactored the shared Explorer shell so the section tabs and the sector/system/archive controls can reflow independently.
- Updated the control-strip CSS so the tab-first stacked layout is the default and only switches back to a split desktop layout once the viewport is wide enough to keep the full tab set on one row.
- Added regression coverage for the shared shell structure and the responsive breakpoint behavior.

Why
- The previous split layout handed too little width to the tabs at normal desktop widths, so they wrapped into multiple rows even when the overall page still had plenty of space.
- This change keeps the tabs visually prioritized and moves the secondary controls underneath them until there is truly enough width for both areas to coexist without wrapping.

Validation
- dotnet test StarWin.Web.Tests\StarWin.Web.Tests.csproj
- Verified the live Explorer layout on the issue branch at the previously failing desktop widths and confirmed the tab row stays on one line.