### PR TITLE
Codex - #75 3D sector map keyboard controls should support combined rotation input and plus/minus zoom

### DIFF
--- a/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
+++ b/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
@@ -26,4 +26,37 @@ public sealed class SectorMap3dScriptTests
         Assert.Contains("return selected ? 1.44 : 1.08;", script);
         Assert.Contains("const radius = (0.34 + Math.min(0.76, Math.max(0.18, scale) * 0.34)) * 2;", script);
     }
+
+    [Fact]
+    public void KeyboardNavigationTracksHeldKeysAndCancelsConflicts()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "js", "sectorMap3d.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("activeKeys: new Set()", script);
+        Assert.Contains("canvas.addEventListener(\"keyup\", event => handleKeyUp(state, event));", script);
+        Assert.Contains("canvas.addEventListener(\"blur\", () => clearActiveKeys(state));", script);
+        Assert.Contains("const yawDirection = getAxisDirection(state.activeKeys, [\"a\"], [\"d\"]);", script);
+        Assert.Contains("const pitchDirection = getAxisDirection(state.activeKeys, [\"w\"], [\"s\"]);", script);
+        Assert.Contains("const rollDirection = getAxisDirection(state.activeKeys, [\"e\"], [\"q\"]);", script);
+        Assert.Contains("if (negativeActive === positiveActive) {", script);
+    }
+
+    [Fact]
+    public void KeyboardNavigationSupportsZoomAndArrowKeyPanning()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "js", "sectorMap3d.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("case \"add\":", script);
+        Assert.Contains("case \"subtract\":", script);
+        Assert.Contains("const zoomDirection = getAxisDirection(state.activeKeys, [\"-\"], [\"+\"]);", script);
+        Assert.Contains("const panHorizontalDirection = getAxisDirection(state.activeKeys, [\"arrowleft\"], [\"arrowright\"]);", script);
+        Assert.Contains("const panVerticalDirection = getAxisDirection(state.activeKeys, [\"arrowdown\"], [\"arrowup\"]);", script);
+        Assert.Contains("state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius + radiusDelta));", script);
+        Assert.Contains("state.target.addScaledVector(right, horizontalDelta);", script);
+        Assert.Contains("state.target.addScaledVector(up, verticalDelta);", script);
+    }
 }

--- a/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
+++ b/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
@@ -44,6 +44,20 @@ public sealed class SectorMap3dScriptTests
     }
 
     [Fact]
+    public void KeyboardNavigationUsesRollAwareCameraAxes()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "js", "sectorMap3d.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("const { up: cameraUp, right } = getCameraAxes(state);", script);
+        Assert.Contains("const { right, up } = getCameraAxes(state);", script);
+        Assert.Contains("if (state.roll) {", script);
+        Assert.Contains("up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));", script);
+        Assert.Contains("state.camera.up.copy(up);", script);
+    }
+
+    [Fact]
     public void KeyboardNavigationSupportsZoomAndArrowKeyPanning()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));

--- a/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
+++ b/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
@@ -53,7 +53,7 @@ public sealed class SectorMap3dScriptTests
         Assert.Contains("const { up: cameraUp, right } = getCameraAxes(state);", script);
         Assert.Contains("const { right, up } = getCameraAxes(state);", script);
         Assert.Contains("if (state.roll) {", script);
-        Assert.Contains("up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));", script);
+        Assert.Contains("up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(offset.clone().normalize(), state.roll));", script);
         Assert.Contains("state.camera.up.copy(up);", script);
     }
 
@@ -72,5 +72,6 @@ public sealed class SectorMap3dScriptTests
         Assert.Contains("state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius + radiusDelta));", script);
         Assert.Contains("state.target.addScaledVector(right, horizontalDelta);", script);
         Assert.Contains("state.target.addScaledVector(up, verticalDelta);", script);
+        Assert.Contains("Math.min(2, Math.max(0, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds))", script);
     }
 }

--- a/StarWin.Web/wwwroot/js/sectorMap3d.js
+++ b/StarWin.Web/wwwroot/js/sectorMap3d.js
@@ -1039,31 +1039,22 @@ function panCameraTarget(state, horizontalDelta, verticalDelta) {
         return;
     }
 
-    const forward = new state.THREE.Vector3().subVectors(state.target, state.camera.position).normalize();
-    const right = new state.THREE.Vector3().crossVectors(forward, state.camera.up).normalize();
-    const up = new state.THREE.Vector3().crossVectors(right, forward).normalize();
+    const { right, up } = getCameraAxes(state);
 
     state.target.addScaledVector(right, horizontalDelta);
     state.target.addScaledVector(up, verticalDelta);
 }
 
 function updateCamera(state) {
-    const offset = state.baseCameraOffset.clone().setLength(state.radius).applyQuaternion(state.orbitRotation);
-    const up = new state.THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
+    const { offset, up } = getCameraAxes(state);
     state.camera.position.copy(state.target).add(offset);
     state.camera.up.copy(up);
     state.camera.lookAt(state.target);
-    if (state.roll) {
-        state.camera.rotateZ(state.roll);
-    }
 }
 
 function rotateCameraOffset(state, yawDelta, pitchDelta) {
     const THREE = state.THREE;
-    const offset = state.baseCameraOffset.clone().applyQuaternion(state.orbitRotation).normalize();
-    const cameraUp = new THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
-    const forward = offset.clone().multiplyScalar(-1).normalize();
-    const right = new THREE.Vector3().crossVectors(forward, cameraUp).normalize();
+    const { up: cameraUp, right } = getCameraAxes(state);
 
     if (Math.abs(yawDelta) > 0) {
         state.orbitRotation.premultiply(new THREE.Quaternion().setFromAxisAngle(cameraUp, yawDelta));
@@ -1072,6 +1063,21 @@ function rotateCameraOffset(state, yawDelta, pitchDelta) {
     if (Math.abs(pitchDelta) > 0) {
         state.orbitRotation.premultiply(new THREE.Quaternion().setFromAxisAngle(right, pitchDelta));
     }
+}
+
+function getCameraAxes(state) {
+    const THREE = state.THREE;
+    const offset = state.baseCameraOffset.clone().setLength(state.radius).applyQuaternion(state.orbitRotation);
+    const forward = offset.clone().normalize().multiplyScalar(-1);
+    let up = new THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
+
+    if (state.roll) {
+        up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));
+    }
+
+    const right = new THREE.Vector3().crossVectors(forward, up).normalize();
+    up = new THREE.Vector3().crossVectors(right, forward).normalize();
+    return { offset, forward, up, right };
 }
 
 function resize(state) {

--- a/StarWin.Web/wwwroot/js/sectorMap3d.js
+++ b/StarWin.Web/wwwroot/js/sectorMap3d.js
@@ -8,6 +8,9 @@ const slowFrameRatio = 0.32;
 const minimumAdaptiveSystemLimit = 150;
 const compactSystemScale = 0.38;
 const systemCoordinateScale = 8;
+const minimumCameraRadius = 26;
+const maximumCameraRadius = 220;
+const keyboardFrameMilliseconds = 1000 / 60;
 
 async function loadThree() {
     if (!threePromise) {
@@ -131,7 +134,9 @@ function createMap(host, THREE) {
         orbitRotation: new THREE.Quaternion(),
         radius: 116,
         roll: 0,
-        drag: null
+        drag: null,
+        activeKeys: new Set(),
+        lastAnimationTimestamp: 0
     };
 
     canvas.addEventListener("pointerdown", event => {
@@ -154,6 +159,8 @@ function createMap(host, THREE) {
     canvas.addEventListener("pointerup", event => handlePointerUp(state, event));
     canvas.addEventListener("wheel", event => handleWheel(state, event), { passive: false });
     canvas.addEventListener("keydown", event => handleKeyDown(state, event));
+    canvas.addEventListener("keyup", event => handleKeyUp(state, event));
+    canvas.addEventListener("blur", () => clearActiveKeys(state));
     canvas.addEventListener("contextmenu", event => event.preventDefault());
     updateCamera(state);
     animate(state);
@@ -911,7 +918,7 @@ function disposeLabelSprite(label) {
 function handleWheel(state, event) {
     event.preventDefault();
     const direction = event.deltaY > 0 ? 1 : -1;
-    state.radius = Math.max(26, Math.min(220, state.radius * (1 + direction * 0.12)));
+    state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius * (1 + direction * 0.12)));
     updateCamera(state);
 }
 
@@ -920,40 +927,124 @@ function handleKeyDown(state, event) {
         return;
     }
 
-    const key = event.key.toLowerCase();
-    const rotationStep = event.shiftKey ? 0.16 : 0.08;
-    let handled = true;
-
-    switch (key) {
-        case "a":
-            rotateCameraOffset(state, -rotationStep, 0);
-            break;
-        case "d":
-            rotateCameraOffset(state, rotationStep, 0);
-            break;
-        case "w":
-            rotateCameraOffset(state, 0, -rotationStep);
-            break;
-        case "s":
-            rotateCameraOffset(state, 0, rotationStep);
-            break;
-        case "q":
-            state.roll += rotationStep;
-            break;
-        case "e":
-            state.roll -= rotationStep;
-            break;
-        default:
-            handled = false;
-            break;
-    }
-
-    if (!handled) {
+    const key = normalizeKeyboardNavigationKey(event.key);
+    if (!isKeyboardNavigationKey(key)) {
         return;
     }
 
+    state.activeKeys.add(key);
     event.preventDefault();
-    updateCamera(state);
+}
+
+function handleKeyUp(state, event) {
+    const key = normalizeKeyboardNavigationKey(event.key);
+    if (!isKeyboardNavigationKey(key)) {
+        return;
+    }
+
+    state.activeKeys.delete(key);
+    event.preventDefault();
+}
+
+function clearActiveKeys(state) {
+    state.activeKeys.clear();
+}
+
+function normalizeKeyboardNavigationKey(key) {
+    const normalizedKey = key.toLowerCase();
+    switch (normalizedKey) {
+        case "=":
+        case "+":
+        case "add":
+            return "+";
+        case "_":
+        case "-":
+        case "subtract":
+            return "-";
+        default:
+            return normalizedKey;
+    }
+}
+
+function isKeyboardNavigationKey(key) {
+    return [
+        "a",
+        "d",
+        "w",
+        "s",
+        "q",
+        "e",
+        "+",
+        "-",
+        "arrowup",
+        "arrowdown",
+        "arrowleft",
+        "arrowright",
+        "shift"
+    ].includes(key);
+}
+
+function applyKeyboardNavigation(state, frameScale) {
+    if (!state.activeKeys.size) {
+        return false;
+    }
+
+    const speedMultiplier = state.activeKeys.has("shift") ? 2 : 1;
+    const rotationStep = 0.032 * speedMultiplier * frameScale;
+    const panStep = state.radius * 0.012 * speedMultiplier * frameScale;
+    const zoomStep = state.radius * 0.022 * speedMultiplier * frameScale;
+    const yawDirection = getAxisDirection(state.activeKeys, ["a"], ["d"]);
+    const pitchDirection = getAxisDirection(state.activeKeys, ["w"], ["s"]);
+    const rollDirection = getAxisDirection(state.activeKeys, ["e"], ["q"]);
+    const zoomDirection = getAxisDirection(state.activeKeys, ["-"], ["+"]);
+    const panHorizontalDirection = getAxisDirection(state.activeKeys, ["arrowleft"], ["arrowright"]);
+    const panVerticalDirection = getAxisDirection(state.activeKeys, ["arrowdown"], ["arrowup"]);
+
+    if (yawDirection === 0
+        && pitchDirection === 0
+        && rollDirection === 0
+        && zoomDirection === 0
+        && panHorizontalDirection === 0
+        && panVerticalDirection === 0) {
+        return false;
+    }
+
+    rotateCameraOffset(state, yawDirection * rotationStep, pitchDirection * rotationStep);
+    state.roll += rollDirection * rotationStep;
+    adjustCameraRadius(state, -zoomDirection * zoomStep);
+    panCameraTarget(state, panHorizontalDirection * panStep, panVerticalDirection * panStep);
+    return true;
+}
+
+function getAxisDirection(activeKeys, negativeKeys, positiveKeys) {
+    const negativeActive = negativeKeys.some(key => activeKeys.has(key));
+    const positiveActive = positiveKeys.some(key => activeKeys.has(key));
+    if (negativeActive === positiveActive) {
+        return 0;
+    }
+
+    return positiveActive ? 1 : -1;
+}
+
+function adjustCameraRadius(state, radiusDelta) {
+    if (radiusDelta === 0) {
+        return;
+    }
+
+    state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius + radiusDelta));
+}
+
+function panCameraTarget(state, horizontalDelta, verticalDelta) {
+    if (horizontalDelta === 0 && verticalDelta === 0) {
+        return;
+    }
+
+    const forward = new state.THREE.Vector3().subVectors(state.target, state.camera.position).normalize();
+    const right = new state.THREE.Vector3().crossVectors(forward, state.camera.up).normalize();
+    const up = new state.THREE.Vector3().crossVectors(right, forward).normalize();
+
+    state.target.addScaledVector(right, horizontalDelta);
+    state.target.addScaledVector(up, verticalDelta);
 }
 
 function updateCamera(state) {
@@ -997,6 +1088,15 @@ function resize(state) {
 
 function animate(state, timestamp = performance.now()) {
     state.animationFrame = requestAnimationFrame(nextTimestamp => animate(state, nextTimestamp));
+    const frameScale = state.lastAnimationTimestamp === 0
+        ? 1
+        : Math.min(2, Math.max(0.5, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds));
+    state.lastAnimationTimestamp = timestamp;
+
+    if (applyKeyboardNavigation(state, frameScale)) {
+        updateCamera(state);
+    }
+
     trackMapPerformance(state, timestamp);
     faceImageMarkers(state);
     state.renderer.render(state.scene, state.camera);

--- a/StarWin.Web/wwwroot/js/sectorMap3d.js
+++ b/StarWin.Web/wwwroot/js/sectorMap3d.js
@@ -1072,7 +1072,7 @@ function getCameraAxes(state) {
     let up = new THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
 
     if (state.roll) {
-        up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));
+        up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(offset.clone().normalize(), state.roll));
     }
 
     const right = new THREE.Vector3().crossVectors(forward, up).normalize();
@@ -1096,7 +1096,7 @@ function animate(state, timestamp = performance.now()) {
     state.animationFrame = requestAnimationFrame(nextTimestamp => animate(state, nextTimestamp));
     const frameScale = state.lastAnimationTimestamp === 0
         ? 1
-        : Math.min(2, Math.max(0.5, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds));
+        : Math.min(2, Math.max(0, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds));
     state.lastAnimationTimestamp = timestamp;
 
     if (applyKeyboardNavigation(state, frameScale)) {


### PR DESCRIPTION
Addresses #75

## Summary
- rework the 3D sector map keyboard input to track held keys in the animation loop
- add combined WASD/QE rotation with axis cancellation, plus/minus zoom, and arrow-key panning
- make the WASD rotation and keyboard panning axes follow the current camera roll after Q/E rotation
- add script coverage for held-key navigation, zoom and panning, and roll-aware camera axes

## Root cause
The map keyboard controls were handled as isolated keydown nudges, and the yaw/pitch basis continued to use the unrolled orbit orientation even after camera roll was applied separately.

## Validation
- `dotnet test .\StarWin.Web.Tests\StarWin.Web.Tests.csproj --no-restore`
- `dotnet test .\StarWin.Web.Tests\StarWin.Web.Tests.csproj --filter FullyQualifiedName~SectorMap3dScriptTests --no-restore`
- manual verification in the browser on `http://127.0.0.1:10075/`