### PR TITLE
115 Add null-argument tests for WorldControlService

### DIFF
--- a/StarWin.Domain.Tests/Services/WorldControlServiceTests.cs
+++ b/StarWin.Domain.Tests/Services/WorldControlServiceTests.cs
@@ -68,4 +68,15 @@ public sealed class WorldControlServiceTests
         Assert.Null(world.Colony.ControllingEmpireId);
         Assert.Equal(ColonyPoliticalStatus.Independent, world.Colony.PoliticalStatus);
     }
+
+    [Fact]
+    public void TransferControl_WithNullWorld_ThrowsArgumentNullException()
+    {
+        var service = new WorldControlService();
+        var empire = new Empire { Id = 42 };
+
+        var error = Assert.Throws<ArgumentNullException>(() => service.TransferControl(null!, empire));
+
+        Assert.Equal("world", error.ParamName);
+    }
 }


### PR DESCRIPTION
## Coverage gap
`WorldControlService` guards null inputs in `TransferControl` and `ClearControl`, but the current unit coverage does not validate the null-guard paths.

## Behavior validated
- Adds a focused unit test ensuring `TransferControl(null, controllingEmpire)` throws `ArgumentNullException`.
- Verifies the argument name is `world`.

## Test command
- `dotnet test StarWin.Domain.Tests/StarWin.Domain.Tests.csproj --filter FullyQualifiedName~WorldControlServiceTests`

## Changelog
- Added `TransferControl_WithNullWorld_ThrowsArgumentNullException` to `StarWin.Domain.Tests/Services/WorldControlServiceTests.cs`.