### PR TITLE
Add null-argument unit coverage for SpaceHabitat construction

### DIFF
--- a/StarWin.Domain.Tests/Services/SpaceHabitatConstructionServiceTests.cs
+++ b/StarWin.Domain.Tests/Services/SpaceHabitatConstructionServiceTests.cs
@@ -37,4 +37,15 @@ public sealed class SpaceHabitatConstructionServiceTests
         Assert.Equal(OrbitTargetKind.World, habitat.OrbitTargetKind);
         Assert.Equal(3401, habitat.OrbitTargetId);
     }
+
+    [Fact]
+    public void BuildOrbitingWorld_WithNullBuilder_ThrowsArgumentNullException()
+    {
+        var service = new SpaceHabitatConstructionService();
+        var world = new World { Id = 3401 };
+
+        var error = Assert.Throws<ArgumentNullException>(() => service.BuildOrbitingWorld(null!, world, "Null Builder"));
+
+        Assert.Equal("builder", error.ParamName);
+    }
 }


### PR DESCRIPTION
## Coverage gap
`SpaceHabitatConstructionService` had happy-path tests for target selection but did not validate its `ArgumentNullException` guard clauses.

## Added test
- Added a focused unit test to verify `BuildOrbitingWorld` throws `ArgumentNullException` when `builder` is null.
- Asserted the exception parameter name is `builder` to ensure the correct guard is exercised.

## Command run
- `dotnet test StarWin.Domain.Tests/StarWin.Domain.Tests.csproj --filter FullyQualifiedName~SpaceHabitatConstructionServiceTests`

Closes #113 (issue remains open per project workflow.)