### PR TITLE
Codex - Promote dev to master for 2026-07-07.0 Developer Preview

### DIFF
--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -200,7 +200,11 @@ public sealed record ExplorerAlienRaceDetail(
     IReadOnlyList<StarWin.Domain.Model.Entity.Civilization.Empire> Empires);
 
 public sealed record ExplorerEmpireFilterOptions(
-    IReadOnlyList<ExplorerLookupOption> Races);
+    IReadOnlyList<ExplorerLookupOption> Races,
+    int MaxControlledWorldCount = 1,
+    long MaxNativePopulationMillions = 1,
+    int MaxGurpsTechLevel = 1,
+    int MaxStarWinTechLevel = 1);
 
 public enum ExplorerEmpireStatusFilter
 {

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -202,13 +202,42 @@ public sealed record ExplorerAlienRaceDetail(
 public sealed record ExplorerEmpireFilterOptions(
     IReadOnlyList<ExplorerLookupOption> Races);
 
+public enum ExplorerEmpireStatusFilter
+{
+    Both = 0,
+    Active = 1,
+    Fallen = 2
+}
+
+public enum ExplorerEmpireTechLevelSystem
+{
+    Gurps = 0,
+    StarWin = 1
+}
+
+public enum ExplorerEmpireSortOption
+{
+    Alphabetical = 0,
+    Population = 1,
+    ControlledWorlds = 2,
+    EconomicPower = 3
+}
+
 public sealed record ExplorerEmpireListPageRequest(
     int SectorId,
     int Offset,
     int Limit,
     string? Query = null,
     int? RaceId = null,
-    bool FallenOnly = false);
+    ExplorerEmpireStatusFilter StatusFilter = ExplorerEmpireStatusFilter.Both,
+    int? MinControlledWorldCount = null,
+    int? MaxControlledWorldCount = null,
+    long? MinNativePopulationMillions = null,
+    long? MaxNativePopulationMillions = null,
+    ExplorerEmpireTechLevelSystem TechLevelSystem = ExplorerEmpireTechLevelSystem.Gurps,
+    int? MinTechLevel = null,
+    int? MaxTechLevel = null,
+    ExplorerEmpireSortOption SortOption = ExplorerEmpireSortOption.Alphabetical);
 
 public sealed record ExplorerEmpireListPage(
     IReadOnlyList<ExplorerEmpireListItem> Items,
@@ -220,6 +249,9 @@ public sealed record ExplorerEmpireListItem(
     int ControlledWorldCount,
     int TrackedWorldCount,
     int GurpsTechLevel,
+    int StarWinTechLevel,
+    long NativePopulationMillions,
+    long EconomicPowerMcr,
     bool IsFallen);
 
 public sealed record ExplorerEmpireDetail(

--- a/StarWin.Application/Services/IStarWinExplorerQueryService.cs
+++ b/StarWin.Application/Services/IStarWinExplorerQueryService.cs
@@ -147,7 +147,10 @@ public sealed record ExplorerSectorConfigurationState(
     StarWin.Domain.Model.Entity.StarMap.SectorConfiguration Configuration,
     int SavedRouteCount,
     StarWin.Domain.Services.SectorHyperlaneNetworkReport SavedRouteReport,
-    int SelectedSystemRouteCount);
+    int SelectedSystemRouteCount,
+    DateTime? SectorEmpireStatsCalculatedAtUtc = null,
+    DateTime? SectorEmpireStatsInvalidatedAtUtc = null,
+    int SectorEmpireStatsEmpireCount = 0);
 
 public sealed record ExplorerHyperlanePageState(
     int SectorId,

--- a/StarWin.Application/Services/IStarWinSectorEmpireStatsService.cs
+++ b/StarWin.Application/Services/IStarWinSectorEmpireStatsService.cs
@@ -1,0 +1,29 @@
+namespace StarWin.Application.Services;
+
+public interface IStarWinSectorEmpireStatsService
+{
+    Task<SectorEmpireStatsRefreshResult> RebuildSectorStatsAsync(
+        int sectorId,
+        CancellationToken cancellationToken = default);
+
+    Task<SectorEmpireStatRefreshResult?> RefreshEmpireStatsAsync(
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken = default);
+
+    Task MarkSectorStatsStaleAsync(
+        int sectorId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record SectorEmpireStatsRefreshResult(
+    int SectorId,
+    int EmpireCount,
+    DateTime CalculatedAtUtc);
+
+public sealed record SectorEmpireStatRefreshResult(
+    int SectorId,
+    int EmpireId,
+    int ControlledWorldCount,
+    int TrackedWorldCount,
+    DateTime CalculatedAtUtc);

--- a/StarWin.Desktop/StarWin.Desktop.csproj
+++ b/StarWin.Desktop/StarWin.Desktop.csproj
@@ -31,10 +31,10 @@
     <AssemblyTitle>Starforged Atlas Desktop</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
-    <AssemblyVersion>2026.4.28.0</AssemblyVersion>
-    <FileVersion>2026.4.28.0</FileVersion>
-    <Version>2026.4.28.0</Version>
-    <InformationalVersion>2026-04-28.0-developer-preview</InformationalVersion>
+    <AssemblyVersion>2026.7.7.0</AssemblyVersion>
+    <FileVersion>2026.7.7.0</FileVersion>
+    <Version>2026.7.7.0</Version>
+    <InformationalVersion>2026-07-07.0-developer-preview</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/StarWin.Desktop/StarWin.Desktop.csproj
+++ b/StarWin.Desktop/StarWin.Desktop.csproj
@@ -31,10 +31,10 @@
     <AssemblyTitle>Starforged Atlas Desktop</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
-    <AssemblyVersion>2026.4.30.0</AssemblyVersion>
-    <FileVersion>2026.4.30.0</FileVersion>
-    <Version>2026.4.30.0</Version>
-    <InformationalVersion>2026-04-30.0-developer-preview</InformationalVersion>
+    <AssemblyVersion>2026.4.28.0</AssemblyVersion>
+    <FileVersion>2026.4.28.0</FileVersion>
+    <Version>2026.4.28.0</Version>
+    <InformationalVersion>2026-04-28.0-developer-preview</InformationalVersion>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/StarWin.Domain.Tests/Services/SpaceHabitatConstructionServiceTests.cs
+++ b/StarWin.Domain.Tests/Services/SpaceHabitatConstructionServiceTests.cs
@@ -37,4 +37,15 @@ public sealed class SpaceHabitatConstructionServiceTests
         Assert.Equal(OrbitTargetKind.World, habitat.OrbitTargetKind);
         Assert.Equal(3401, habitat.OrbitTargetId);
     }
+
+    [Fact]
+    public void BuildOrbitingWorld_WithNullBuilder_ThrowsArgumentNullException()
+    {
+        var service = new SpaceHabitatConstructionService();
+        var world = new World { Id = 3401 };
+
+        var error = Assert.Throws<ArgumentNullException>(() => service.BuildOrbitingWorld(null!, world, "Null Builder"));
+
+        Assert.Equal("builder", error.ParamName);
+    }
 }

--- a/StarWin.Domain.Tests/Services/WorldControlServiceTests.cs
+++ b/StarWin.Domain.Tests/Services/WorldControlServiceTests.cs
@@ -68,4 +68,15 @@ public sealed class WorldControlServiceTests
         Assert.Null(world.Colony.ControllingEmpireId);
         Assert.Equal(ColonyPoliticalStatus.Independent, world.Colony.PoliticalStatus);
     }
+
+    [Fact]
+    public void TransferControl_WithNullWorld_ThrowsArgumentNullException()
+    {
+        var service = new WorldControlService();
+        var empire = new Empire { Id = 42 };
+
+        var error = Assert.Throws<ArgumentNullException>(() => service.TransferControl(null!, empire));
+
+        Assert.Equal("world", error.ParamName);
+    }
 }

--- a/StarWin.Domain/Model/Entity/Civilization/SectorEmpireStat.cs
+++ b/StarWin.Domain/Model/Entity/Civilization/SectorEmpireStat.cs
@@ -1,0 +1,14 @@
+namespace StarWin.Domain.Model.Entity.Civilization;
+
+public sealed class SectorEmpireStat
+{
+    public int SectorId { get; set; }
+
+    public int EmpireId { get; set; }
+
+    public int ControlledWorldCount { get; set; }
+
+    public int TrackedWorldCount { get; set; }
+
+    public DateTime LastCalculatedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/StarWin.Domain/Model/Entity/StarMap/SectorConfiguration.cs
+++ b/StarWin.Domain/Model/Entity/StarMap/SectorConfiguration.cs
@@ -50,5 +50,9 @@ public sealed class SectorConfiguration
 
     public decimal Tl10HyperlaneSpeedModifier { get; set; } = 3m;
 
+    public DateTime? SectorEmpireStatsCalculatedAtUtc { get; set; }
+
+    public DateTime? SectorEmpireStatsInvalidatedAtUtc { get; set; }
+
     public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
 }

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -327,6 +328,23 @@ public sealed class StarWinExplorerQueryServiceTests
         {
             DeleteIfExists(databasePath);
         }
+    }
+
+    [Fact]
+    public void BuildEmpireListSql_uses_provider_appropriate_paging_and_sort_syntax()
+    {
+        var request = new ExplorerEmpireListPageRequest(1, 0, 30, SortOption: ExplorerEmpireSortOption.Alphabetical);
+
+        var sqliteSql = BuildEmpireListSqlForProvider(request, "Microsoft.EntityFrameworkCore.Sqlite");
+        Assert.Contains("COLLATE NOCASE", sqliteSql.Format);
+        Assert.Contains("LIMIT {15}", sqliteSql.Format);
+        Assert.Contains("OFFSET {16}", sqliteSql.Format);
+        Assert.DoesNotContain("FETCH NEXT", sqliteSql.Format);
+
+        var sqlServerSql = BuildEmpireListSqlForProvider(request, "Microsoft.EntityFrameworkCore.SqlServer");
+        Assert.DoesNotContain("COLLATE NOCASE", sqlServerSql.Format);
+        Assert.Contains("OFFSET {16} ROWS FETCH NEXT {15} ROWS ONLY", sqlServerSql.Format);
+        Assert.DoesNotContain("LIMIT {15}", sqlServerSql.Format);
     }
 
     [Fact]
@@ -930,6 +948,17 @@ public sealed class StarWinExplorerQueryServiceTests
             });
 
         await dbContext.SaveChangesAsync();
+    }
+
+    private static FormattableString BuildEmpireListSqlForProvider(ExplorerEmpireListPageRequest request, string providerName)
+    {
+        var method = typeof(StarWinExplorerQueryService).GetMethod(
+            "BuildEmpireListSql",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        return Assert.IsAssignableFrom<FormattableString>(method!.Invoke(null, [request, null, 31, 0, providerName]));
     }
 
     private static IDbContextFactory<StarWinDbContext> CreateFactory(string databasePath)

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -544,6 +544,46 @@ public sealed class StarWinExplorerQueryServiceTests
     }
 
     [Fact]
+    public async Task LoadEmpireListPageAsync_only_attempts_timeout_recovery_once()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var seedContext = CreateDbContext(databasePath);
+            await seedContext.Database.EnsureCreatedAsync();
+            await SeedExplorerDataAsync(seedContext);
+
+            var configuration = await seedContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
+            configuration.SectorEmpireStatsInvalidatedAtUtc = DateTime.UtcNow;
+            await seedContext.SaveChangesAsync();
+
+            var interceptor = new ThrowTimeoutOnReaderInvocationInterceptor(readerInvocationNumber: 2);
+
+            var service = new StarWinExplorerQueryService(CreateFactory(databasePath, interceptor));
+            var method = typeof(StarWinExplorerQueryService).GetMethod(
+                "LoadEmpireListPageCoreAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var invocation = Assert.IsType<Task<ExplorerEmpireListPage>>(method!.Invoke(service, [
+                new ExplorerEmpireListPageRequest(1, 0, 30, Query: "Concord"),
+                1,
+                CancellationToken.None])!);
+
+            await Assert.ThrowsAsync<TimeoutException>(async () => await invocation);
+
+            await using var verificationContext = CreateDbContext(databasePath);
+            var refreshedConfiguration = await verificationContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
+            Assert.NotNull(refreshedConfiguration.SectorEmpireStatsInvalidatedAtUtc);
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
     public async Task LoadEmpireDetailAsync_orders_member_races_by_population_descending()
     {
         var databasePath = CreateTempFilePath(".db");
@@ -1148,4 +1188,5 @@ public sealed class StarWinExplorerQueryServiceTests
             return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
         }
     }
+
 }

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -466,6 +466,43 @@ public sealed class StarWinExplorerQueryServiceTests
     }
 
     [Fact]
+    public async Task LoadEmpireDetailAsync_refreshes_missing_sector_empire_stat_row_when_cache_is_stale()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var seedContext = CreateDbContext(databasePath);
+            await seedContext.Database.EnsureCreatedAsync();
+            await SeedExplorerDataAsync(seedContext);
+
+            var configuration = await seedContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
+            configuration.SectorEmpireStatsInvalidatedAtUtc = DateTime.UtcNow.AddMinutes(5);
+            var staleRow = await seedContext.Set<SectorEmpireStat>().SingleAsync(item => item.SectorId == 1 && item.EmpireId == 201);
+            seedContext.Remove(staleRow);
+            await seedContext.SaveChangesAsync();
+
+            var service = new StarWinExplorerQueryService(CreateFactory(databasePath));
+
+            var detail = await service.LoadEmpireDetailAsync(1, 201);
+
+            Assert.NotNull(detail);
+
+            await using var verificationContext = CreateDbContext(databasePath);
+            var rebuiltRow = await verificationContext.Set<SectorEmpireStat>().SingleAsync(item => item.SectorId == 1 && item.EmpireId == 201);
+            Assert.Equal(1, rebuiltRow.ControlledWorldCount);
+            Assert.Equal(1, rebuiltRow.TrackedWorldCount);
+
+            var verificationConfiguration = await verificationContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
+            Assert.NotNull(verificationConfiguration.SectorEmpireStatsInvalidatedAtUtc);
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
     public async Task LoadEmpireDetailAsync_orders_member_races_by_population_descending()
     {
         var databasePath = CreateTempFilePath(".db");
@@ -654,7 +691,16 @@ public sealed class StarWinExplorerQueryServiceTests
 
     private static async Task SeedExplorerDataAsync(StarWinDbContext dbContext)
     {
-        var sector = new StarWinSector { Id = 1, Name = "Delcora" };
+        var sector = new StarWinSector
+        {
+            Id = 1,
+            Name = "Delcora",
+            Configuration = new SectorConfiguration
+            {
+                SectorId = 1,
+                SectorEmpireStatsCalculatedAtUtc = new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc)
+            }
+        };
         var homeSystem = new StarSystem { Id = 10, SectorId = 1, Name = "Helios", AllegianceId = 201 };
         var remoteSystem = new StarSystem { Id = 20, SectorId = 1, Name = "Nadir", AllegianceId = 201 };
 
@@ -908,6 +954,31 @@ public sealed class StarWinExplorerQueryServiceTests
         dbContext.Sectors.Add(sector);
         dbContext.AlienRaces.AddRange(aurelian, krell);
         dbContext.Empires.AddRange(aurelianEmpire, krellEmpire, fallenEmpire);
+        dbContext.Set<SectorEmpireStat>().AddRange(
+            new SectorEmpireStat
+            {
+                SectorId = 1,
+                EmpireId = 201,
+                ControlledWorldCount = 1,
+                TrackedWorldCount = 1,
+                LastCalculatedAtUtc = sector.Configuration.SectorEmpireStatsCalculatedAtUtc!.Value
+            },
+            new SectorEmpireStat
+            {
+                SectorId = 1,
+                EmpireId = 202,
+                ControlledWorldCount = 2,
+                TrackedWorldCount = 2,
+                LastCalculatedAtUtc = sector.Configuration.SectorEmpireStatsCalculatedAtUtc!.Value
+            },
+            new SectorEmpireStat
+            {
+                SectorId = 1,
+                EmpireId = 203,
+                ControlledWorldCount = 0,
+                TrackedWorldCount = 1,
+                LastCalculatedAtUtc = sector.Configuration.SectorEmpireStatsCalculatedAtUtc!.Value
+            });
         dbContext.Religions.AddRange(solarDoctrine, dunePath);
         dbContext.Set<EmpireReligion>().AddRange(
             new EmpireReligion

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -495,6 +496,46 @@ public sealed class StarWinExplorerQueryServiceTests
 
             var verificationConfiguration = await verificationContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
             Assert.NotNull(verificationConfiguration.SectorEmpireStatsInvalidatedAtUtc);
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task LoadEmpireListPageAsync_rebuilds_sector_empire_stats_and_retries_when_fallback_times_out()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var seedContext = CreateDbContext(databasePath);
+            await seedContext.Database.EnsureCreatedAsync();
+            await SeedExplorerDataAsync(seedContext);
+
+            var configuration = await seedContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
+            configuration.SectorEmpireStatsInvalidatedAtUtc = DateTime.UtcNow;
+
+            var deletedStat = await seedContext.Set<SectorEmpireStat>().SingleAsync(item => item.SectorId == 1 && item.EmpireId == 201);
+            seedContext.Remove(deletedStat);
+            await seedContext.SaveChangesAsync();
+
+            var interceptor = new ThrowTimeoutOnReaderInvocationInterceptor(readerInvocationNumber: 2);
+
+            var service = new StarWinExplorerQueryService(CreateFactory(databasePath, interceptor));
+
+            var page = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(1, 0, 30, Query: "Concord"));
+
+            Assert.Single(page.Items);
+            Assert.Equal("Aurelian Concord", page.Items[0].Name);
+
+            await using var verificationContext = CreateDbContext(databasePath);
+            Assert.NotNull(await verificationContext.Set<SectorEmpireStat>().SingleOrDefaultAsync(item => item.SectorId == 1 && item.EmpireId == 201));
+
+            var refreshedConfiguration = await verificationContext.Set<SectorConfiguration>().SingleAsync(item => item.SectorId == 1);
+            Assert.NotNull(refreshedConfiguration.SectorEmpireStatsCalculatedAtUtc);
+            Assert.Null(refreshedConfiguration.SectorEmpireStatsInvalidatedAtUtc);
         }
         finally
         {
@@ -1036,12 +1077,18 @@ public sealed class StarWinExplorerQueryServiceTests
         return Assert.IsAssignableFrom<FormattableString>(method!.Invoke(null, [request, null, 31, 0, providerName]));
     }
 
-    private static IDbContextFactory<StarWinDbContext> CreateFactory(string databasePath)
+    private static IDbContextFactory<StarWinDbContext> CreateFactory(string databasePath, params IInterceptor[] interceptors)
     {
-        var options = new DbContextOptionsBuilder<StarWinDbContext>()
+        var builder = new DbContextOptionsBuilder<StarWinDbContext>()
             .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning))
-            .UseSqlite($"Data Source={databasePath}")
-            .Options;
+            .UseSqlite($"Data Source={databasePath}");
+
+        if (interceptors.Length > 0)
+        {
+            builder.AddInterceptors(interceptors);
+        }
+
+        var options = builder.Options;
 
         return new OptionsDbContextFactory(options);
     }
@@ -1080,6 +1127,25 @@ public sealed class StarWinExplorerQueryServiceTests
         public Task<StarWinDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(CreateDbContext());
+        }
+    }
+
+    private sealed class ThrowTimeoutOnReaderInvocationInterceptor(int readerInvocationNumber) : DbCommandInterceptor
+    {
+        private int readerExecutionCount;
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref readerExecutionCount) == readerInvocationNumber)
+            {
+                throw new TimeoutException("Simulated command timeout for fallback query recovery.");
+            }
+
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
         }
     }
 }

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -202,7 +202,7 @@ public sealed class StarWinExplorerQueryServiceTests
     }
 
     [Fact]
-    public async Task LoadEmpireListPageAsync_applies_query_and_race_filters_and_marks_fallen_empires()
+    public async Task LoadEmpireListPageAsync_applies_query_race_and_status_filters_and_marks_fallen_empires()
     {
         var databasePath = CreateTempFilePath(".db");
 
@@ -236,12 +236,92 @@ public sealed class StarWinExplorerQueryServiceTests
             Assert.Single(fallenSearch.Items);
             Assert.True(fallenSearch.Items[0].IsFallen);
 
-            var fallenOnlySearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(1, 0, 30, FallenOnly: true));
+            var fallenOnlySearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                StatusFilter: ExplorerEmpireStatusFilter.Fallen));
             Assert.Single(fallenOnlySearch.Items);
             Assert.Equal("Watcher Remnant", fallenOnlySearch.Items[0].Name);
             Assert.Equal(0, fallenOnlySearch.Items[0].ControlledWorldCount);
             Assert.Equal(1, fallenOnlySearch.Items[0].TrackedWorldCount);
             Assert.True(fallenOnlySearch.Items[0].IsFallen);
+        }
+        finally
+        {
+            DeleteIfExists(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task LoadEmpireListPageAsync_applies_world_population_tl_and_sort_filters_in_database()
+    {
+        var databasePath = CreateTempFilePath(".db");
+
+        try
+        {
+            await using var seedContext = CreateDbContext(databasePath);
+            await seedContext.Database.EnsureCreatedAsync();
+            await SeedExplorerDataAsync(seedContext);
+
+            var service = new StarWinExplorerQueryService(CreateFactory(databasePath));
+
+            var activeOnlySearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                StatusFilter: ExplorerEmpireStatusFilter.Active));
+            Assert.Equal(["Aurelian Concord", "Krell Reach"], activeOnlySearch.Items.Select(item => item.Name).ToArray());
+
+            var controlledWorldRangeSearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                MinControlledWorldCount: 2));
+            Assert.Single(controlledWorldRangeSearch.Items);
+            Assert.Equal("Krell Reach", controlledWorldRangeSearch.Items[0].Name);
+
+            var populationRangeSearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                MinNativePopulationMillions: 100,
+                MaxNativePopulationMillions: 800));
+            Assert.Single(populationRangeSearch.Items);
+            Assert.Equal("Krell Reach", populationRangeSearch.Items[0].Name);
+
+            var gurpsTechLevelSearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                MinTechLevel: 10,
+                MaxTechLevel: 10));
+            Assert.Single(gurpsTechLevelSearch.Items);
+            Assert.Equal("Krell Reach", gurpsTechLevelSearch.Items[0].Name);
+
+            var starWinTechLevelSearch = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                TechLevelSystem: ExplorerEmpireTechLevelSystem.StarWin,
+                MinTechLevel: 8,
+                MaxTechLevel: 8));
+            Assert.Single(starWinTechLevelSearch.Items);
+            Assert.Equal("Krell Reach", starWinTechLevelSearch.Items[0].Name);
+
+            var controlledWorldSort = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                SortOption: ExplorerEmpireSortOption.ControlledWorlds));
+            Assert.Equal("Krell Reach", controlledWorldSort.Items[0].Name);
+
+            var economicPowerSort = await service.LoadEmpireListPageAsync(new ExplorerEmpireListPageRequest(
+                1,
+                0,
+                30,
+                SortOption: ExplorerEmpireSortOption.EconomicPower));
+            Assert.Equal("Krell Reach", economicPowerSort.Items[0].Name);
         }
         finally
         {
@@ -694,6 +774,7 @@ public sealed class StarWinExplorerQueryServiceTests
             Id = 201,
             Name = "Aurelian Concord",
             GovernmentType = "Council",
+            EconomicPowerMcr = 2200,
             NativePopulationMillions = 1200
         };
         aurelianEmpire.CivilizationProfile.TechLevel = 6;
@@ -738,6 +819,7 @@ public sealed class StarWinExplorerQueryServiceTests
             Id = 202,
             Name = "Krell Reach",
             GovernmentType = "Council",
+            EconomicPowerMcr = 5100,
             NativePopulationMillions = 450
         };
         krellEmpire.CivilizationProfile.TechLevel = 8;
@@ -763,6 +845,7 @@ public sealed class StarWinExplorerQueryServiceTests
             Id = 203,
             Name = "Watcher Remnant",
             GovernmentType = "Council",
+            EconomicPowerMcr = 900,
             Planets = 1,
             NativePopulationMillions = 30,
             IsFallen = true

--- a/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/Explorer/StarWinExplorerQueryServiceTests.cs
@@ -183,6 +183,10 @@ public sealed class StarWinExplorerQueryServiceTests
 
             var options = await service.LoadEmpireFilterOptionsAsync(1);
 
+            Assert.Equal(2, options.MaxControlledWorldCount);
+            Assert.Equal(1200, options.MaxNativePopulationMillions);
+            Assert.Equal(10, options.MaxGurpsTechLevel);
+            Assert.Equal(8, options.MaxStarWinTechLevel);
             Assert.Collection(
                 options.Races.OrderBy(item => item.Id),
                 item =>

--- a/StarWin.Infrastructure.Tests/LegacyImport/StarWinLegacyImportServiceTests.cs
+++ b/StarWin.Infrastructure.Tests/LegacyImport/StarWinLegacyImportServiceTests.cs
@@ -68,11 +68,11 @@ public sealed class StarWinLegacyImportServiceTests
             Assert.Equal(1, await verificationContext.Empires.CountAsync());
             Assert.Equal(1, await verificationContext.Set<EmpireRaceMembership>().CountAsync());
             Assert.Equal(1, await verificationContext.Set<EmpireContact>().CountAsync());
-
             var race = await verificationContext.AlienRaces.SingleAsync();
             var empire = await verificationContext.Empires
                 .Include(item => item.Religions)
                 .SingleAsync();
+            var sectorConfiguration = await verificationContext.Set<StarWin.Domain.Model.Entity.StarMap.SectorConfiguration>().SingleAsync();
             var membership = await verificationContext.Set<EmpireRaceMembership>().SingleAsync();
             var contact = await verificationContext.Set<EmpireContact>().SingleAsync();
 
@@ -92,6 +92,7 @@ public sealed class StarWinLegacyImportServiceTests
             Assert.Equal("Veloran Tradition", empire.Religions[0].ReligionName);
             Assert.False(string.IsNullOrWhiteSpace(empire.ImportDataJson));
             Assert.True(empire.IsFallen);
+            Assert.NotNull(sectorConfiguration.SectorEmpireStatsCalculatedAtUtc);
             Assert.Equal(1, await verificationContext.Religions.CountAsync());
 
             using var raceImportData = JsonDocument.Parse(race.ImportDataJson!);
@@ -145,7 +146,7 @@ public sealed class StarWinLegacyImportServiceTests
                 Assert.True(secondResult.Success);
             }
 
-            Assert.Equal(2, countingFactory.CreateCount);
+            Assert.Equal(4, countingFactory.CreateCount);
         }
         finally
         {
@@ -200,6 +201,7 @@ public sealed class StarWinLegacyImportServiceTests
             Assert.True(await verificationContext.Worlds.AnyAsync());
             Assert.True(await verificationContext.AlienRaces.AnyAsync());
             Assert.True(await verificationContext.Empires.AnyAsync());
+            Assert.True(await verificationContext.Set<SectorEmpireStat>().AnyAsync());
             Assert.True(await verificationContext.Set<EmpireRaceMembership>().AnyAsync());
             Assert.True(await verificationContext.Set<EmpireContact>().AnyAsync());
         }

--- a/StarWin.Infrastructure/Data/Migrations/20260513182728_AddSectorEmpireStatsCache.Designer.cs
+++ b/StarWin.Infrastructure/Data/Migrations/20260513182728_AddSectorEmpireStatsCache.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using StarWin.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using StarWin.Infrastructure.Data;
 namespace StarWin.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(StarWinDbContext))]
-    partial class StarWinDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513182728_AddSectorEmpireStatsCache")]
+    partial class AddSectorEmpireStatsCache
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/StarWin.Infrastructure/Data/Migrations/20260513182728_AddSectorEmpireStatsCache.cs
+++ b/StarWin.Infrastructure/Data/Migrations/20260513182728_AddSectorEmpireStatsCache.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace StarWin.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSectorEmpireStatsCache : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "SectorEmpireStatsCalculatedAtUtc",
+                table: "SectorConfigurations",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "SectorEmpireStatsInvalidatedAtUtc",
+                table: "SectorConfigurations",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "SectorEmpireStats",
+                columns: table => new
+                {
+                    SectorId = table.Column<int>(type: "int", nullable: false),
+                    EmpireId = table.Column<int>(type: "int", nullable: false),
+                    ControlledWorldCount = table.Column<int>(type: "int", nullable: false),
+                    TrackedWorldCount = table.Column<int>(type: "int", nullable: false),
+                    LastCalculatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SectorEmpireStats", x => new { x.SectorId, x.EmpireId });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SectorEmpireStats_EmpireId_SectorId",
+                table: "SectorEmpireStats",
+                columns: new[] { "EmpireId", "SectorId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SectorEmpireStats");
+
+            migrationBuilder.DropColumn(
+                name: "SectorEmpireStatsCalculatedAtUtc",
+                table: "SectorConfigurations");
+
+            migrationBuilder.DropColumn(
+                name: "SectorEmpireStatsInvalidatedAtUtc",
+                table: "SectorConfigurations");
+        }
+    }
+}

--- a/StarWin.Infrastructure/Data/StarWinDbContext.cs
+++ b/StarWin.Infrastructure/Data/StarWinDbContext.cs
@@ -22,6 +22,8 @@ public sealed class StarWinDbContext(DbContextOptions<StarWinDbContext> options)
 
     public DbSet<Empire> Empires => Set<Empire>();
 
+    public DbSet<SectorEmpireStat> SectorEmpireStats => Set<SectorEmpireStat>();
+
     public DbSet<Religion> Religions => Set<Religion>();
 
     public DbSet<Colony> Colonies => Set<Colony>();
@@ -91,6 +93,8 @@ public sealed class StarWinDbContext(DbContextOptions<StarWinDbContext> options)
             entity.Property(configuration => configuration.Tl10MaximumDistanceParsecs).HasPrecision(8, 3);
             entity.Property(configuration => configuration.Tl10OffLaneSpeedMultiplier).HasPrecision(8, 3);
             entity.Property(configuration => configuration.Tl10HyperlaneSpeedModifier).HasPrecision(8, 3);
+            entity.Property(configuration => configuration.SectorEmpireStatsCalculatedAtUtc);
+            entity.Property(configuration => configuration.SectorEmpireStatsInvalidatedAtUtc);
         });
 
         modelBuilder.Entity<SectorSavedRoute>(entity =>
@@ -309,6 +313,13 @@ public sealed class StarWinDbContext(DbContextOptions<StarWinDbContext> options)
             entity.Property(religion => religion.ReligionName).HasMaxLength(160);
             entity.HasKey(religion => new { religion.EmpireId, religion.ReligionId });
             entity.HasOne<Religion>().WithMany().HasForeignKey(religion => religion.ReligionId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<SectorEmpireStat>(entity =>
+        {
+            entity.ToTable("SectorEmpireStats");
+            entity.HasKey(stat => new { stat.SectorId, stat.EmpireId });
+            entity.HasIndex(stat => new { stat.EmpireId, stat.SectorId });
         });
 
         modelBuilder.Entity<Colony>(entity =>

--- a/StarWin.Infrastructure/DependencyInjection.cs
+++ b/StarWin.Infrastructure/DependencyInjection.cs
@@ -59,6 +59,7 @@ public static class DependencyInjection
         services.AddScoped<IStarWinSpaceHabitatService, StarWinSpaceHabitatService>();
         services.AddScoped<IStarWinLegacyImportService, StarWinLegacyImportService>();
         services.AddScoped<IStarWinSectorConfigurationService, StarWinSectorConfigurationService>();
+        services.AddScoped<IStarWinSectorEmpireStatsService, StarWinSectorEmpireStatsService>();
         services.AddScoped<IStarWinSectorRouteService, StarWinSectorRouteService>();
 
         return services;
@@ -182,6 +183,8 @@ public static class DependencyInjection
             await EnsureColumnAsync(connection, "SectorConfigurations", "Tl10MaximumDistanceParsecs", "REAL NOT NULL DEFAULT -1");
             await EnsureColumnAsync(connection, "SectorConfigurations", "Tl10OffLaneSpeedMultiplier", "REAL NOT NULL DEFAULT 32");
             await EnsureColumnAsync(connection, "SectorConfigurations", "Tl10HyperlaneSpeedModifier", "REAL NOT NULL DEFAULT 3");
+            await EnsureColumnAsync(connection, "SectorConfigurations", "SectorEmpireStatsCalculatedAtUtc", "TEXT NULL");
+            await EnsureColumnAsync(connection, "SectorConfigurations", "SectorEmpireStatsInvalidatedAtUtc", "TEXT NULL");
 
             if (await ColumnExistsAsync(connection, "SectorConfigurations", "BasicHyperlaneMaximumLengthParsecs"))
             {
@@ -195,6 +198,26 @@ public static class DependencyInjection
             }
 
             await EnsureAlienEmpireImportParitySqliteAsync(connection);
+
+            await ExecuteNonQueryAsync(
+                connection,
+                """
+                CREATE TABLE IF NOT EXISTS "SectorEmpireStats" (
+                    "SectorId" INTEGER NOT NULL,
+                    "EmpireId" INTEGER NOT NULL,
+                    "ControlledWorldCount" INTEGER NOT NULL,
+                    "TrackedWorldCount" INTEGER NOT NULL,
+                    "LastCalculatedAtUtc" TEXT NOT NULL,
+                    CONSTRAINT "PK_SectorEmpireStats" PRIMARY KEY ("SectorId", "EmpireId")
+                )
+                """);
+
+            await ExecuteNonQueryAsync(
+                connection,
+                """
+                CREATE INDEX IF NOT EXISTS "IX_SectorEmpireStats_EmpireId_SectorId"
+                ON "SectorEmpireStats" ("EmpireId", "SectorId")
+                """);
 
             await ExecuteNonQueryAsync(
                 connection,

--- a/StarWin.Infrastructure/Services/SectorEmpireStatRefreshOperations.cs
+++ b/StarWin.Infrastructure/Services/SectorEmpireStatRefreshOperations.cs
@@ -1,0 +1,380 @@
+using Microsoft.EntityFrameworkCore;
+using StarWin.Application.Services;
+using StarWin.Domain.Model.Entity.Civilization;
+using StarWin.Domain.Model.Entity.StarMap;
+using StarWin.Infrastructure.Data;
+
+namespace StarWin.Infrastructure.Services;
+
+internal static class SectorEmpireStatRefreshOperations
+{
+    public static async Task<SectorEmpireStatsRefreshResult> RebuildSectorAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        if (sectorId <= 0)
+        {
+            throw new InvalidOperationException("Sector was not found.");
+        }
+
+        var sectorExists = await dbContext.Sectors
+            .AsNoTracking()
+            .AnyAsync(sector => sector.Id == sectorId, cancellationToken);
+        if (!sectorExists)
+        {
+            throw new InvalidOperationException("Sector was not found.");
+        }
+
+        var calculatedAtUtc = DateTime.UtcNow;
+        var empireIds = await LoadSectorEmpireIdsAsync(dbContext, sectorId, cancellationToken);
+        var controlledCountsByEmpireId = await LoadControlledWorldCountsByEmpireIdAsync(dbContext, sectorId, cancellationToken);
+        var trackedCountsByEmpireId = await LoadTrackedWorldCountsByEmpireIdAsync(dbContext, sectorId, cancellationToken);
+
+        var existingRowsByEmpireId = await dbContext.SectorEmpireStats
+            .Where(stat => stat.SectorId == sectorId)
+            .ToDictionaryAsync(stat => stat.EmpireId, cancellationToken);
+
+        foreach (var obsoleteRow in existingRowsByEmpireId.Values.Where(row => !empireIds.Contains(row.EmpireId)).ToList())
+        {
+            dbContext.SectorEmpireStats.Remove(obsoleteRow);
+        }
+
+        foreach (var empireId in empireIds.OrderBy(id => id))
+        {
+            var controlledWorldCount = controlledCountsByEmpireId.GetValueOrDefault(empireId);
+            var trackedWorldCount = trackedCountsByEmpireId.GetValueOrDefault(empireId);
+            if (!existingRowsByEmpireId.TryGetValue(empireId, out var row))
+            {
+                row = new SectorEmpireStat
+                {
+                    SectorId = sectorId,
+                    EmpireId = empireId
+                };
+                dbContext.SectorEmpireStats.Add(row);
+            }
+
+            row.ControlledWorldCount = controlledWorldCount;
+            row.TrackedWorldCount = trackedWorldCount;
+            row.LastCalculatedAtUtc = calculatedAtUtc;
+        }
+
+        var configuration = await EnsureSectorConfigurationAsync(dbContext, sectorId, cancellationToken);
+        configuration.SectorEmpireStatsCalculatedAtUtc = calculatedAtUtc;
+        configuration.SectorEmpireStatsInvalidatedAtUtc = null;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return new SectorEmpireStatsRefreshResult(sectorId, empireIds.Count, calculatedAtUtc);
+    }
+
+    public static async Task<SectorEmpireStatRefreshResult?> RefreshEmpireAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        if (sectorId <= 0 || empireId <= 0)
+        {
+            return null;
+        }
+
+        var calculatedAtUtc = DateTime.UtcNow;
+        var isPresentInSector = await EmpireIsPresentInSectorAsync(dbContext, sectorId, empireId, cancellationToken);
+        var existingRow = await dbContext.SectorEmpireStats
+            .FirstOrDefaultAsync(
+                stat => stat.SectorId == sectorId && stat.EmpireId == empireId,
+                cancellationToken);
+
+        if (!isPresentInSector)
+        {
+            if (existingRow is not null)
+            {
+                dbContext.SectorEmpireStats.Remove(existingRow);
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            return null;
+        }
+
+        var controlledWorldCount = await LoadControlledWorldCountAsync(dbContext, sectorId, empireId, cancellationToken);
+        var trackedWorldCount = await LoadTrackedWorldCountAsync(dbContext, sectorId, empireId, cancellationToken);
+        if (existingRow is null)
+        {
+            existingRow = new SectorEmpireStat
+            {
+                SectorId = sectorId,
+                EmpireId = empireId
+            };
+            dbContext.SectorEmpireStats.Add(existingRow);
+        }
+
+        existingRow.ControlledWorldCount = controlledWorldCount;
+        existingRow.TrackedWorldCount = trackedWorldCount;
+        existingRow.LastCalculatedAtUtc = calculatedAtUtc;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new SectorEmpireStatRefreshResult(
+            sectorId,
+            empireId,
+            controlledWorldCount,
+            trackedWorldCount,
+            calculatedAtUtc);
+    }
+
+    public static async Task MarkSectorStatsStaleAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        if (sectorId <= 0)
+        {
+            return;
+        }
+
+        var configuration = await EnsureSectorConfigurationAsync(dbContext, sectorId, cancellationToken);
+        configuration.SectorEmpireStatsInvalidatedAtUtc = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static async Task<SectorConfiguration> EnsureSectorConfigurationAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var configuration = await dbContext.Set<SectorConfiguration>()
+            .FirstOrDefaultAsync(item => item.SectorId == sectorId, cancellationToken);
+        if (configuration is not null)
+        {
+            return configuration;
+        }
+
+        configuration = new SectorConfiguration { SectorId = sectorId };
+        dbContext.Set<SectorConfiguration>().Add(configuration);
+        return configuration;
+    }
+
+    private static async Task<HashSet<int>> LoadSectorEmpireIdsAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var empireIds = new HashSet<int>();
+
+        empireIds.UnionWith(await dbContext.StarSystems
+            .AsNoTracking()
+            .Where(system => system.SectorId == sectorId && system.AllegianceId != ushort.MaxValue)
+            .Select(system => (int)system.AllegianceId)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from habitat in dbContext.SpaceHabitats.AsNoTracking()
+            join system in dbContext.StarSystems.AsNoTracking()
+                on EF.Property<int>(habitat, "StarSystemId") equals system.Id
+            where system.SectorId == sectorId && habitat.BuiltByEmpireId.HasValue
+            select habitat.BuiltByEmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from habitat in dbContext.SpaceHabitats.AsNoTracking()
+            join system in dbContext.StarSystems.AsNoTracking()
+                on EF.Property<int>(habitat, "StarSystemId") equals system.Id
+            where system.SectorId == sectorId && habitat.ControlledByEmpireId.HasValue
+            select habitat.ControlledByEmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from world in dbContext.Worlds.AsNoTracking()
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && world.ControlledByEmpireId.HasValue
+            select world.ControlledByEmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from world in dbContext.Worlds.AsNoTracking()
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && world.AllegianceId != ushort.MaxValue
+            select (int)world.AllegianceId)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && colony.ControllingEmpireId.HasValue
+            select colony.ControllingEmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && colony.FoundingEmpireId.HasValue
+            select colony.FoundingEmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && colony.ParentEmpireId.HasValue
+            select colony.ParentEmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && colony.AllegianceId != ushort.MaxValue
+            select (int)colony.AllegianceId)
+            .ToListAsync(cancellationToken));
+
+        empireIds.UnionWith(await dbContext.HistoryEvents
+            .AsNoTracking()
+            .Where(history => history.SectorId == sectorId && history.EmpireId.HasValue)
+            .Select(history => history.EmpireId!.Value)
+            .ToListAsync(cancellationToken));
+
+        return empireIds;
+    }
+
+    private static async Task<Dictionary<int, int>> LoadControlledWorldCountsByEmpireIdAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var groupedCounts = await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId && colony.ControllingEmpireId.HasValue
+            group colony.WorldId by colony.ControllingEmpireId!.Value into grouped
+            select new
+            {
+                EmpireId = grouped.Key,
+                ControlledWorldCount = grouped.Distinct().Count()
+            })
+            .ToListAsync(cancellationToken);
+
+        return groupedCounts.ToDictionary(item => item.EmpireId, item => item.ControlledWorldCount);
+    }
+
+    private static async Task<Dictionary<int, int>> LoadTrackedWorldCountsByEmpireIdAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var trackedLinks = await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && (colony.ControllingEmpireId.HasValue || colony.FoundingEmpireId.HasValue)
+            select new
+            {
+                colony.WorldId,
+                colony.ControllingEmpireId,
+                colony.FoundingEmpireId
+            })
+            .ToListAsync(cancellationToken);
+
+        return trackedLinks
+            .SelectMany(link =>
+            {
+                var pairs = new List<(int EmpireId, int WorldId)>(2);
+                if (link.ControllingEmpireId is int controllingEmpireId)
+                {
+                    pairs.Add((controllingEmpireId, link.WorldId));
+                }
+
+                if (link.FoundingEmpireId is int foundingEmpireId)
+                {
+                    pairs.Add((foundingEmpireId, link.WorldId));
+                }
+
+                return pairs;
+            })
+            .Distinct()
+            .GroupBy(item => item.EmpireId)
+            .ToDictionary(group => group.Key, group => group.Count());
+    }
+
+    private static async Task<int> LoadControlledWorldCountAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken)
+    {
+        return await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && colony.ControllingEmpireId == empireId
+            select colony.WorldId)
+            .Distinct()
+            .CountAsync(cancellationToken);
+    }
+
+    private static async Task<int> LoadTrackedWorldCountAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken)
+    {
+        return await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && (colony.ControllingEmpireId == empireId || colony.FoundingEmpireId == empireId)
+            select colony.WorldId)
+            .Distinct()
+            .CountAsync(cancellationToken);
+    }
+
+    private static async Task<bool> EmpireIsPresentInSectorAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken)
+    {
+        return await dbContext.StarSystems
+                   .AsNoTracking()
+                   .AnyAsync(system => system.SectorId == sectorId && system.AllegianceId == empireId, cancellationToken)
+               || await (
+                   from habitat in dbContext.SpaceHabitats.AsNoTracking()
+                   join system in dbContext.StarSystems.AsNoTracking()
+                       on EF.Property<int>(habitat, "StarSystemId") equals system.Id
+                   where system.SectorId == sectorId
+                       && (habitat.BuiltByEmpireId == empireId || habitat.ControlledByEmpireId == empireId)
+                   select habitat.Id)
+                   .AnyAsync(cancellationToken)
+               || await (
+                   from world in dbContext.Worlds.AsNoTracking()
+                   join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                   where system.SectorId == sectorId
+                       && (world.ControlledByEmpireId == empireId || world.AllegianceId == empireId)
+                   select world.Id)
+                   .AnyAsync(cancellationToken)
+               || await (
+                   from colony in dbContext.Colonies.AsNoTracking()
+                   join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+                   join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                   where system.SectorId == sectorId
+                       && (colony.ControllingEmpireId == empireId
+                           || colony.FoundingEmpireId == empireId
+                           || colony.ParentEmpireId == empireId
+                           || colony.AllegianceId == empireId)
+                   select colony.Id)
+                   .AnyAsync(cancellationToken)
+               || await dbContext.HistoryEvents
+                   .AsNoTracking()
+                   .AnyAsync(history => history.SectorId == sectorId && history.EmpireId == empireId, cancellationToken);
+    }
+}

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -1243,131 +1244,45 @@ public sealed class StarWinExplorerQueryService(
 
     public async Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)
     {
-        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, request.SectorId, cancellationToken)).EmpireIds;
-        if (sectorEmpireIds.Count == 0)
+        if (request.SectorId <= 0)
         {
             return new ExplorerEmpireListPage([], false);
         }
 
-        var empiresQuery = dbContext.Empires
-            .AsNoTracking()
-            .Where(empire => sectorEmpireIds.Contains(empire.Id));
-
-        empiresQuery = ApplyEmpireFilters(dbContext, empiresQuery, request);
-
-        var headerItems = await empiresQuery
-            .OrderBy(empire => empire.Name)
-            .ThenBy(empire => empire.Id)
-            .Select(empire => new EmpireListHeaderProjection(
-                empire.Id,
-                empire.Name,
-                empire.CivilizationProfile.TechLevel + 2,
-                empire.GovernmentType,
-                empire.Founding.Origin,
-                empire.Founding.FoundingRaceId,
-                empire.Founding.FoundingWorldId,
-                dbContext.AlienRaces
-                    .Where(race => race.Id == empire.Founding.FoundingRaceId)
-                    .Select(race => race.Name)
-                    .FirstOrDefault(),
-                dbContext.Worlds
-                    .Where(world => world.Id == empire.Founding.FoundingWorldId)
-                    .Select(world => world.Name)
-                    .FirstOrDefault(),
-                empire.IsFallen))
-            .Skip(request.Offset)
-            .Take(request.Limit + 1)
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var pageRows = await dbContext.Database
+            .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(request, empireId: null, limit: request.Limit + 1, offset: request.Offset))
             .ToListAsync(cancellationToken);
 
-        var hasMore = headerItems.Count > request.Limit;
-        var visibleHeaders = headerItems.Take(request.Limit).ToList();
-        var worldCountsByEmpireId = await LoadEmpireWorldCountsByEmpireIdAsync(
-            dbContext,
-            request.SectorId,
-            visibleHeaders.Select(item => item.EmpireId).ToList(),
-            cancellationToken);
+        var hasMore = pageRows.Count > request.Limit;
         return new ExplorerEmpireListPage(
-            visibleHeaders
-                .Select(item =>
-                {
-                    var counts = worldCountsByEmpireId.GetValueOrDefault(item.EmpireId) ?? EmptyEmpireWorldCountProjection;
-                    return BuildEmpireListItem(new EmpireListProjection(
-                        item.EmpireId,
-                        item.Name,
-                        counts.ControlledWorldCount,
-                        counts.TrackedWorldCount,
-                        item.GurpsTechLevel,
-                        item.GovernmentType,
-                        item.Origin,
-                        item.FoundingRaceId,
-                        item.FoundingWorldId,
-                        item.FoundingRaceName,
-                        item.FoundingWorldName,
-                        item.IsFallen));
-                })
+            pageRows
+                .Take(request.Limit)
+                .Select(MapEmpireListSqlRow)
+                .Select(BuildEmpireListItem)
                 .ToList(),
             hasMore);
     }
 
     public async Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
     {
-        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
-        if (!sectorEmpireIds.Contains(empireId))
+        if (sectorId <= 0 || empireId <= 0)
         {
             return null;
         }
 
-        var item = await dbContext.Empires
-            .AsNoTracking()
-            .Where(empire => empire.Id == empireId)
-            .Select(empire => new EmpireListHeaderProjection(
-                empire.Id,
-                empire.Name,
-                empire.CivilizationProfile.TechLevel + 2,
-                empire.GovernmentType,
-                empire.Founding.Origin,
-                empire.Founding.FoundingRaceId,
-                empire.Founding.FoundingWorldId,
-                dbContext.AlienRaces
-                    .Where(race => race.Id == empire.Founding.FoundingRaceId)
-                    .Select(race => race.Name)
-                    .FirstOrDefault(),
-                dbContext.Worlds
-                    .Where(world => world.Id == empire.Founding.FoundingWorldId)
-                    .Select(world => world.Name)
-                    .FirstOrDefault(),
-                empire.IsFallen))
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var item = await dbContext.Database
+            .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
+                new ExplorerEmpireListPageRequest(sectorId, 0, 1),
+                empireId,
+                limit: 1,
+                offset: 0))
             .FirstOrDefaultAsync(cancellationToken);
 
-        if (item is null)
-        {
-            return null;
-        }
-
-        var counts = (await LoadEmpireWorldCountsByEmpireIdAsync(
-            dbContext,
-            sectorId,
-            [item.EmpireId],
-            cancellationToken))
-            .GetValueOrDefault(item.EmpireId)
-            ?? EmptyEmpireWorldCountProjection;
-        return BuildEmpireListItem(new EmpireListProjection(
-            item.EmpireId,
-            item.Name,
-            counts.ControlledWorldCount,
-            counts.TrackedWorldCount,
-            item.GurpsTechLevel,
-            item.GovernmentType,
-            item.Origin,
-            item.FoundingRaceId,
-            item.FoundingWorldId,
-            item.FoundingRaceName,
-            item.FoundingWorldName,
-            item.IsFallen));
+        return item is null
+            ? null
+            : BuildEmpireListItem(MapEmpireListSqlRow(item));
     }
 
     public async Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
@@ -2237,36 +2152,6 @@ public sealed class StarWinExplorerQueryService(
         return copy;
     }
 
-    private static IQueryable<Empire> ApplyEmpireFilters(
-        StarWinDbContext dbContext,
-        IQueryable<Empire> empiresQuery,
-        ExplorerEmpireListPageRequest request)
-    {
-        if (request.RaceId is int raceId)
-        {
-            empiresQuery = empiresQuery.Where(empire => empire.RaceMemberships.Any(membership => membership.RaceId == raceId));
-        }
-
-        if (request.FallenOnly)
-        {
-            empiresQuery = empiresQuery.Where(empire => empire.IsFallen);
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Query))
-        {
-            var searchPattern = $"%{request.Query.Trim()}%";
-            empiresQuery = empiresQuery.Where(empire =>
-                EF.Functions.Like(empire.Name, searchPattern)
-                || dbContext.EntityNotes.Any(note =>
-                    note.TargetId == empire.Id
-                    && (note.TargetKind == EntityNoteTargetKind.Empire
-                        || note.TargetKind == EntityNoteTargetKind.EmpireSummary)
-                    && EF.Functions.Like(note.Markdown, searchPattern)));
-        }
-
-        return empiresQuery;
-    }
-
     private static IQueryable<AlienRace> ApplyAlienRaceFilters(
         StarWinDbContext dbContext,
         IQueryable<AlienRace> racesQuery,
@@ -2692,6 +2577,203 @@ public sealed class StarWinExplorerQueryService(
             : empireName.Trim();
     }
 
+    private static FormattableString BuildEmpireListSql(
+        ExplorerEmpireListPageRequest request,
+        int? empireId,
+        int limit,
+        int offset)
+    {
+        var orderByClause = GetEmpireListOrderByClause(request.SortOption);
+        var queryPattern = string.IsNullOrWhiteSpace(request.Query)
+            ? null
+            : $"%{request.Query.Trim()}%";
+        var sqlFormat = """
+            WITH SectorSystems AS (
+                SELECT Id, AllegianceId
+                FROM StarSystems
+                WHERE SectorId = {0}
+            ),
+            SectorWorlds AS (
+                SELECT Worlds.Id, Worlds.ControlledByEmpireId, Worlds.AllegianceId
+                FROM Worlds
+                INNER JOIN SectorSystems ON Worlds.StarSystemId = SectorSystems.Id
+            ),
+            SectorColonies AS (
+                SELECT Colonies.WorldId, Colonies.ControllingEmpireId, Colonies.FoundingEmpireId, Colonies.ParentEmpireId, Colonies.AllegianceId
+                FROM Colonies
+                INNER JOIN SectorWorlds ON Colonies.WorldId = SectorWorlds.Id
+            ),
+            SectorEmpireIds AS (
+                SELECT CAST(AllegianceId AS INTEGER) AS EmpireId
+                FROM SectorSystems
+                WHERE AllegianceId <> {1}
+                UNION
+                SELECT CAST(ControlledByEmpireId AS INTEGER) AS EmpireId
+                FROM SectorWorlds
+                WHERE ControlledByEmpireId IS NOT NULL
+                UNION
+                SELECT CAST(AllegianceId AS INTEGER) AS EmpireId
+                FROM SectorWorlds
+                WHERE AllegianceId <> {1}
+                UNION
+                SELECT CAST(ControllingEmpireId AS INTEGER) AS EmpireId
+                FROM SectorColonies
+                WHERE ControllingEmpireId IS NOT NULL
+                UNION
+                SELECT CAST(FoundingEmpireId AS INTEGER) AS EmpireId
+                FROM SectorColonies
+                WHERE FoundingEmpireId IS NOT NULL
+                UNION
+                SELECT CAST(ParentEmpireId AS INTEGER) AS EmpireId
+                FROM SectorColonies
+                WHERE ParentEmpireId IS NOT NULL
+                UNION
+                SELECT CAST(AllegianceId AS INTEGER) AS EmpireId
+                FROM SectorColonies
+                WHERE AllegianceId <> {1}
+            ),
+            ControlledWorldCounts AS (
+                SELECT CAST(ControllingEmpireId AS INTEGER) AS EmpireId, COUNT(DISTINCT WorldId) AS ControlledWorldCount
+                FROM SectorColonies
+                WHERE ControllingEmpireId IS NOT NULL
+                GROUP BY ControllingEmpireId
+            ),
+            TrackedWorldLinks AS (
+                SELECT CAST(ControllingEmpireId AS INTEGER) AS EmpireId, WorldId
+                FROM SectorColonies
+                WHERE ControllingEmpireId IS NOT NULL
+                UNION
+                SELECT CAST(FoundingEmpireId AS INTEGER) AS EmpireId, WorldId
+                FROM SectorColonies
+                WHERE FoundingEmpireId IS NOT NULL
+            ),
+            TrackedWorldCounts AS (
+                SELECT EmpireId, COUNT(DISTINCT WorldId) AS TrackedWorldCount
+                FROM TrackedWorldLinks
+                GROUP BY EmpireId
+            )
+            SELECT
+                Empires.Id AS EmpireId,
+                Empires.Name AS Name,
+                COALESCE(ControlledWorldCounts.ControlledWorldCount, 0) AS ControlledWorldCount,
+                COALESCE(TrackedWorldCounts.TrackedWorldCount, 0) AS TrackedWorldCount,
+                CAST(Empires.CivilizationProfile_TechLevel AS INTEGER) + 2 AS GurpsTechLevel,
+                CAST(Empires.CivilizationProfile_TechLevel AS INTEGER) AS StarWinTechLevel,
+                Empires.NativePopulationMillions AS NativePopulationMillions,
+                Empires.EconomicPowerMcr AS EconomicPowerMcr,
+                Empires.GovernmentType AS GovernmentType,
+                Empires.Founding_Origin AS Origin,
+                Empires.Founding_FoundingRaceId AS FoundingRaceId,
+                Empires.Founding_FoundingWorldId AS FoundingWorldId,
+                FoundingRace.Name AS FoundingRaceName,
+                FoundingWorld.Name AS FoundingWorldName,
+                Empires.IsFallen AS IsFallen
+            FROM Empires
+            LEFT JOIN ControlledWorldCounts ON ControlledWorldCounts.EmpireId = Empires.Id
+            LEFT JOIN TrackedWorldCounts ON TrackedWorldCounts.EmpireId = Empires.Id
+            LEFT JOIN AlienRaces AS FoundingRace ON FoundingRace.Id = Empires.Founding_FoundingRaceId
+            LEFT JOIN Worlds AS FoundingWorld ON FoundingWorld.Id = Empires.Founding_FoundingWorldId
+            WHERE Empires.Id IN (SELECT EmpireId FROM SectorEmpireIds)
+              AND ({2} IS NULL OR Empires.Id = {2})
+              AND ({3} IS NULL OR EXISTS (
+                    SELECT 1
+                    FROM EmpireRaceMemberships
+                    WHERE EmpireId = Empires.Id
+                      AND RaceId = {3}))
+              AND (
+                    {4} = 0
+                    OR ({4} = 1 AND Empires.IsFallen = 0)
+                    OR ({4} = 2 AND Empires.IsFallen = 1)
+                  )
+              AND ({5} IS NULL OR COALESCE(ControlledWorldCounts.ControlledWorldCount, 0) >= {5})
+              AND ({6} IS NULL OR COALESCE(ControlledWorldCounts.ControlledWorldCount, 0) <= {6})
+              AND ({7} IS NULL OR Empires.NativePopulationMillions >= {7})
+              AND ({8} IS NULL OR Empires.NativePopulationMillions <= {8})
+              AND (
+                    {9} IS NULL
+                    OR CASE
+                          WHEN {11} = 1 THEN CAST(Empires.CivilizationProfile_TechLevel AS INTEGER)
+                          ELSE CAST(Empires.CivilizationProfile_TechLevel AS INTEGER) + 2
+                       END >= {9}
+                  )
+              AND (
+                    {10} IS NULL
+                    OR CASE
+                          WHEN {11} = 1 THEN CAST(Empires.CivilizationProfile_TechLevel AS INTEGER)
+                          ELSE CAST(Empires.CivilizationProfile_TechLevel AS INTEGER) + 2
+                       END <= {10}
+                  )
+              AND (
+                    {12} IS NULL
+                    OR Empires.Name LIKE {12}
+                    OR EXISTS (
+                        SELECT 1
+                        FROM EntityNotes
+                        WHERE TargetId = Empires.Id
+                          AND (TargetKind = {13} OR TargetKind = {14})
+                          AND Markdown LIKE {12}
+                    )
+                  )
+            ORDER BY 
+            """ + orderByClause + " " + """
+            LIMIT {15}
+            OFFSET {16}
+            """;
+
+        return FormattableStringFactory.Create(
+            sqlFormat,
+            request.SectorId,
+            ushort.MaxValue,
+            empireId,
+            request.RaceId,
+            (int)request.StatusFilter,
+            request.MinControlledWorldCount,
+            request.MaxControlledWorldCount,
+            request.MinNativePopulationMillions,
+            request.MaxNativePopulationMillions,
+            request.MinTechLevel,
+            request.MaxTechLevel,
+            (int)request.TechLevelSystem,
+            queryPattern,
+            EntityNoteTargetKind.Empire.ToString(),
+            EntityNoteTargetKind.EmpireSummary.ToString(),
+            limit,
+            offset);
+    }
+
+    private static string GetEmpireListOrderByClause(ExplorerEmpireSortOption sortOption)
+    {
+        return sortOption switch
+        {
+            ExplorerEmpireSortOption.Population => "Empires.NativePopulationMillions DESC, Empires.Name COLLATE NOCASE ASC, Empires.Id ASC",
+            ExplorerEmpireSortOption.ControlledWorlds => "ControlledWorldCount DESC, Empires.Name COLLATE NOCASE ASC, Empires.Id ASC",
+            ExplorerEmpireSortOption.EconomicPower => "Empires.EconomicPowerMcr DESC, Empires.Name COLLATE NOCASE ASC, Empires.Id ASC",
+            _ => "Empires.Name COLLATE NOCASE ASC, Empires.Id ASC"
+        };
+    }
+
+    private static EmpireListProjection MapEmpireListSqlRow(EmpireListSqlRow row)
+    {
+        return new EmpireListProjection(
+            row.EmpireId,
+            row.Name,
+            row.ControlledWorldCount,
+            row.TrackedWorldCount,
+            row.GurpsTechLevel,
+            row.StarWinTechLevel,
+            row.NativePopulationMillions,
+            row.EconomicPowerMcr,
+            row.GovernmentType,
+            Enum.TryParse<EmpireOrigin>(row.Origin, ignoreCase: true, out var origin)
+                ? origin
+                : EmpireOrigin.Unknown,
+            row.FoundingRaceId,
+            row.FoundingWorldId,
+            row.FoundingRaceName,
+            row.FoundingWorldName,
+            row.IsFallen);
+    }
+
     private static ExplorerEmpireListItem BuildEmpireListItem(EmpireListProjection item)
     {
         return new ExplorerEmpireListItem(
@@ -2707,6 +2789,9 @@ public sealed class StarWinExplorerQueryService(
             item.ControlledWorldCount,
             item.TrackedWorldCount,
             item.GurpsTechLevel,
+            item.StarWinTechLevel,
+            item.NativePopulationMillions,
+            item.EconomicPowerMcr,
             item.IsFallen);
     }
 
@@ -2940,23 +3025,44 @@ public sealed class StarWinExplorerQueryService(
         public int RaceCount { get; set; }
     }
 
+    private sealed class EmpireListSqlRow
+    {
+        public int EmpireId { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public int ControlledWorldCount { get; set; }
+
+        public int TrackedWorldCount { get; set; }
+
+        public int GurpsTechLevel { get; set; }
+
+        public int StarWinTechLevel { get; set; }
+
+        public long NativePopulationMillions { get; set; }
+
+        public long EconomicPowerMcr { get; set; }
+
+        public string GovernmentType { get; set; } = string.Empty;
+
+        public string Origin { get; set; } = string.Empty;
+
+        public int? FoundingRaceId { get; set; }
+
+        public int? FoundingWorldId { get; set; }
+
+        public string? FoundingRaceName { get; set; }
+
+        public string? FoundingWorldName { get; set; }
+
+        public bool IsFallen { get; set; }
+    }
+
     private sealed record RaceDisplayProjection(int RaceId, string RaceName, string? HomeWorldName);
 
     private sealed record EmpireWorldLinkProjection(int EmpireId, int WorldId);
 
     private sealed record EmpireWorldCountProjection(int ControlledWorldCount, int TrackedWorldCount);
-
-    private sealed record EmpireListHeaderProjection(
-        int EmpireId,
-        string Name,
-        int GurpsTechLevel,
-        string GovernmentType,
-        EmpireOrigin Origin,
-        int? FoundingRaceId,
-        int? FoundingWorldId,
-        string? FoundingRaceName,
-        string? FoundingWorldName,
-        bool IsFallen);
 
     private sealed record EmpireListProjection(
         int EmpireId,
@@ -2964,6 +3070,9 @@ public sealed class StarWinExplorerQueryService(
         int ControlledWorldCount,
         int TrackedWorldCount,
         int GurpsTechLevel,
+        int StarWinTechLevel,
+        long NativePopulationMillions,
+        long EconomicPowerMcr,
         string GovernmentType,
         EmpireOrigin Origin,
         int? FoundingRaceId,

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -695,7 +695,8 @@ public sealed class StarWinExplorerQueryService(
                 sector.Id,
                 sector.Name,
                 sector.Configuration,
-                SavedRouteCount = sector.SavedRoutes.Count
+                SavedRouteCount = sector.SavedRoutes.Count,
+                SectorEmpireStatsEmpireCount = dbContext.SectorEmpireStats.Count(stat => stat.SectorId == sector.Id)
             })
             .FirstOrDefaultAsync(cancellationToken);
         if (stateRow is null)
@@ -750,7 +751,10 @@ public sealed class StarWinExplorerQueryService(
             CloneSectorConfiguration(stateRow.Configuration),
             stateRow.SavedRouteCount,
             savedRouteReport,
-            selectedSystemRouteCount);
+            selectedSystemRouteCount,
+            stateRow.Configuration.SectorEmpireStatsCalculatedAtUtc,
+            stateRow.Configuration.SectorEmpireStatsInvalidatedAtUtc,
+            stateRow.SectorEmpireStatsEmpireCount);
     }
 
     public async Task<ExplorerHyperlanePageState?> LoadHyperlanePageStateAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -1211,6 +1215,11 @@ public sealed class StarWinExplorerQueryService(
     public async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        if (await HasCurrentSectorEmpireStatsAsync(dbContext, sectorId, cancellationToken))
+        {
+            return await LoadEmpireFilterOptionsFromStatsAsync(dbContext, sectorId, cancellationToken);
+        }
+
         var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
         if (sectorEmpireIds.Count == 0)
         {
@@ -1281,6 +1290,11 @@ public sealed class StarWinExplorerQueryService(
         }
 
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        if (await HasCurrentSectorEmpireStatsAsync(dbContext, request.SectorId, cancellationToken))
+        {
+            return await LoadEmpireListPageFromStatsAsync(dbContext, request, empireId: null, cancellationToken);
+        }
+
         var pageRows = await dbContext.Database
             .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
                 request,
@@ -1308,6 +1322,24 @@ public sealed class StarWinExplorerQueryService(
         }
 
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        if (await HasCurrentSectorEmpireStatsAsync(dbContext, sectorId, cancellationToken))
+        {
+            var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
+            if (!sectorEmpireIds.Contains(empireId))
+            {
+                return null;
+            }
+
+            await EnsureSectorEmpireStatFreshAsync(dbContext, sectorId, empireId, cancellationToken);
+
+            var page = await LoadEmpireListPageFromStatsAsync(
+                dbContext,
+                new ExplorerEmpireListPageRequest(sectorId, 0, 1),
+                empireId,
+                cancellationToken);
+            return page.Items.FirstOrDefault();
+        }
+
         var item = await dbContext.Database
             .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
                 new ExplorerEmpireListPageRequest(sectorId, 0, 1),
@@ -1331,6 +1363,8 @@ public sealed class StarWinExplorerQueryService(
         {
             return null;
         }
+
+        await EnsureSectorEmpireStatFreshAsync(dbContext, sectorId, empireId, cancellationToken);
 
         var empire = await dbContext.Empires
             .AsNoTracking()
@@ -1536,6 +1570,256 @@ public sealed class StarWinExplorerQueryService(
             controlledColonyCount,
             empire.IsFallen,
             BuildEmpireCivilizationModifierDetail(empire));
+    }
+
+    private async Task<bool> HasCurrentSectorEmpireStatsAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var metadata = await dbContext.Set<SectorConfiguration>()
+            .AsNoTracking()
+            .Where(configuration => configuration.SectorId == sectorId)
+            .Select(configuration => new
+            {
+                configuration.SectorEmpireStatsCalculatedAtUtc,
+                configuration.SectorEmpireStatsInvalidatedAtUtc
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return metadata?.SectorEmpireStatsCalculatedAtUtc is DateTime
+            && metadata.SectorEmpireStatsInvalidatedAtUtc is null;
+    }
+
+    private async Task EnsureSectorEmpireStatFreshAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken)
+    {
+        var metadata = await dbContext.Set<SectorConfiguration>()
+            .AsNoTracking()
+            .Where(configuration => configuration.SectorId == sectorId)
+            .Select(configuration => new
+            {
+                configuration.SectorEmpireStatsCalculatedAtUtc,
+                configuration.SectorEmpireStatsInvalidatedAtUtc
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var statRow = await dbContext.SectorEmpireStats
+            .AsNoTracking()
+            .Where(stat => stat.SectorId == sectorId && stat.EmpireId == empireId)
+            .Select(stat => new
+            {
+                stat.LastCalculatedAtUtc
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var needsRefresh = metadata?.SectorEmpireStatsCalculatedAtUtc is not DateTime
+            || statRow is null
+            || metadata.SectorEmpireStatsInvalidatedAtUtc is DateTime invalidatedAt
+                && statRow.LastCalculatedAtUtc < invalidatedAt;
+        if (!needsRefresh)
+        {
+            return;
+        }
+
+        await SectorEmpireStatRefreshOperations.RefreshEmpireAsync(dbContext, sectorId, empireId, cancellationToken);
+    }
+
+    private async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsFromStatsAsync(
+        StarWinDbContext dbContext,
+        int sectorId,
+        CancellationToken cancellationToken)
+    {
+        var sectorStats = dbContext.SectorEmpireStats
+            .AsNoTracking()
+            .Where(stat => stat.SectorId == sectorId);
+        var hasStats = await sectorStats.AnyAsync(cancellationToken);
+        if (!hasStats)
+        {
+            return new ExplorerEmpireFilterOptions([]);
+        }
+
+        var raceOptions = await (
+            from stat in sectorStats
+            join membership in dbContext.Set<EmpireRaceMembership>().AsNoTracking() on stat.EmpireId equals membership.EmpireId
+            join race in dbContext.AlienRaces.AsNoTracking() on membership.RaceId equals race.Id
+            join homeWorld in dbContext.Worlds.AsNoTracking() on race.HomePlanetId equals homeWorld.Id into homeWorlds
+            from homeWorld in homeWorlds.DefaultIfEmpty()
+            orderby race.Name, race.Id
+            select new RaceDisplayProjection(
+                race.Id,
+                race.Name,
+                homeWorld != null ? homeWorld.Name : null))
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var maxControlledWorldCount = await sectorStats
+            .MaxAsync(stat => (int?)stat.ControlledWorldCount, cancellationToken)
+            ?? 0;
+        var sectorEmpires = from stat in sectorStats
+                            join empire in dbContext.Empires.AsNoTracking() on stat.EmpireId equals empire.Id
+                            select empire;
+        var maxNativePopulationMillions = await sectorEmpires
+            .MaxAsync(empire => (long?)empire.NativePopulationMillions, cancellationToken)
+            ?? 0L;
+        var maxStarWinTechLevel = await sectorEmpires
+            .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel, cancellationToken)
+            ?? 0;
+        var maxGurpsTechLevel = await sectorEmpires
+            .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel + 2, cancellationToken)
+            ?? 0;
+
+        return new ExplorerEmpireFilterOptions(raceOptions
+            .Select(race => new ExplorerLookupOption(
+                race.RaceId,
+                ResolveRaceDisplayName(race.RaceId, race.RaceName, race.HomeWorldName)))
+            .DistinctBy(race => race.Id)
+            .OrderBy(race => race.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(race => race.Id)
+            .ToList(),
+            Math.Max(1, maxControlledWorldCount),
+            Math.Max(1L, maxNativePopulationMillions),
+            Math.Max(1, maxGurpsTechLevel),
+            Math.Max(1, maxStarWinTechLevel));
+    }
+
+    private async Task<ExplorerEmpireListPage> LoadEmpireListPageFromStatsAsync(
+        StarWinDbContext dbContext,
+        ExplorerEmpireListPageRequest request,
+        int? empireId,
+        CancellationToken cancellationToken)
+    {
+        var projectionsQuery =
+            from stat in dbContext.SectorEmpireStats.AsNoTracking()
+            where stat.SectorId == request.SectorId
+            join empire in dbContext.Empires.AsNoTracking() on stat.EmpireId equals empire.Id
+            join foundingRace in dbContext.AlienRaces.AsNoTracking() on empire.Founding.FoundingRaceId equals (int?)foundingRace.Id into foundingRaces
+            from foundingRace in foundingRaces.DefaultIfEmpty()
+            join foundingWorld in dbContext.Worlds.AsNoTracking() on empire.Founding.FoundingWorldId equals foundingWorld.Id into foundingWorlds
+            from foundingWorld in foundingWorlds.DefaultIfEmpty()
+            select new
+            {
+                Stat = stat,
+                Empire = empire,
+                FoundingRaceName = foundingRace != null ? foundingRace.Name : null,
+                FoundingWorldName = foundingWorld != null ? foundingWorld.Name : null
+            };
+
+        if (empireId is int requestedEmpireId)
+        {
+            projectionsQuery = projectionsQuery.Where(item => item.Empire.Id == requestedEmpireId);
+        }
+
+        if (request.RaceId is int raceId)
+        {
+            projectionsQuery = projectionsQuery.Where(item =>
+                dbContext.Set<EmpireRaceMembership>().Any(membership =>
+                    membership.EmpireId == item.Empire.Id
+                    && membership.RaceId == raceId));
+        }
+
+        projectionsQuery = request.StatusFilter switch
+        {
+            ExplorerEmpireStatusFilter.Active => projectionsQuery.Where(item => !item.Empire.IsFallen),
+            ExplorerEmpireStatusFilter.Fallen => projectionsQuery.Where(item => item.Empire.IsFallen),
+            _ => projectionsQuery
+        };
+
+        if (request.MinControlledWorldCount.HasValue)
+        {
+            projectionsQuery = projectionsQuery.Where(item => item.Stat.ControlledWorldCount >= request.MinControlledWorldCount.Value);
+        }
+
+        if (request.MaxControlledWorldCount.HasValue)
+        {
+            projectionsQuery = projectionsQuery.Where(item => item.Stat.ControlledWorldCount <= request.MaxControlledWorldCount.Value);
+        }
+
+        if (request.MinNativePopulationMillions.HasValue)
+        {
+            projectionsQuery = projectionsQuery.Where(item => item.Empire.NativePopulationMillions >= request.MinNativePopulationMillions.Value);
+        }
+
+        if (request.MaxNativePopulationMillions.HasValue)
+        {
+            projectionsQuery = projectionsQuery.Where(item => item.Empire.NativePopulationMillions <= request.MaxNativePopulationMillions.Value);
+        }
+
+        if (request.MinTechLevel.HasValue)
+        {
+            projectionsQuery = request.TechLevelSystem == ExplorerEmpireTechLevelSystem.StarWin
+                ? projectionsQuery.Where(item => item.Empire.CivilizationProfile.TechLevel >= request.MinTechLevel.Value)
+                : projectionsQuery.Where(item => item.Empire.CivilizationProfile.TechLevel + 2 >= request.MinTechLevel.Value);
+        }
+
+        if (request.MaxTechLevel.HasValue)
+        {
+            projectionsQuery = request.TechLevelSystem == ExplorerEmpireTechLevelSystem.StarWin
+                ? projectionsQuery.Where(item => item.Empire.CivilizationProfile.TechLevel <= request.MaxTechLevel.Value)
+                : projectionsQuery.Where(item => item.Empire.CivilizationProfile.TechLevel + 2 <= request.MaxTechLevel.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+        {
+            var queryPattern = $"%{request.Query.Trim()}%";
+            projectionsQuery = projectionsQuery.Where(item =>
+                EF.Functions.Like(item.Empire.Name, queryPattern)
+                || dbContext.EntityNotes.Any(note =>
+                    note.TargetId == item.Empire.Id
+                    && (note.TargetKind == EntityNoteTargetKind.Empire || note.TargetKind == EntityNoteTargetKind.EmpireSummary)
+                    && EF.Functions.Like(note.Markdown, queryPattern)));
+        }
+
+        projectionsQuery = request.SortOption switch
+        {
+            ExplorerEmpireSortOption.Population => projectionsQuery
+                .OrderByDescending(item => item.Empire.NativePopulationMillions)
+                .ThenBy(item => item.Empire.Name)
+                .ThenBy(item => item.Empire.Id),
+            ExplorerEmpireSortOption.ControlledWorlds => projectionsQuery
+                .OrderByDescending(item => item.Stat.ControlledWorldCount)
+                .ThenBy(item => item.Empire.Name)
+                .ThenBy(item => item.Empire.Id),
+            ExplorerEmpireSortOption.EconomicPower => projectionsQuery
+                .OrderByDescending(item => item.Empire.EconomicPowerMcr)
+                .ThenBy(item => item.Empire.Name)
+                .ThenBy(item => item.Empire.Id),
+            _ => projectionsQuery
+                .OrderBy(item => item.Empire.Name)
+                .ThenBy(item => item.Empire.Id)
+        };
+
+        var pageRows = await projectionsQuery
+            .Select(item => new EmpireListProjection(
+                item.Empire.Id,
+                item.Empire.Name,
+                item.Stat.ControlledWorldCount,
+                item.Stat.TrackedWorldCount,
+                item.Empire.CivilizationProfile.TechLevel + 2,
+                item.Empire.CivilizationProfile.TechLevel,
+                item.Empire.NativePopulationMillions,
+                item.Empire.EconomicPowerMcr,
+                item.Empire.GovernmentType,
+                item.Empire.Founding.Origin,
+                item.Empire.Founding.FoundingRaceId,
+                item.Empire.Founding.FoundingWorldId,
+                item.FoundingRaceName,
+                item.FoundingWorldName,
+                item.Empire.IsFallen))
+            .Skip(request.Offset)
+            .Take(request.Limit + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = pageRows.Count > request.Limit;
+        return new ExplorerEmpireListPage(
+            pageRows
+                .Take(request.Limit)
+                .Select(BuildEmpireListItem)
+                .ToList(),
+            hasMore);
     }
 
     public async Task<ExplorerReligionFilterOptions> LoadReligionFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
@@ -2049,6 +2333,8 @@ public sealed class StarWinExplorerQueryService(
             Tl10MaximumDistanceParsecs = configuration.Tl10MaximumDistanceParsecs,
             Tl10OffLaneSpeedMultiplier = configuration.Tl10OffLaneSpeedMultiplier,
             Tl10HyperlaneSpeedModifier = configuration.Tl10HyperlaneSpeedModifier,
+            SectorEmpireStatsCalculatedAtUtc = configuration.SectorEmpireStatsCalculatedAtUtc,
+            SectorEmpireStatsInvalidatedAtUtc = configuration.SectorEmpireStatsInvalidatedAtUtc,
             UpdatedAtUtc = configuration.UpdatedAtUtc
         };
     }

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -19,6 +19,7 @@ public sealed class StarWinExplorerQueryService(
     ILogger<StarWinExplorerQueryService>? logger = null) : IStarWinExplorerQueryService
 {
     private static readonly TimeSpan SectorEntityUsageCacheDuration = TimeSpan.FromSeconds(20);
+    private const int MaxEmpireFallbackRecoveryAttempts = 1;
     private readonly Dictionary<int, CachedSectorEntityUsage> sectorEntityUsageCache = [];
     private readonly ILogger<StarWinExplorerQueryService> logger = logger ?? NullLogger<StarWinExplorerQueryService>.Instance;
 
@@ -1215,6 +1216,14 @@ public sealed class StarWinExplorerQueryService(
 
     public async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsAsync(int sectorId, CancellationToken cancellationToken = default)
     {
+        return await LoadEmpireFilterOptionsCoreAsync(sectorId, recoveryAttempt: 0, cancellationToken);
+    }
+
+    private async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsCoreAsync(
+        int sectorId,
+        int recoveryAttempt,
+        CancellationToken cancellationToken)
+    {
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         if (await HasCurrentSectorEmpireStatsAsync(dbContext, sectorId, cancellationToken))
         {
@@ -1284,18 +1293,30 @@ public sealed class StarWinExplorerQueryService(
                 Math.Max(1, maxGurpsTechLevel),
                 Math.Max(1, maxStarWinTechLevel));
         }
-        catch (Exception ex) when (IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
+        catch (Exception ex) when (recoveryAttempt < MaxEmpireFallbackRecoveryAttempts
+            && IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
         {
             return await RetryWithRebuiltSectorEmpireStatsAsync(
                 sectorId,
                 nameof(LoadEmpireFilterOptionsAsync),
                 ex,
-                (retryContext, retryCancellationToken) => LoadEmpireFilterOptionsFromStatsAsync(retryContext, sectorId, retryCancellationToken),
+                retryCancellationToken => LoadEmpireFilterOptionsCoreAsync(
+                    sectorId,
+                    recoveryAttempt + 1,
+                    retryCancellationToken),
                 cancellationToken);
         }
     }
 
     public async Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)
+    {
+        return await LoadEmpireListPageCoreAsync(request, recoveryAttempt: 0, cancellationToken);
+    }
+
+    private async Task<ExplorerEmpireListPage> LoadEmpireListPageCoreAsync(
+        ExplorerEmpireListPageRequest request,
+        int recoveryAttempt,
+        CancellationToken cancellationToken)
     {
         if (request.SectorId <= 0)
         {
@@ -1328,18 +1349,31 @@ public sealed class StarWinExplorerQueryService(
                     .ToList(),
                 hasMore);
         }
-        catch (Exception ex) when (IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
+        catch (Exception ex) when (recoveryAttempt < MaxEmpireFallbackRecoveryAttempts
+            && IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
         {
             return await RetryWithRebuiltSectorEmpireStatsAsync(
                 request.SectorId,
                 nameof(LoadEmpireListPageAsync),
                 ex,
-                (retryContext, retryCancellationToken) => LoadEmpireListPageFromStatsAsync(retryContext, request, empireId: null, retryCancellationToken),
+                retryCancellationToken => LoadEmpireListPageCoreAsync(
+                    request,
+                    recoveryAttempt + 1,
+                    retryCancellationToken),
                 cancellationToken);
         }
     }
 
     public async Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
+    {
+        return await LoadEmpireListItemCoreAsync(sectorId, empireId, recoveryAttempt: 0, cancellationToken);
+    }
+
+    private async Task<ExplorerEmpireListItem?> LoadEmpireListItemCoreAsync(
+        int sectorId,
+        int empireId,
+        int recoveryAttempt,
+        CancellationToken cancellationToken)
     {
         if (sectorId <= 0 || empireId <= 0)
         {
@@ -1380,21 +1414,18 @@ public sealed class StarWinExplorerQueryService(
                 ? null
                 : BuildEmpireListItem(MapEmpireListSqlRow(item));
         }
-        catch (Exception ex) when (IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
+        catch (Exception ex) when (recoveryAttempt < MaxEmpireFallbackRecoveryAttempts
+            && IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
         {
             return await RetryWithRebuiltSectorEmpireStatsAsync(
                 sectorId,
                 nameof(LoadEmpireListItemAsync),
                 ex,
-                async (retryContext, retryCancellationToken) =>
-                {
-                    var page = await LoadEmpireListPageFromStatsAsync(
-                        retryContext,
-                        new ExplorerEmpireListPageRequest(sectorId, 0, 1),
-                        empireId,
-                        retryCancellationToken);
-                    return page.Items.FirstOrDefault();
-                },
+                retryCancellationToken => LoadEmpireListItemCoreAsync(
+                    sectorId,
+                    empireId,
+                    recoveryAttempt + 1,
+                    retryCancellationToken),
                 cancellationToken);
         }
     }
@@ -1677,7 +1708,7 @@ public sealed class StarWinExplorerQueryService(
         int sectorId,
         string operationName,
         Exception exception,
-        Func<StarWinDbContext, CancellationToken, Task<T>> retryOperation,
+        Func<CancellationToken, Task<T>> retryOperation,
         CancellationToken cancellationToken)
     {
         logger.LogWarning(
@@ -1689,8 +1720,7 @@ public sealed class StarWinExplorerQueryService(
         await using var rebuildContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         await SectorEmpireStatRefreshOperations.RebuildSectorAsync(rebuildContext, sectorId, cancellationToken);
 
-        await using var retryContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-        return await retryOperation(retryContext, cancellationToken);
+        return await retryOperation(cancellationToken);
     }
 
     private static bool IsRecoverableEmpireFallbackTimeout(Exception exception, CancellationToken cancellationToken)

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -1232,6 +1232,33 @@ public sealed class StarWinExplorerQueryService(
             .Distinct()
             .ToListAsync(cancellationToken);
 
+        var controlledWorldCounts = await (
+            from colony in dbContext.Colonies.AsNoTracking()
+            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+            where system.SectorId == sectorId
+                && colony.ControllingEmpireId.HasValue
+                && sectorEmpireIds.Contains(colony.ControllingEmpireId.Value)
+            group colony by colony.ControllingEmpireId into grouped
+            select grouped.Count())
+            .ToListAsync(cancellationToken);
+        var maxControlledWorldCount = controlledWorldCounts.Count > 0
+            ? controlledWorldCounts.Max()
+            : 0;
+
+        var sectorEmpires = dbContext.Empires
+            .AsNoTracking()
+            .Where(empire => sectorEmpireIds.Contains(empire.Id));
+        var maxNativePopulationMillions = await sectorEmpires
+            .MaxAsync(empire => (long?)empire.NativePopulationMillions, cancellationToken)
+            ?? 0L;
+        var maxStarWinTechLevel = await sectorEmpires
+            .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel, cancellationToken)
+            ?? 0;
+        var maxGurpsTechLevel = await sectorEmpires
+            .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel + 2, cancellationToken)
+            ?? 0;
+
         return new ExplorerEmpireFilterOptions(raceOptions
             .Select(race => new ExplorerLookupOption(
                 race.RaceId,
@@ -1239,7 +1266,11 @@ public sealed class StarWinExplorerQueryService(
             .DistinctBy(race => race.Id)
             .OrderBy(race => race.Name, StringComparer.OrdinalIgnoreCase)
             .ThenBy(race => race.Id)
-            .ToList());
+            .ToList(),
+            Math.Max(1, maxControlledWorldCount),
+            Math.Max(1L, maxNativePopulationMillions),
+            Math.Max(1, maxGurpsTechLevel),
+            Math.Max(1, maxStarWinTechLevel));
     }
 
     public async Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Data.Common;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -1220,66 +1221,78 @@ public sealed class StarWinExplorerQueryService(
             return await LoadEmpireFilterOptionsFromStatsAsync(dbContext, sectorId, cancellationToken);
         }
 
-        var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
-        if (sectorEmpireIds.Count == 0)
+        try
         {
-            return new ExplorerEmpireFilterOptions([]);
+            var sectorEmpireIds = (await GetCachedSectorEntityUsageAsync(dbContext, sectorId, cancellationToken)).EmpireIds;
+            if (sectorEmpireIds.Count == 0)
+            {
+                return new ExplorerEmpireFilterOptions([]);
+            }
+
+            var raceOptions = await (
+                from empire in dbContext.Empires.AsNoTracking()
+                from membership in empire.RaceMemberships
+                join race in dbContext.AlienRaces.AsNoTracking() on membership.RaceId equals race.Id
+                join homeWorld in dbContext.Worlds.AsNoTracking() on race.HomePlanetId equals homeWorld.Id into homeWorlds
+                from homeWorld in homeWorlds.DefaultIfEmpty()
+                where sectorEmpireIds.Contains(empire.Id)
+                orderby race.Name, race.Id
+                select new RaceDisplayProjection(
+                    race.Id,
+                    race.Name,
+                    homeWorld != null ? homeWorld.Name : null))
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            var controlledWorldCounts = await (
+                from colony in dbContext.Colonies.AsNoTracking()
+                join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
+                join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
+                where system.SectorId == sectorId
+                    && colony.ControllingEmpireId.HasValue
+                    && sectorEmpireIds.Contains(colony.ControllingEmpireId.Value)
+                group colony by colony.ControllingEmpireId into grouped
+                select grouped.Count())
+                .ToListAsync(cancellationToken);
+            var maxControlledWorldCount = controlledWorldCounts.Count > 0
+                ? controlledWorldCounts.Max()
+                : 0;
+
+            var sectorEmpires = dbContext.Empires
+                .AsNoTracking()
+                .Where(empire => sectorEmpireIds.Contains(empire.Id));
+            var maxNativePopulationMillions = await sectorEmpires
+                .MaxAsync(empire => (long?)empire.NativePopulationMillions, cancellationToken)
+                ?? 0L;
+            var maxStarWinTechLevel = await sectorEmpires
+                .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel, cancellationToken)
+                ?? 0;
+            var maxGurpsTechLevel = await sectorEmpires
+                .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel + 2, cancellationToken)
+                ?? 0;
+
+            return new ExplorerEmpireFilterOptions(raceOptions
+                .Select(race => new ExplorerLookupOption(
+                    race.RaceId,
+                    ResolveRaceDisplayName(race.RaceId, race.RaceName, race.HomeWorldName)))
+                .DistinctBy(race => race.Id)
+                .OrderBy(race => race.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(race => race.Id)
+                .ToList(),
+                Math.Max(1, maxControlledWorldCount),
+                Math.Max(1L, maxNativePopulationMillions),
+                Math.Max(1, maxGurpsTechLevel),
+                Math.Max(1, maxStarWinTechLevel));
         }
-
-        var raceOptions = await (
-            from empire in dbContext.Empires.AsNoTracking()
-            from membership in empire.RaceMemberships
-            join race in dbContext.AlienRaces.AsNoTracking() on membership.RaceId equals race.Id
-            join homeWorld in dbContext.Worlds.AsNoTracking() on race.HomePlanetId equals homeWorld.Id into homeWorlds
-            from homeWorld in homeWorlds.DefaultIfEmpty()
-            where sectorEmpireIds.Contains(empire.Id)
-            orderby race.Name, race.Id
-            select new RaceDisplayProjection(
-                race.Id,
-                race.Name,
-                homeWorld != null ? homeWorld.Name : null))
-            .Distinct()
-            .ToListAsync(cancellationToken);
-
-        var controlledWorldCounts = await (
-            from colony in dbContext.Colonies.AsNoTracking()
-            join world in dbContext.Worlds.AsNoTracking() on colony.WorldId equals world.Id
-            join system in dbContext.StarSystems.AsNoTracking() on world.StarSystemId equals system.Id
-            where system.SectorId == sectorId
-                && colony.ControllingEmpireId.HasValue
-                && sectorEmpireIds.Contains(colony.ControllingEmpireId.Value)
-            group colony by colony.ControllingEmpireId into grouped
-            select grouped.Count())
-            .ToListAsync(cancellationToken);
-        var maxControlledWorldCount = controlledWorldCounts.Count > 0
-            ? controlledWorldCounts.Max()
-            : 0;
-
-        var sectorEmpires = dbContext.Empires
-            .AsNoTracking()
-            .Where(empire => sectorEmpireIds.Contains(empire.Id));
-        var maxNativePopulationMillions = await sectorEmpires
-            .MaxAsync(empire => (long?)empire.NativePopulationMillions, cancellationToken)
-            ?? 0L;
-        var maxStarWinTechLevel = await sectorEmpires
-            .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel, cancellationToken)
-            ?? 0;
-        var maxGurpsTechLevel = await sectorEmpires
-            .MaxAsync(empire => (int?)empire.CivilizationProfile.TechLevel + 2, cancellationToken)
-            ?? 0;
-
-        return new ExplorerEmpireFilterOptions(raceOptions
-            .Select(race => new ExplorerLookupOption(
-                race.RaceId,
-                ResolveRaceDisplayName(race.RaceId, race.RaceName, race.HomeWorldName)))
-            .DistinctBy(race => race.Id)
-            .OrderBy(race => race.Name, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(race => race.Id)
-            .ToList(),
-            Math.Max(1, maxControlledWorldCount),
-            Math.Max(1L, maxNativePopulationMillions),
-            Math.Max(1, maxGurpsTechLevel),
-            Math.Max(1, maxStarWinTechLevel));
+        catch (Exception ex) when (IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
+        {
+            return await RetryWithRebuiltSectorEmpireStatsAsync(
+                sectorId,
+                nameof(LoadEmpireFilterOptionsAsync),
+                ex,
+                (retryContext, retryCancellationToken) => LoadEmpireFilterOptionsFromStatsAsync(retryContext, sectorId, retryCancellationToken),
+                cancellationToken);
+        }
     }
 
     public async Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)
@@ -1295,23 +1308,35 @@ public sealed class StarWinExplorerQueryService(
             return await LoadEmpireListPageFromStatsAsync(dbContext, request, empireId: null, cancellationToken);
         }
 
-        var pageRows = await dbContext.Database
-            .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
-                request,
-                empireId: null,
-                limit: request.Limit + 1,
-                offset: request.Offset,
-                dbContext.Database.ProviderName))
-            .ToListAsync(cancellationToken);
+        try
+        {
+            var pageRows = await dbContext.Database
+                .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
+                    request,
+                    empireId: null,
+                    limit: request.Limit + 1,
+                    offset: request.Offset,
+                    dbContext.Database.ProviderName))
+                .ToListAsync(cancellationToken);
 
-        var hasMore = pageRows.Count > request.Limit;
-        return new ExplorerEmpireListPage(
-            pageRows
-                .Take(request.Limit)
-                .Select(MapEmpireListSqlRow)
-                .Select(BuildEmpireListItem)
-                .ToList(),
-            hasMore);
+            var hasMore = pageRows.Count > request.Limit;
+            return new ExplorerEmpireListPage(
+                pageRows
+                    .Take(request.Limit)
+                    .Select(MapEmpireListSqlRow)
+                    .Select(BuildEmpireListItem)
+                    .ToList(),
+                hasMore);
+        }
+        catch (Exception ex) when (IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
+        {
+            return await RetryWithRebuiltSectorEmpireStatsAsync(
+                request.SectorId,
+                nameof(LoadEmpireListPageAsync),
+                ex,
+                (retryContext, retryCancellationToken) => LoadEmpireListPageFromStatsAsync(retryContext, request, empireId: null, retryCancellationToken),
+                cancellationToken);
+        }
     }
 
     public async Task<ExplorerEmpireListItem?> LoadEmpireListItemAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
@@ -1340,18 +1365,38 @@ public sealed class StarWinExplorerQueryService(
             return page.Items.FirstOrDefault();
         }
 
-        var item = await dbContext.Database
-            .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
-                new ExplorerEmpireListPageRequest(sectorId, 0, 1),
-                empireId,
-                limit: 1,
-                offset: 0,
-                dbContext.Database.ProviderName))
-            .FirstOrDefaultAsync(cancellationToken);
+        try
+        {
+            var item = await dbContext.Database
+                .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
+                    new ExplorerEmpireListPageRequest(sectorId, 0, 1),
+                    empireId,
+                    limit: 1,
+                    offset: 0,
+                    dbContext.Database.ProviderName))
+                .FirstOrDefaultAsync(cancellationToken);
 
-        return item is null
-            ? null
-            : BuildEmpireListItem(MapEmpireListSqlRow(item));
+            return item is null
+                ? null
+                : BuildEmpireListItem(MapEmpireListSqlRow(item));
+        }
+        catch (Exception ex) when (IsRecoverableEmpireFallbackTimeout(ex, cancellationToken))
+        {
+            return await RetryWithRebuiltSectorEmpireStatsAsync(
+                sectorId,
+                nameof(LoadEmpireListItemAsync),
+                ex,
+                async (retryContext, retryCancellationToken) =>
+                {
+                    var page = await LoadEmpireListPageFromStatsAsync(
+                        retryContext,
+                        new ExplorerEmpireListPageRequest(sectorId, 0, 1),
+                        empireId,
+                        retryCancellationToken);
+                    return page.Items.FirstOrDefault();
+                },
+                cancellationToken);
+        }
     }
 
     public async Task<ExplorerEmpireDetail?> LoadEmpireDetailAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
@@ -1626,6 +1671,73 @@ public sealed class StarWinExplorerQueryService(
         }
 
         await SectorEmpireStatRefreshOperations.RefreshEmpireAsync(dbContext, sectorId, empireId, cancellationToken);
+    }
+
+    private async Task<T> RetryWithRebuiltSectorEmpireStatsAsync<T>(
+        int sectorId,
+        string operationName,
+        Exception exception,
+        Func<StarWinDbContext, CancellationToken, Task<T>> retryOperation,
+        CancellationToken cancellationToken)
+    {
+        logger.LogWarning(
+            exception,
+            "Explorer empire fallback timed out during {Operation}. sectorId={SectorId}. Rebuilding sector empire stats and retrying with the cache.",
+            operationName,
+            sectorId);
+
+        await using var rebuildContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        await SectorEmpireStatRefreshOperations.RebuildSectorAsync(rebuildContext, sectorId, cancellationToken);
+
+        await using var retryContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await retryOperation(retryContext, cancellationToken);
+    }
+
+    private static bool IsRecoverableEmpireFallbackTimeout(Exception exception, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested || exception is OperationCanceledException)
+        {
+            return false;
+        }
+
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is TimeoutException)
+            {
+                return true;
+            }
+
+            if (current is DbException dbException && IsCommandTimeoutMessage(dbException.Message))
+            {
+                return true;
+            }
+
+            if (current.GetType().FullName == "Microsoft.Data.SqlClient.SqlException"
+                && current.GetType().GetProperty("Number")?.GetValue(current) is int sqlErrorNumber
+                && sqlErrorNumber == -2)
+            {
+                return true;
+            }
+
+            if (IsCommandTimeoutMessage(current.Message))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCommandTimeoutMessage(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return false;
+        }
+
+        return message.Contains("Execution Timeout Expired", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("timeout period elapsed", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("command timeout", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<ExplorerEmpireFilterOptions> LoadEmpireFilterOptionsFromStatsAsync(

--- a/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
+++ b/StarWin.Infrastructure/Services/StarWinExplorerQueryService.cs
@@ -1251,7 +1251,12 @@ public sealed class StarWinExplorerQueryService(
 
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var pageRows = await dbContext.Database
-            .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(request, empireId: null, limit: request.Limit + 1, offset: request.Offset))
+            .SqlQuery<EmpireListSqlRow>(BuildEmpireListSql(
+                request,
+                empireId: null,
+                limit: request.Limit + 1,
+                offset: request.Offset,
+                dbContext.Database.ProviderName))
             .ToListAsync(cancellationToken);
 
         var hasMore = pageRows.Count > request.Limit;
@@ -1277,7 +1282,8 @@ public sealed class StarWinExplorerQueryService(
                 new ExplorerEmpireListPageRequest(sectorId, 0, 1),
                 empireId,
                 limit: 1,
-                offset: 0))
+                offset: 0,
+                dbContext.Database.ProviderName))
             .FirstOrDefaultAsync(cancellationToken);
 
         return item is null
@@ -2581,9 +2587,14 @@ public sealed class StarWinExplorerQueryService(
         ExplorerEmpireListPageRequest request,
         int? empireId,
         int limit,
-        int offset)
+        int offset,
+        string? providerName)
     {
-        var orderByClause = GetEmpireListOrderByClause(request.SortOption);
+        var usesSqlServerSyntax = providerName?.Contains("SqlServer", StringComparison.OrdinalIgnoreCase) == true;
+        var orderByClause = GetEmpireListOrderByClause(request.SortOption, usesSqlServerSyntax);
+        var pagingClause = usesSqlServerSyntax
+            ? "OFFSET {16} ROWS FETCH NEXT {15} ROWS ONLY"
+            : "LIMIT {15} OFFSET {16}";
         var queryPattern = string.IsNullOrWhiteSpace(request.Query)
             ? null
             : $"%{request.Query.Trim()}%";
@@ -2715,10 +2726,7 @@ public sealed class StarWinExplorerQueryService(
                     )
                   )
             ORDER BY 
-            """ + orderByClause + " " + """
-            LIMIT {15}
-            OFFSET {16}
-            """;
+            """ + orderByClause + " " + pagingClause;
 
         return FormattableStringFactory.Create(
             sqlFormat,
@@ -2741,14 +2749,18 @@ public sealed class StarWinExplorerQueryService(
             offset);
     }
 
-    private static string GetEmpireListOrderByClause(ExplorerEmpireSortOption sortOption)
+    private static string GetEmpireListOrderByClause(ExplorerEmpireSortOption sortOption, bool usesSqlServerSyntax)
     {
+        var nameOrderingClause = usesSqlServerSyntax
+            ? "Empires.Name ASC, Empires.Id ASC"
+            : "Empires.Name COLLATE NOCASE ASC, Empires.Id ASC";
+
         return sortOption switch
         {
-            ExplorerEmpireSortOption.Population => "Empires.NativePopulationMillions DESC, Empires.Name COLLATE NOCASE ASC, Empires.Id ASC",
-            ExplorerEmpireSortOption.ControlledWorlds => "ControlledWorldCount DESC, Empires.Name COLLATE NOCASE ASC, Empires.Id ASC",
-            ExplorerEmpireSortOption.EconomicPower => "Empires.EconomicPowerMcr DESC, Empires.Name COLLATE NOCASE ASC, Empires.Id ASC",
-            _ => "Empires.Name COLLATE NOCASE ASC, Empires.Id ASC"
+            ExplorerEmpireSortOption.Population => $"Empires.NativePopulationMillions DESC, {nameOrderingClause}",
+            ExplorerEmpireSortOption.ControlledWorlds => $"ControlledWorldCount DESC, {nameOrderingClause}",
+            ExplorerEmpireSortOption.EconomicPower => $"Empires.EconomicPowerMcr DESC, {nameOrderingClause}",
+            _ => nameOrderingClause
         };
     }
 

--- a/StarWin.Infrastructure/Services/StarWinIndependentColonyService.cs
+++ b/StarWin.Infrastructure/Services/StarWinIndependentColonyService.cs
@@ -90,6 +90,15 @@ public sealed class StarWinIndependentColonyService(IDbContextFactory<StarWinDbC
                     ? $"Converted {createdEmpires.Count:N0} independent colonies into empires."
                     : $"Converted {createdEmpires.Count:N0} independent colonies into empires and assigned {assignments.Count:N0} colonies to independent empires."
             });
+            var configuration = await dbContext.Set<SectorConfiguration>()
+                .FirstOrDefaultAsync(item => item.SectorId == sectorId, cancellationToken);
+            if (configuration is null)
+            {
+                configuration = new SectorConfiguration { SectorId = sectorId };
+                dbContext.Set<SectorConfiguration>().Add(configuration);
+            }
+
+            configuration.SectorEmpireStatsInvalidatedAtUtc = DateTime.UtcNow;
             await dbContext.SaveChangesAsync(cancellationToken);
         }
 

--- a/StarWin.Infrastructure/Services/StarWinLegacyImportService.cs
+++ b/StarWin.Infrastructure/Services/StarWinLegacyImportService.cs
@@ -1611,6 +1611,9 @@ public sealed class StarWinLegacyImportService(IDbContextFactory<StarWinDbContex
             dbContext.ChangeTracker.AutoDetectChangesEnabled = originalAutoDetectChanges;
         }
 
+        await ReportImportProgressAsync(progress, 100, "Refreshing sector empire stats...", $"Caching current sector empire counts for {sector.Name}.");
+        await PopulateSectorEmpireStatsAsync(sector.Id, cancellationToken);
+
         return new StarWinLegacyImportResult(
             true,
             sector.Id,
@@ -1637,6 +1640,12 @@ public sealed class StarWinLegacyImportService(IDbContextFactory<StarWinDbContex
             detail));
 
         await Task.Yield();
+    }
+
+    private async Task PopulateSectorEmpireStatsAsync(int sectorId, CancellationToken cancellationToken)
+    {
+        await using var statsContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        await SectorEmpireStatRefreshOperations.RebuildSectorAsync(statsContext, sectorId, cancellationToken);
     }
 
     private async Task FlushImportChangesAsync(

--- a/StarWin.Infrastructure/Services/StarWinSectorEmpireStatsService.cs
+++ b/StarWin.Infrastructure/Services/StarWinSectorEmpireStatsService.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using StarWin.Application.Services;
+using StarWin.Infrastructure.Data;
+
+namespace StarWin.Infrastructure.Services;
+
+public sealed class StarWinSectorEmpireStatsService(IDbContextFactory<StarWinDbContext> dbContextFactory) : IStarWinSectorEmpireStatsService
+{
+    public async Task<SectorEmpireStatsRefreshResult> RebuildSectorStatsAsync(
+        int sectorId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await SectorEmpireStatRefreshOperations.RebuildSectorAsync(dbContext, sectorId, cancellationToken);
+    }
+
+    public async Task<SectorEmpireStatRefreshResult?> RefreshEmpireStatsAsync(
+        int sectorId,
+        int empireId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await SectorEmpireStatRefreshOperations.RefreshEmpireAsync(dbContext, sectorId, empireId, cancellationToken);
+    }
+
+    public async Task MarkSectorStatsStaleAsync(
+        int sectorId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        await SectorEmpireStatRefreshOperations.MarkSectorStatsStaleAsync(dbContext, sectorId, cancellationToken);
+    }
+}

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -41,18 +41,19 @@ public sealed class AppCssTests
     }
 
     [Fact]
-    public void ExplorerControlStripPromotesTabsAboveSelectorsAtResponsiveBreakpoint()
+    public void ExplorerControlStripDefaultsToTabFirstLayoutAndOnlySplitsAtVeryWideBreakpoint()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
         var css = File.ReadAllText(cssPath);
 
+        Assert.Contains("grid-template-columns: minmax(0, 1fr);", css);
         Assert.Contains(".control-strip-fields {", css);
         Assert.Contains(".control-strip-tabs {", css);
-        Assert.Contains("@media (max-width: 1280px) {", css);
-        Assert.Contains(".control-strip-fields .archive-search {", css);
-        Assert.Contains("grid-column: 1 / -1;", css);
         Assert.Contains("order: -1;", css);
+        Assert.Contains("@media (min-width: 1900px) {", css);
+        Assert.Contains("grid-template-columns: minmax(0, 760px) minmax(0, 1fr);", css);
+        Assert.Contains("order: 0;", css);
     }
 
     [Fact]

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -41,7 +41,7 @@ public sealed class AppCssTests
     }
 
     [Fact]
-    public void ExplorerControlStripDefaultsToTabFirstLayoutAndOnlySplitsAtVeryWideBreakpoint()
+    public void ExplorerControlStripUsesWideGridPlacementWithoutVisualReordering()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
@@ -50,10 +50,10 @@ public sealed class AppCssTests
         Assert.Contains("grid-template-columns: minmax(0, 1fr);", css);
         Assert.Contains(".control-strip-fields {", css);
         Assert.Contains(".control-strip-tabs {", css);
-        Assert.Contains("order: -1;", css);
         Assert.Contains("@media (min-width: 1900px) {", css);
         Assert.Contains("grid-template-columns: minmax(0, 760px) minmax(0, 1fr);", css);
-        Assert.Contains("order: 0;", css);
+        Assert.Contains("grid-column: 2;", css);
+        Assert.Contains("grid-row: 1;", css);
     }
 
     [Fact]

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -51,8 +51,8 @@ public sealed class AppCssTests
         Assert.Contains(".control-strip-fields {", css);
         Assert.Contains(".control-strip-tabs {", css);
         Assert.Contains("@media (min-width: 1900px) {", css);
-        Assert.Contains("grid-template-columns: minmax(0, 760px) minmax(0, 1fr);", css);
-        Assert.Contains("grid-column: 2;", css);
+        Assert.Contains("grid-template-columns: minmax(0, 1fr) minmax(0, 760px);", css);
+        Assert.Contains("grid-column: 1;", css);
         Assert.Contains("grid-row: 1;", css);
     }
 

--- a/StarWin.Web.Tests/Components/AppCssTests.cs
+++ b/StarWin.Web.Tests/Components/AppCssTests.cs
@@ -41,6 +41,21 @@ public sealed class AppCssTests
     }
 
     [Fact]
+    public void ExplorerControlStripPromotesTabsAboveSelectorsAtResponsiveBreakpoint()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var cssPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "app.css");
+        var css = File.ReadAllText(cssPath);
+
+        Assert.Contains(".control-strip-fields {", css);
+        Assert.Contains(".control-strip-tabs {", css);
+        Assert.Contains("@media (max-width: 1280px) {", css);
+        Assert.Contains(".control-strip-fields .archive-search {", css);
+        Assert.Contains("grid-column: 1 / -1;", css);
+        Assert.Contains("order: -1;", css);
+    }
+
+    [Fact]
     public void NavigationFocusTargetsMainContentInsteadOfHeading()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));

--- a/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
+++ b/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
@@ -1,0 +1,47 @@
+using Bunit;
+using StarWin.Domain.Model.Entity.StarMap;
+using StarWin.Web.Components.Explorer;
+
+namespace StarWin.Web.Tests.Components;
+
+public sealed class SectorExplorerShellTests : BunitContext
+{
+    [Fact]
+    public void GroupsTabsSeparatelyFromExplorerSelectorsAndSearch()
+    {
+        var sector = new StarWinSector
+        {
+            Id = 7,
+            Name = "Del Corra"
+        };
+        var system = new StarSystem
+        {
+            Id = 11,
+            SectorId = sector.Id,
+            Name = "Helios"
+        };
+        sector.Systems.Add(system);
+
+        var cut = Render<SectorExplorerShell>(parameters => parameters
+            .Add(component => component.Sectors, [sector])
+            .Add(component => component.Systems, [system])
+            .Add(component => component.SelectedSectorId, sector.Id)
+            .Add(component => component.SelectedSystemText, "11 - Helios")
+            .Add(component => component.Sections, ["Overview", "Systems"])
+            .Add(component => component.ActiveSection, "Overview")
+            .Add(component => component.SectionHrefFactory, section => $"/sector-explorer/{section.ToLowerInvariant()}"));
+
+        var fieldGroup = cut.Find(".control-strip-fields");
+        var tabGroup = cut.Find(".control-strip-tabs");
+
+        Assert.Single(fieldGroup.GetElementsByClassName("sector-field"));
+        Assert.Single(fieldGroup.GetElementsByClassName("system-field"));
+        Assert.Single(fieldGroup.GetElementsByClassName("archive-search"));
+
+        var sectionLinks = tabGroup.QuerySelectorAll(".section-tabs a")
+            .Select(link => link.TextContent.Trim())
+            .ToArray();
+
+        Assert.Equal(["Overview", "Systems"], sectionLinks);
+    }
+}

--- a/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
+++ b/StarWin.Web.Tests/Components/SectorExplorerShellTests.cs
@@ -31,9 +31,12 @@ public sealed class SectorExplorerShellTests : BunitContext
             .Add(component => component.ActiveSection, "Overview")
             .Add(component => component.SectionHrefFactory, section => $"/sector-explorer/{section.ToLowerInvariant()}"));
 
+        var controlStrip = cut.Find(".control-strip");
         var fieldGroup = cut.Find(".control-strip-fields");
         var tabGroup = cut.Find(".control-strip-tabs");
 
+        Assert.Contains("control-strip-tabs", controlStrip.Children[0].ClassName);
+        Assert.Contains("control-strip-fields", controlStrip.Children[1].ClassName);
         Assert.Single(fieldGroup.GetElementsByClassName("sector-field"));
         Assert.Single(fieldGroup.GetElementsByClassName("system-field"));
         Assert.Single(fieldGroup.GetElementsByClassName("archive-search"));

--- a/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
+++ b/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
@@ -26,4 +26,37 @@ public sealed class SectorMap3dScriptTests
         Assert.Contains("return selected ? 1.44 : 1.08;", script);
         Assert.Contains("const radius = (0.34 + Math.min(0.76, Math.max(0.18, scale) * 0.34)) * 2;", script);
     }
+
+    [Fact]
+    public void KeyboardNavigationTracksHeldKeysAndCancelsConflicts()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "js", "sectorMap3d.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("activeKeys: new Set()", script);
+        Assert.Contains("canvas.addEventListener(\"keyup\", event => handleKeyUp(state, event));", script);
+        Assert.Contains("canvas.addEventListener(\"blur\", () => clearActiveKeys(state));", script);
+        Assert.Contains("const yawDirection = getAxisDirection(state.activeKeys, [\"a\"], [\"d\"]);", script);
+        Assert.Contains("const pitchDirection = getAxisDirection(state.activeKeys, [\"w\"], [\"s\"]);", script);
+        Assert.Contains("const rollDirection = getAxisDirection(state.activeKeys, [\"e\"], [\"q\"]);", script);
+        Assert.Contains("if (negativeActive === positiveActive) {", script);
+    }
+
+    [Fact]
+    public void KeyboardNavigationSupportsZoomAndArrowKeyPanning()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "js", "sectorMap3d.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("case \"add\":", script);
+        Assert.Contains("case \"subtract\":", script);
+        Assert.Contains("const zoomDirection = getAxisDirection(state.activeKeys, [\"-\"], [\"+\"]);", script);
+        Assert.Contains("const panHorizontalDirection = getAxisDirection(state.activeKeys, [\"arrowleft\"], [\"arrowright\"]);", script);
+        Assert.Contains("const panVerticalDirection = getAxisDirection(state.activeKeys, [\"arrowdown\"], [\"arrowup\"]);", script);
+        Assert.Contains("state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius + radiusDelta));", script);
+        Assert.Contains("state.target.addScaledVector(right, horizontalDelta);", script);
+        Assert.Contains("state.target.addScaledVector(up, verticalDelta);", script);
+    }
 }

--- a/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
+++ b/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
@@ -44,6 +44,20 @@ public sealed class SectorMap3dScriptTests
     }
 
     [Fact]
+    public void KeyboardNavigationUsesRollAwareCameraAxes()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(repoRoot, "StarWin.Web", "wwwroot", "js", "sectorMap3d.js");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Contains("const { up: cameraUp, right } = getCameraAxes(state);", script);
+        Assert.Contains("const { right, up } = getCameraAxes(state);", script);
+        Assert.Contains("if (state.roll) {", script);
+        Assert.Contains("up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));", script);
+        Assert.Contains("state.camera.up.copy(up);", script);
+    }
+
+    [Fact]
     public void KeyboardNavigationSupportsZoomAndArrowKeyPanning()
     {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));

--- a/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
+++ b/StarWin.Web.Tests/Components/SectorMap3dScriptTests.cs
@@ -53,7 +53,7 @@ public sealed class SectorMap3dScriptTests
         Assert.Contains("const { up: cameraUp, right } = getCameraAxes(state);", script);
         Assert.Contains("const { right, up } = getCameraAxes(state);", script);
         Assert.Contains("if (state.roll) {", script);
-        Assert.Contains("up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));", script);
+        Assert.Contains("up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(offset.clone().normalize(), state.roll));", script);
         Assert.Contains("state.camera.up.copy(up);", script);
     }
 
@@ -72,5 +72,6 @@ public sealed class SectorMap3dScriptTests
         Assert.Contains("state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius + radiusDelta));", script);
         Assert.Contains("state.target.addScaledVector(right, horizontalDelta);", script);
         Assert.Contains("state.target.addScaledVector(up, verticalDelta);", script);
+        Assert.Contains("Math.min(2, Math.max(0, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds))", script);
     }
 }

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -633,6 +633,8 @@ public sealed class EmpiresPageTests : BunitContext
 
         var cut = Render<Empires>();
 
+        Assert.Contains("record-filter-tristate-toggle", cut.Markup);
+
         cut.Find("[data-testid='empire-status-fallen']").Click();
 
         cut.WaitForAssertion(() =>

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -703,6 +703,24 @@ public sealed class EmpiresPageTests : BunitContext
     }
 
     [Fact]
+    public void KeepsSortControlOutsideCollapsedFilterPanel()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ConfigureServices(CreateContext());
+
+        var cut = Render<Empires>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var filterPanel = cut.Find(".record-filter-panel");
+            Assert.Null(filterPanel.GetAttribute("open"));
+            Assert.Null(filterPanel.QuerySelector("[data-testid='empire-sort-select']"));
+            Assert.NotNull(cut.Find(".record-list-toolbar [data-testid='empire-sort-select']"));
+        });
+    }
+
+    [Fact]
     public void ShowsSearchingStateWhileEmpireFiltersReloadResults()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -594,7 +594,7 @@ public sealed class EmpiresPageTests : BunitContext
     }
 
     [Fact]
-    public void FiltersEmpiresByFallenStatusWhenFilterIsApplied()
+    public void FiltersEmpiresByStatusWhenFallenFilterIsApplied()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -633,7 +633,7 @@ public sealed class EmpiresPageTests : BunitContext
 
         var cut = Render<Empires>();
 
-        cut.Find("[data-testid='fallen-empire-filter-toggle']").Change(true);
+        cut.Find("[data-testid='empire-status-fallen']").Click();
 
         cut.WaitForAssertion(() =>
         {
@@ -642,25 +642,59 @@ public sealed class EmpiresPageTests : BunitContext
             Assert.Contains("Ancient Watchers", visibleRows[0].TextContent);
             Assert.Contains("Showing 1 empire", cut.Markup);
             Assert.DoesNotContain("Orion Compact", visibleRows[0].TextContent);
-            Assert.NotNull(cut.Find("[data-testid='fallen-empire-filter-toggle']").GetAttribute("checked"));
+            Assert.Contains("active", cut.Find("[data-testid='empire-status-fallen']").ClassName);
         });
     }
 
     [Fact]
-    public void RendersSciFiToggleVisualLayersForFallenEmpireFilter()
+    public void SearchPanelStartsCollapsedAndShowsActiveFilterChipsWhenClosed()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
-        ConfigureServices(CreateContext());
+        ConfigureServices(CreateContext(
+            additionalEmpires:
+            [
+                CreateEmpire(
+                    3,
+                    "Zephyr League",
+                    foundingWorldId: 102,
+                    primaryRaceId: 1,
+                    planets: 2,
+                    nativePopulationMillions: 800)
+            ],
+            additionalWorlds:
+            [
+                CreateWorld(
+                    102,
+                    "Zephyria",
+                    colonyId: 202,
+                    colonyName: "Zephyria Prime",
+                    controllingEmpireId: 3,
+                    foundingEmpireId: 3)
+            ]),
+            new Dictionary<(EntityNoteTargetKind, int), EntityNote>
+            {
+                [(EntityNoteTargetKind.EmpireSummary, 3)] = new()
+                {
+                    TargetKind = EntityNoteTargetKind.EmpireSummary,
+                    TargetId = 3,
+                    Markdown = "Frontier trade coalition"
+                }
+            });
 
         var cut = Render<Empires>();
 
         cut.WaitForAssertion(() =>
         {
-            Assert.NotNull(cut.Find(".record-filter-toggle-thumb-scan"));
-            Assert.Equal(5, cut.FindAll(".record-filter-toggle-thumb-particle").Count);
-            Assert.Equal(3, cut.FindAll(".record-filter-toggle-energy-ring").Count);
-            Assert.NotNull(cut.Find(".record-filter-toggle-track-line"));
+            Assert.Null(cut.Find(".record-filter-panel").GetAttribute("open"));
+        });
+
+        cut.Find("input[placeholder='Name, summary, or notes...']").Input("Frontier");
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Text: Frontier", cut.Markup);
+            Assert.Contains("record-filter-chip", cut.Markup);
         });
     }
 
@@ -706,14 +740,13 @@ public sealed class EmpiresPageTests : BunitContext
 
         var cut = Render<Empires>();
 
-        cut.Find("[data-testid='fallen-empire-filter-toggle']").Change(true);
+        cut.Find("[data-testid='empire-status-fallen']").Click();
 
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Searching", cut.Markup);
             Assert.Contains("Searching empires with the current filters...", cut.Markup);
-            Assert.Null(cut.Find("[data-testid='fallen-empire-filter-toggle']").GetAttribute("disabled"));
-            Assert.NotNull(cut.Find("[data-testid='fallen-empire-filter-toggle']").GetAttribute("checked"));
+            Assert.Contains("active", cut.Find("[data-testid='empire-status-fallen']").ClassName);
             Assert.Null(cut.Find("input[placeholder='Name, summary, or notes...']").GetAttribute("disabled"));
             Assert.Null(cut.Find("input[placeholder='All races']").GetAttribute("disabled"));
         });
@@ -726,7 +759,7 @@ public sealed class EmpiresPageTests : BunitContext
     }
 
     [Fact]
-    public void AllowsFallenToggleToBeClearedWhileResultsAreStillLoading()
+    public void AllowsStatusFilterToReturnToBothWhileResultsAreStillLoading()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
 
@@ -767,21 +800,20 @@ public sealed class EmpiresPageTests : BunitContext
 
         var cut = Render<Empires>();
 
-        cut.Find("[data-testid='fallen-empire-filter-toggle']").Change(true);
+        cut.Find("[data-testid='empire-status-fallen']").Click();
 
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Searching empires with the current filters...", cut.Markup);
-            Assert.NotNull(cut.Find("[data-testid='fallen-empire-filter-toggle']").GetAttribute("checked"));
+            Assert.Contains("active", cut.Find("[data-testid='empire-status-fallen']").ClassName);
         });
 
-        cut.Find("[data-testid='fallen-empire-filter-toggle']").Change(false);
+        cut.Find("[data-testid='empire-status-both']").Click();
 
         cut.WaitForAssertion(() =>
         {
             Assert.Contains("Searching empires with the current filters...", cut.Markup);
-            Assert.Null(cut.Find("[data-testid='fallen-empire-filter-toggle']").GetAttribute("disabled"));
-            Assert.Null(cut.Find("[data-testid='fallen-empire-filter-toggle']").GetAttribute("checked"));
+            Assert.Contains("active", cut.Find("[data-testid='empire-status-both']").ClassName);
         });
 
         cut.WaitForAssertion(() =>
@@ -792,6 +824,57 @@ public sealed class EmpiresPageTests : BunitContext
             Assert.Contains("Orion Compact", cut.Markup);
             Assert.DoesNotContain("Searching empires with the current filters...", cut.Markup);
         }, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void KeepsSelectedEmpireDetailVisibleWhenFiltersHideItsListRow()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ConfigureServices(CreateContext(
+            additionalEmpires:
+            [
+                CreateEmpire(
+                    3,
+                    "Ancient Watchers",
+                    foundingWorldId: 102,
+                    primaryRaceId: 1,
+                    planets: 1,
+                    nativePopulationMillions: 950,
+                    isFallen: true)
+            ],
+            additionalWorlds:
+            [
+                CreateWorld(
+                    102,
+                    "Watcher Rest",
+                    colonyId: 202,
+                    colonyName: "Watcher Hold",
+                    controllingEmpireId: 4,
+                    foundingEmpireId: 3)
+            ]));
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("http://localhost/sector-explorer/empires?sectorId=7&empireId=2");
+
+        var cut = Render<Empires>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("Homeworld: Helios", cut.Markup);
+            Assert.Contains("Orion Compact", cut.Markup);
+        });
+
+        cut.Find("[data-testid='empire-status-fallen']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var visibleRows = cut.FindAll(".record-row");
+            Assert.Single(visibleRows);
+            Assert.Contains("Ancient Watchers", visibleRows[0].TextContent);
+            Assert.DoesNotContain("Orion Compact", visibleRows[0].TextContent);
+            Assert.Contains("Homeworld: Helios", cut.Markup);
+        });
     }
 
     [Fact]
@@ -963,18 +1046,21 @@ public sealed class EmpiresPageTests : BunitContext
         int primaryRaceId,
         int planets,
         long nativePopulationMillions,
-        bool isFallen = false)
+        bool isFallen = false,
+        int starWinTechLevel = 9,
+        long economicPowerMcr = 0)
     {
         var empire = new Empire
         {
             Id = empireId,
             Name = name,
             Planets = planets,
+            EconomicPowerMcr = economicPowerMcr,
             MilitaryPower = 9,
             NativePopulationMillions = nativePopulationMillions,
             IsFallen = isFallen
         };
-        empire.CivilizationProfile.TechLevel = 9;
+        empire.CivilizationProfile.TechLevel = (byte)starWinTechLevel;
         empire.Founding.FoundingWorldId = foundingWorldId;
         empire.Founding.FoundingRaceId = primaryRaceId;
         empire.RaceMemberships.Add(new EmpireRaceMembership
@@ -1044,21 +1130,50 @@ public sealed class EmpiresPageTests : BunitContext
         public virtual Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)
         {
             var items = GetSectorEmpires(request.SectorId)
-                .Where(empire => MatchesEmpireFilters(request, empire))
-                .OrderBy(empire => empire.Name)
-                .ThenBy(empire => empire.Id)
                 .Select(empire =>
                 {
                     var (controlledWorldCount, trackedWorldCount) = GetEmpireWorldCounts(request.SectorId, empire.Id);
-                    return new ExplorerEmpireListItem(
-                        empire.Id,
-                        empire.Name,
+                    return new TestEmpireListRow(
+                        empire,
                         controlledWorldCount,
                         trackedWorldCount,
-                        empire.CivilizationProfile.TechLevel + 2,
-                        empire.IsFallen);
+                        empire.CivilizationProfile.TechLevel + 2);
                 })
+                .Where(item => MatchesEmpireFilters(request, item))
+                .Select(item => new ExplorerEmpireListItem(
+                    item.Empire.Id,
+                    item.Empire.Name,
+                    item.ControlledWorldCount,
+                    item.TrackedWorldCount,
+                    item.GurpsTechLevel,
+                    item.Empire.CivilizationProfile.TechLevel,
+                    item.Empire.NativePopulationMillions,
+                    item.Empire.EconomicPowerMcr,
+                    item.Empire.IsFallen))
                 .ToList();
+
+            items = request.SortOption switch
+            {
+                ExplorerEmpireSortOption.Population => items
+                    .OrderByDescending(item => item.NativePopulationMillions)
+                    .ThenBy(item => item.Name)
+                    .ThenBy(item => item.EmpireId)
+                    .ToList(),
+                ExplorerEmpireSortOption.ControlledWorlds => items
+                    .OrderByDescending(item => item.ControlledWorldCount)
+                    .ThenBy(item => item.Name)
+                    .ThenBy(item => item.EmpireId)
+                    .ToList(),
+                ExplorerEmpireSortOption.EconomicPower => items
+                    .OrderByDescending(item => item.EconomicPowerMcr)
+                    .ThenBy(item => item.Name)
+                    .ThenBy(item => item.EmpireId)
+                    .ToList(),
+                _ => items
+                    .OrderBy(item => item.Name)
+                    .ThenBy(item => item.EmpireId)
+                    .ToList()
+            };
 
             var page = items.Skip(request.Offset).Take(request.Limit + 1).ToList();
             var hasMore = page.Count > request.Limit;
@@ -1079,6 +1194,9 @@ public sealed class EmpiresPageTests : BunitContext
                 GetEmpireWorldCounts(sectorId, empire.Id).ControlledWorldCount,
                 GetEmpireWorldCounts(sectorId, empire.Id).TrackedWorldCount,
                 empire.CivilizationProfile.TechLevel + 2,
+                empire.CivilizationProfile.TechLevel,
+                empire.NativePopulationMillions,
+                empire.EconomicPowerMcr,
                 empire.IsFallen));
         }
 
@@ -1261,14 +1379,53 @@ public sealed class EmpiresPageTests : BunitContext
             return (controlledWorldCount, trackedWorldCount);
         }
 
-        private bool MatchesEmpireFilters(ExplorerEmpireListPageRequest request, Empire empire)
+        private bool MatchesEmpireFilters(ExplorerEmpireListPageRequest request, TestEmpireListRow item)
         {
+            var empire = item.Empire;
             if (request.RaceId is int raceId && !empire.RaceMemberships.Any(membership => membership.RaceId == raceId))
             {
                 return false;
             }
 
-            if (request.FallenOnly && !empire.IsFallen)
+            if (request.StatusFilter == ExplorerEmpireStatusFilter.Active && empire.IsFallen)
+            {
+                return false;
+            }
+
+            if (request.StatusFilter == ExplorerEmpireStatusFilter.Fallen && !empire.IsFallen)
+            {
+                return false;
+            }
+
+            if (request.MinControlledWorldCount is int minControlledWorldCount && item.ControlledWorldCount < minControlledWorldCount)
+            {
+                return false;
+            }
+
+            if (request.MaxControlledWorldCount is int maxControlledWorldCount && item.ControlledWorldCount > maxControlledWorldCount)
+            {
+                return false;
+            }
+
+            if (request.MinNativePopulationMillions is long minNativePopulationMillions && empire.NativePopulationMillions < minNativePopulationMillions)
+            {
+                return false;
+            }
+
+            if (request.MaxNativePopulationMillions is long maxNativePopulationMillions && empire.NativePopulationMillions > maxNativePopulationMillions)
+            {
+                return false;
+            }
+
+            var techLevel = request.TechLevelSystem == ExplorerEmpireTechLevelSystem.Gurps
+                ? item.GurpsTechLevel
+                : empire.CivilizationProfile.TechLevel;
+            if (request.MinTechLevel is int minTechLevel && techLevel < minTechLevel)
+            {
+                return false;
+            }
+
+            if (request.MaxTechLevel is int maxTechLevel && techLevel > maxTechLevel)
             {
                 return false;
             }
@@ -1424,7 +1581,15 @@ public sealed class EmpiresPageTests : BunitContext
     {
         public override async Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)
         {
-            if (!string.IsNullOrWhiteSpace(request.Query) || request.RaceId.HasValue || request.FallenOnly)
+            if (!string.IsNullOrWhiteSpace(request.Query)
+                || request.RaceId.HasValue
+                || request.StatusFilter != ExplorerEmpireStatusFilter.Both
+                || request.MinControlledWorldCount.HasValue
+                || request.MaxControlledWorldCount.HasValue
+                || request.MinNativePopulationMillions.HasValue
+                || request.MaxNativePopulationMillions.HasValue
+                || request.MinTechLevel.HasValue
+                || request.MaxTechLevel.HasValue)
             {
                 await Task.Delay(delay, cancellationToken);
             }
@@ -1432,6 +1597,12 @@ public sealed class EmpiresPageTests : BunitContext
             return await base.LoadEmpireListPageAsync(request, cancellationToken);
         }
     }
+
+    private sealed record TestEmpireListRow(
+        Empire Empire,
+        int ControlledWorldCount,
+        int TrackedWorldCount,
+        int GurpsTechLevel);
 
     private sealed record TestEmpireRacePopulationRow(
         int RaceId,

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -634,6 +634,8 @@ public sealed class EmpiresPageTests : BunitContext
         var cut = Render<Empires>();
 
         Assert.Contains("record-filter-tristate-toggle", cut.Markup);
+        Assert.Contains("record-filter-tristate-toggle-track", cut.Markup);
+        Assert.Contains("record-filter-tristate-toggle-energy-rings", cut.Markup);
 
         cut.Find("[data-testid='empire-status-fallen']").Click();
 

--- a/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
+++ b/StarWin.Web.Tests/Pages/EmpiresPageTests.cs
@@ -148,6 +148,68 @@ public sealed class EmpiresPageTests : BunitContext
     }
 
     [Fact]
+    public void RendersRangeSlidersAndControlledWorldSliderFiltersEmpires()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        ConfigureServices(CreateContext(
+            additionalEmpires:
+            [
+                CreateEmpire(
+                    3,
+                    "Zephyr League",
+                    foundingWorldId: 102,
+                    primaryRaceId: 1,
+                    planets: 2,
+                    nativePopulationMillions: 800)
+            ],
+            additionalWorlds:
+            [
+                CreateWorld(
+                    102,
+                    "Zephyria",
+                    colonyId: 202,
+                    colonyName: "Zephyria Prime",
+                    controllingEmpireId: 3,
+                    foundingEmpireId: 3),
+                CreateWorld(
+                    103,
+                    "Orion Reach",
+                    colonyId: 203,
+                    colonyName: "Orion Reach Prime",
+                    controllingEmpireId: 2,
+                    foundingEmpireId: 2),
+                CreateWorld(
+                    104,
+                    "Orion Gate",
+                    colonyId: 204,
+                    colonyName: "Orion Gate Prime",
+                    controllingEmpireId: 2,
+                    foundingEmpireId: 2)
+            ]));
+
+        var cut = Render<Empires>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotNull(cut.Find("[data-testid='empire-controlled-worlds-min-slider']"));
+            Assert.NotNull(cut.Find("[data-testid='empire-population-min-slider']"));
+            Assert.NotNull(cut.Find("[data-testid='empire-tech-level-min-slider']"));
+        });
+
+        cut.Find("[data-testid='empire-controlled-worlds-min-slider']").Input("2");
+
+        cut.WaitForAssertion(() =>
+        {
+            var visibleRows = cut.FindAll(".record-row");
+            Assert.Single(visibleRows);
+            Assert.Contains("Orion Compact", visibleRows[0].TextContent);
+            Assert.Contains("Showing 1 empire", cut.Markup);
+            Assert.Equal("2", cut.Find("[data-testid='empire-controlled-worlds-min-input']").GetAttribute("value"));
+        });
+    }
+
+    [Fact]
     public void FiltersEmpiresByRaceWhenRaceFilterIsApplied()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -1146,7 +1208,30 @@ public sealed class EmpiresPageTests : BunitContext
                 .ThenBy(option => option.Id)
                 .ToList();
 
-            return Task.FromResult(new ExplorerEmpireFilterOptions(races));
+            var sectorEmpires = GetSectorEmpires(sectorId);
+            var maxControlledWorldCount = sectorEmpires
+                .Select(empire => GetEmpireWorldCounts(sectorId, empire.Id).ControlledWorldCount)
+                .DefaultIfEmpty(0)
+                .Max();
+            var maxNativePopulationMillions = sectorEmpires
+                .Select(empire => empire.NativePopulationMillions)
+                .DefaultIfEmpty(0L)
+                .Max();
+            var maxStarWinTechLevel = sectorEmpires
+                .Select(empire => (int)empire.CivilizationProfile.TechLevel)
+                .DefaultIfEmpty(0)
+                .Max();
+            var maxGurpsTechLevel = sectorEmpires
+                .Select(empire => (int)empire.CivilizationProfile.TechLevel + 2)
+                .DefaultIfEmpty(0)
+                .Max();
+
+            return Task.FromResult(new ExplorerEmpireFilterOptions(
+                races,
+                Math.Max(1, maxControlledWorldCount),
+                Math.Max(1L, maxNativePopulationMillions),
+                Math.Max(1, maxGurpsTechLevel),
+                Math.Max(1, maxStarWinTechLevel)));
         }
 
         public virtual Task<ExplorerEmpireListPage> LoadEmpireListPageAsync(ExplorerEmpireListPageRequest request, CancellationToken cancellationToken = default)

--- a/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorConfigurationPageTests.cs
@@ -33,6 +33,7 @@ public sealed class SectorConfigurationPageTests : BunitContext
             Assert.Contains("Del Corra", cut.Markup);
             Assert.Contains("Save configuration", cut.Markup);
             Assert.Contains("Saved route report", cut.Markup);
+            Assert.Contains("Sector empire stats", cut.Markup);
         });
 
         Assert.Equal(0, queryService.HyperlaneWorkspaceLoadCount);
@@ -78,6 +79,24 @@ public sealed class SectorConfigurationPageTests : BunitContext
     }
 
     [Fact]
+    public void RecalculateSectorEmpireStatsUsesStatsService()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var statsService = new FakeSectorEmpireStatsService();
+        var explorerContextService = new FakeExplorerContextService(CreateContext());
+        ConfigureServices(explorerContextService, statsService: statsService);
+
+        var cut = Render<SectorConfigurationPage>();
+        cut.FindAll("button").Single(button => button.TextContent.Trim() == "Recalculate sector empire stats").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(statsService.RebuildCalled);
+            Assert.Contains("Refreshed 4 sector empire stat rows", cut.Markup);
+        });
+    }
+
+    [Fact]
     public void ConvertIndependentColoniesDisplaysConversionSummary()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -100,13 +119,15 @@ public sealed class SectorConfigurationPageTests : BunitContext
         ContextBackedExplorerQueryService? queryService = null,
         FakeSectorConfigurationService? configService = null,
         FakeSectorRouteService? routeService = null,
-        FakeIndependentColonyService? colonyService = null)
+        FakeIndependentColonyService? colonyService = null,
+        FakeSectorEmpireStatsService? statsService = null)
     {
         Services.AddScoped<SectorExplorerLayoutStateStore>();
         Services.AddSingleton<IStarWinExplorerContextService>(explorerContextService);
         Services.AddSingleton<IStarWinExplorerQueryService>(queryService ?? new ContextBackedExplorerQueryService(explorerContextService.Context));
         Services.AddSingleton<IStarWinSearchService>(new FakeSearchService());
         Services.AddSingleton<IStarWinSectorConfigurationService>(configService ?? new FakeSectorConfigurationService());
+        Services.AddSingleton<IStarWinSectorEmpireStatsService>(statsService ?? new FakeSectorEmpireStatsService());
         Services.AddSingleton<IStarWinSectorRouteService>(routeService ?? new FakeSectorRouteService());
         Services.AddSingleton<IStarWinIndependentColonyService>(colonyService ?? new FakeIndependentColonyService());
     }
@@ -206,6 +227,27 @@ public sealed class SectorConfigurationPageTests : BunitContext
         }
 
         public Task DeleteSavedRouteAsync(int sectorId, int routeId, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class FakeSectorEmpireStatsService : IStarWinSectorEmpireStatsService
+    {
+        public bool RebuildCalled { get; private set; }
+
+        public Task<SectorEmpireStatsRefreshResult> RebuildSectorStatsAsync(int sectorId, CancellationToken cancellationToken = default)
+        {
+            RebuildCalled = true;
+            return Task.FromResult(new SectorEmpireStatsRefreshResult(sectorId, 4, DateTime.UtcNow));
+        }
+
+        public Task<SectorEmpireStatRefreshResult?> RefreshEmpireStatsAsync(int sectorId, int empireId, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task MarkSectorStatsStaleAsync(int sectorId, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }

--- a/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
+++ b/StarWin.Web.Tests/Pages/SectorExplorerPageTests.cs
@@ -18,6 +18,29 @@ namespace StarWin.Web.Tests.Pages;
 public sealed class SectorExplorerPageTests : BunitContext
 {
     [Fact]
+    public void OverviewRendersConfigurationAsFinalExplorerTab()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var sector = CreateSector();
+        var workspace = new FakeWorkspace(sector);
+        ConfigureServices(sector, workspace);
+
+        var cut = Render<SectorExplorer>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var sectionTabs = cut.FindAll(".section-tabs a")
+                .Select(link => link.TextContent.Trim())
+                .ToArray();
+
+            Assert.Equal(
+                ["Overview", "Timeline", "Hyperlanes", "Systems", "Worlds", "Colonies", "Aliens", "Religions", "Empires", "Configuration"],
+                sectionTabs);
+        });
+    }
+
+    [Fact]
     public void OverviewDefersMapWorkspaceUntilAfterInitialRender()
     {
         JSInterop.Mode = JSRuntimeMode.Loose;

--- a/StarWin.Web/Components/Explorer/SectorExplorerSections.cs
+++ b/StarWin.Web/Components/Explorer/SectorExplorerSections.cs
@@ -6,13 +6,13 @@ internal static class SectorExplorerSections
     [
         "Overview",
         "Timeline",
-        "Configuration",
         "Hyperlanes",
         "Systems",
         "Worlds",
         "Colonies",
         "Aliens",
         "Religions",
-        "Empires"
+        "Empires",
+        "Configuration"
     ];
 }

--- a/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
@@ -7,6 +7,15 @@
 }
 
 <section class="control-strip">
+    <div class="control-strip-tabs">
+        <ExplorerSectionTabs Sections="Sections"
+                             ActiveSection="@ActiveSection"
+                             IsLoading="@IsLoading"
+                             LoadingTarget="@LoadingTarget"
+                             LoadingStatus="@LoadingStatus"
+                             SectionHrefFactory="SectionHrefFactory" />
+    </div>
+
     <div class="control-strip-fields">
         <label class="control-field sector-field">
             Sector
@@ -57,15 +66,6 @@
                 <p class="search-empty">No matching systems, worlds, races, colonies, empires, habitats, or history.</p>
             }
         </div>
-    </div>
-
-    <div class="control-strip-tabs">
-        <ExplorerSectionTabs Sections="Sections"
-                             ActiveSection="@ActiveSection"
-                             IsLoading="@IsLoading"
-                             LoadingTarget="@LoadingTarget"
-                             LoadingStatus="@LoadingStatus"
-                             SectionHrefFactory="SectionHrefFactory" />
     </div>
 </section>
 

--- a/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
+++ b/StarWin.Web/Components/Explorer/SectorExplorerShell.razor
@@ -7,62 +7,66 @@
 }
 
 <section class="control-strip">
-    <label class="control-field sector-field">
-        Sector
-        <select value="@SelectedSectorId" @onchange="HandleSectorChanged">
-            @foreach (var item in Sectors)
-            {
-                <option value="@item.Id">@item.Name</option>
-            }
-        </select>
-    </label>
-
-    <label class="control-field system-field">
-        System
-        <input list="sector-system-options"
-               placeholder="Select system..."
-               value="@SelectedSystemText"
-               @onchange="HandleSystemTextChanged" />
-        <datalist id="sector-system-options">
-            @foreach (var system in Systems)
-            {
-                <option value="@FormatSystemOption(system)" />
-            }
-        </datalist>
-    </label>
-
-    <div class="archive-search">
-        <label for="archive-search-input">Archive search</label>
-        <input id="archive-search-input"
-               placeholder="System, world, colony, race, empire..."
-               value="@SearchQuery"
-               @oninput="HandleSearchQueryInput" />
-
-        @if (SearchResults.Count > 0)
-        {
-            <div class="search-results">
-                @foreach (var result in SearchResults)
+    <div class="control-strip-fields">
+        <label class="control-field sector-field">
+            Sector
+            <select value="@SelectedSectorId" @onchange="HandleSectorChanged">
+                @foreach (var item in Sectors)
                 {
-                    <button type="button" class="search-result" @onclick="() => SearchResultSelected.InvokeAsync(result)">
-                        <span>@DisplayResultType(result.Type)</span>
-                        <strong>@result.Title</strong>
-                        <small>@result.Subtitle</small>
-                    </button>
+                    <option value="@item.Id">@item.Name</option>
                 }
-            </div>
-        }
-        else if (!string.IsNullOrWhiteSpace(SearchQuery))
-        {
-            <p class="search-empty">No matching systems, worlds, races, colonies, empires, habitats, or history.</p>
-        }
+            </select>
+        </label>
+
+        <label class="control-field system-field">
+            System
+            <input list="sector-system-options"
+                   placeholder="Select system..."
+                   value="@SelectedSystemText"
+                   @onchange="HandleSystemTextChanged" />
+            <datalist id="sector-system-options">
+                @foreach (var system in Systems)
+                {
+                    <option value="@FormatSystemOption(system)" />
+                }
+            </datalist>
+        </label>
+
+        <div class="archive-search">
+            <label for="archive-search-input">Archive search</label>
+            <input id="archive-search-input"
+                   placeholder="System, world, colony, race, empire..."
+                   value="@SearchQuery"
+                   @oninput="HandleSearchQueryInput" />
+
+            @if (SearchResults.Count > 0)
+            {
+                <div class="search-results">
+                    @foreach (var result in SearchResults)
+                    {
+                        <button type="button" class="search-result" @onclick="() => SearchResultSelected.InvokeAsync(result)">
+                            <span>@DisplayResultType(result.Type)</span>
+                            <strong>@result.Title</strong>
+                            <small>@result.Subtitle</small>
+                        </button>
+                    }
+                </div>
+            }
+            else if (!string.IsNullOrWhiteSpace(SearchQuery))
+            {
+                <p class="search-empty">No matching systems, worlds, races, colonies, empires, habitats, or history.</p>
+            }
+        </div>
     </div>
 
-    <ExplorerSectionTabs Sections="Sections"
-                         ActiveSection="@ActiveSection"
-                         IsLoading="@IsLoading"
-                         LoadingTarget="@LoadingTarget"
-                         LoadingStatus="@LoadingStatus"
-                         SectionHrefFactory="SectionHrefFactory" />
+    <div class="control-strip-tabs">
+        <ExplorerSectionTabs Sections="Sections"
+                             ActiveSection="@ActiveSection"
+                             IsLoading="@IsLoading"
+                             LoadingTarget="@LoadingTarget"
+                             LoadingStatus="@LoadingStatus"
+                             SectionHrefFactory="SectionHrefFactory" />
+    </div>
 </section>
 
 @if (!string.IsNullOrWhiteSpace(ErrorMessage))

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -5,6 +5,7 @@
 @{
     var sector = GetSelectedSector();
     var selectedEmpire = selectedEmpireDetail?.Empire;
+    var activeEmpireFilterChips = GetActiveEmpireFilterChips();
     var layoutState = new SectorExplorerLayoutState(
         null,
         ExplorerSectors,
@@ -29,76 +30,157 @@
 
 <section class="content-grid">
             <div class="record-list">
-                <details class="record-filter-panel" open>
-                    <summary class="record-filter-summary">Search</summary>
-                    <label>
-                        Search
-                        <input placeholder="Name, summary, or notes..."
-                               @bind="empireQuery"
-                               @bind:event="oninput"
-                               @bind:after="HandleEmpireFiltersChangedAsync" />
-                    </label>
-                    <div class="record-filter-actions">
-                        <button type="button" class="timeline-clear-button" @onclick="HandleClearEmpireFiltersAsync">Clear filters</button>
-                    </div>
-                    <label>
-                        Race
-                        <input list="empire-race-options"
-                               placeholder="All races"
-                               @bind="empireRaceText"
-                               @bind:event="oninput"
-                               @bind:after="ApplyEmpireRaceFilterAsync" />
-                        <datalist id="empire-race-options">
-                            @foreach (var race in empireFilterOptions.Races)
+                <details class="record-filter-panel">
+                    <summary class="record-filter-summary">
+                        <span class="record-filter-summary-copy">
+                            <span>Search</span>
+                            @if (activeEmpireFilterChips.Count > 0)
                             {
-                                <option value="@($"{race.Id} - {race.Name}")" />
-                            }
-                        </datalist>
-                    </label>
-                    <div class="record-filter-toggle-row">
-                        <label class="record-filter-toggle">
-                            <span class="record-filter-toggle-copy">
-                                <span class="record-filter-toggle-label">Fallen empires only</span>
-                                <span class="record-filter-toggle-hint">Limit the list to inactive former empires</span>
-                            </span>
-                            <span class="record-filter-toggle-control">
-                                <input type="checkbox"
-                                       class="record-filter-toggle-input"
-                                       data-testid="fallen-empire-filter-toggle"
-                                       checked="@showOnlyFallenEmpires"
-                                       @onchange="ToggleFallenEmpireFilterAsync" />
-                                <span class="record-filter-toggle-track" aria-hidden="true">
-                                    <span class="record-filter-toggle-track-lines">
-                                        <span class="record-filter-toggle-track-line"></span>
-                                    </span>
-                                    <span class="record-filter-toggle-data">
-                                        <span class="record-filter-toggle-data-text off">OFF</span>
-                                        <span class="record-filter-toggle-data-text on">ON</span>
-                                        <span class="record-filter-toggle-status off"></span>
-                                        <span class="record-filter-toggle-status on"></span>
-                                    </span>
-                                    <span class="record-filter-toggle-energy-rings">
-                                        <span class="record-filter-toggle-energy-ring"></span>
-                                        <span class="record-filter-toggle-energy-ring"></span>
-                                        <span class="record-filter-toggle-energy-ring"></span>
-                                    </span>
-                                    <span class="record-filter-toggle-thumb">
-                                        <span class="record-filter-toggle-thumb-core"></span>
-                                        <span class="record-filter-toggle-thumb-inner"></span>
-                                        <span class="record-filter-toggle-thumb-scan"></span>
-                                        <span class="record-filter-toggle-thumb-particles">
-                                            <span class="record-filter-toggle-thumb-particle"></span>
-                                            <span class="record-filter-toggle-thumb-particle"></span>
-                                            <span class="record-filter-toggle-thumb-particle"></span>
-                                            <span class="record-filter-toggle-thumb-particle"></span>
-                                            <span class="record-filter-toggle-thumb-particle"></span>
-                                        </span>
-                                    </span>
-                                    <span class="record-filter-toggle-reflection"></span>
-                                    <span class="record-filter-toggle-holo-glow"></span>
+                                <span class="record-filter-chip-list">
+                                    @foreach (var chip in activeEmpireFilterChips)
+                                    {
+                                        <span class="record-filter-chip">@chip</span>
+                                    }
                                 </span>
-                            </span>
+                            }
+                        </span>
+                    </summary>
+                    <div class="record-filter-grid">
+                        <label>
+                            Search
+                            <input placeholder="Name, summary, or notes..."
+                                   @bind="empireQuery"
+                                   @bind:event="oninput"
+                                   @bind:after="HandleEmpireFiltersChangedAsync" />
                         </label>
+                        <label>
+                            Race
+                            <input list="empire-race-options"
+                                   placeholder="All races"
+                                   @bind="empireRaceText"
+                                   @bind:event="oninput"
+                                   @bind:after="ApplyEmpireRaceFilterAsync" />
+                            <datalist id="empire-race-options">
+                                @foreach (var race in empireFilterOptions.Races)
+                                {
+                                    <option value="@($"{race.Id} - {race.Name}")" />
+                                }
+                            </datalist>
+                        </label>
+                        <div class="record-filter-inline-group">
+                            <div class="record-filter-fieldset">
+                                <span class="record-filter-heading">Status</span>
+                                <div class="segmented-control record-filter-segmented-control" data-testid="empire-status-filter">
+                                    <button type="button"
+                                            class="@(empireStatusFilter == ExplorerEmpireStatusFilter.Active ? "active" : null)"
+                                            data-testid="empire-status-active"
+                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Active)">Active</button>
+                                    <button type="button"
+                                            class="@(empireStatusFilter == ExplorerEmpireStatusFilter.Both ? "active" : null)"
+                                            data-testid="empire-status-both"
+                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Both)">Both</button>
+                                    <button type="button"
+                                            class="@(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen ? "active" : null)"
+                                            data-testid="empire-status-fallen"
+                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Fallen)">Fallen</button>
+                                </div>
+                            </div>
+                            <label class="record-filter-select-label">
+                                Sort
+                                <select @bind="empireSortOption"
+                                        @bind:after="HandleEmpireSortChangedAsync"
+                                        data-testid="empire-sort-select">
+                                    <option value="@ExplorerEmpireSortOption.Alphabetical">Alphabetical</option>
+                                    <option value="@ExplorerEmpireSortOption.Population">Population</option>
+                                    <option value="@ExplorerEmpireSortOption.ControlledWorlds">Controlled worlds</option>
+                                    <option value="@ExplorerEmpireSortOption.EconomicPower">Economic power</option>
+                                </select>
+                            </label>
+                        </div>
+                        <div class="record-filter-fieldset">
+                            <span class="record-filter-heading">Controlled worlds</span>
+                            <div class="record-filter-range-inputs">
+                                <label>
+                                    <span>Min</span>
+                                    <input type="text"
+                                           inputmode="numeric"
+                                           placeholder="0"
+                                           @bind="controlledWorldCountMinText"
+                                           @bind:event="oninput"
+                                           @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                                <label>
+                                    <span>Max</span>
+                                    <input type="text"
+                                           inputmode="numeric"
+                                           placeholder="Any"
+                                           @bind="controlledWorldCountMaxText"
+                                           @bind:event="oninput"
+                                           @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                            </div>
+                        </div>
+                        <div class="record-filter-fieldset">
+                            <span class="record-filter-heading">Population</span>
+                            <div class="record-filter-range-inputs">
+                                <label>
+                                    <span>Min</span>
+                                    <input type="text"
+                                           placeholder="e.g. 500M"
+                                           title="@GetPopulationFilterInputTitle(nativePopulationMinText)"
+                                           @bind="nativePopulationMinText"
+                                           @bind:event="oninput"
+                                           @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                                <label>
+                                    <span>Max</span>
+                                    <input type="text"
+                                           placeholder="e.g. 12B"
+                                           title="@GetPopulationFilterInputTitle(nativePopulationMaxText)"
+                                           @bind="nativePopulationMaxText"
+                                           @bind:event="oninput"
+                                           @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                            </div>
+                        </div>
+                        <div class="record-filter-fieldset">
+                            <div class="record-filter-fieldset-header">
+                                <span class="record-filter-heading">Tech level</span>
+                                <div class="segmented-control record-filter-segmented-control">
+                                    <button type="button"
+                                            class="@(empireTechLevelSystem == ExplorerEmpireTechLevelSystem.Gurps ? "active" : null)"
+                                            data-testid="empire-tech-system-gurps"
+                                            @onclick="() => SetEmpireTechLevelSystemAsync(ExplorerEmpireTechLevelSystem.Gurps)">GURPS</button>
+                                    <button type="button"
+                                            class="@(empireTechLevelSystem == ExplorerEmpireTechLevelSystem.StarWin ? "active" : null)"
+                                            data-testid="empire-tech-system-starwin"
+                                            @onclick="() => SetEmpireTechLevelSystemAsync(ExplorerEmpireTechLevelSystem.StarWin)">StarWin</button>
+                                </div>
+                            </div>
+                            <div class="record-filter-range-inputs">
+                                <label>
+                                    <span>Min</span>
+                                    <input type="text"
+                                           inputmode="numeric"
+                                           placeholder="Any"
+                                           @bind="techLevelMinText"
+                                           @bind:event="oninput"
+                                           @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                                <label>
+                                    <span>Max</span>
+                                    <input type="text"
+                                           inputmode="numeric"
+                                           placeholder="Any"
+                                           @bind="techLevelMaxText"
+                                           @bind:event="oninput"
+                                           @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                            </div>
+                        </div>
+                        <div class="record-filter-actions">
+                            <button type="button" class="timeline-clear-button" @onclick="HandleClearEmpireFiltersAsync">Clear filters</button>
+                        </div>
                     </div>
                 </details>
                 <div class="timeline-count">Showing @LoadedEmpireSummaries.Count empire@(LoadedEmpireSummaries.Count == 1 ? string.Empty : "s")@(empireHasMoreRecords ? "+" : string.Empty)</div>

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -70,19 +70,39 @@
                         <div class="record-filter-inline-group">
                             <div class="record-filter-fieldset">
                                 <span class="record-filter-heading">Status</span>
-                                <div class="segmented-control record-filter-segmented-control" data-testid="empire-status-filter">
-                                    <button type="button"
-                                            class="@(empireStatusFilter == ExplorerEmpireStatusFilter.Active ? "active" : null)"
-                                            data-testid="empire-status-active"
-                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Active)">Active</button>
-                                    <button type="button"
-                                            class="@(empireStatusFilter == ExplorerEmpireStatusFilter.Both ? "active" : null)"
-                                            data-testid="empire-status-both"
-                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Both)">Both</button>
-                                    <button type="button"
-                                            class="@(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen ? "active" : null)"
-                                            data-testid="empire-status-fallen"
-                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Fallen)">Fallen</button>
+                                <div class="record-filter-tristate-toggle @GetEmpireStatusToggleStateClass()"
+                                     style="--toggle-index:@GetEmpireStatusToggleIndex();"
+                                     role="radiogroup"
+                                     aria-label="Empire status filter"
+                                     data-testid="empire-status-filter">
+                                    <span class="record-filter-tristate-toggle-thumb" aria-hidden="true"></span>
+                                    <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Active ? "active" : null)"
+                                           data-testid="empire-status-active"
+                                           @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Active)">
+                                        <input type="radio"
+                                               name="empire-status-filter"
+                                               checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Active)"
+                                               aria-label="Active empires" />
+                                        <span>Active</span>
+                                    </label>
+                                    <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Both ? "active" : null)"
+                                           data-testid="empire-status-both"
+                                           @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Both)">
+                                        <input type="radio"
+                                               name="empire-status-filter"
+                                               checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Both)"
+                                               aria-label="Active and fallen empires" />
+                                        <span>Both</span>
+                                    </label>
+                                    <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen ? "active" : null)"
+                                           data-testid="empire-status-fallen"
+                                           @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Fallen)">
+                                        <input type="radio"
+                                               name="empire-status-filter"
+                                               checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen)"
+                                               aria-label="Fallen empires" />
+                                        <span>Fallen</span>
+                                    </label>
                                 </div>
                             </div>
                             <label class="record-filter-select-label">

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -75,7 +75,29 @@
                                      role="radiogroup"
                                      aria-label="Empire status filter"
                                      data-testid="empire-status-filter">
-                                    <span class="record-filter-tristate-toggle-thumb" aria-hidden="true"></span>
+                                    <span class="record-filter-tristate-toggle-track" aria-hidden="true">
+                                        <span class="record-filter-tristate-toggle-track-lines">
+                                            <span class="record-filter-tristate-toggle-track-line"></span>
+                                        </span>
+                                        <span class="record-filter-tristate-toggle-reflection"></span>
+                                        <span class="record-filter-tristate-toggle-holo-glow"></span>
+                                    </span>
+                                    <span class="record-filter-tristate-toggle-thumb" aria-hidden="true">
+                                        <span class="record-filter-tristate-toggle-energy-rings">
+                                            <span class="record-filter-tristate-toggle-energy-ring"></span>
+                                            <span class="record-filter-tristate-toggle-energy-ring"></span>
+                                            <span class="record-filter-tristate-toggle-energy-ring"></span>
+                                        </span>
+                                        <span class="record-filter-tristate-toggle-thumb-core"></span>
+                                        <span class="record-filter-tristate-toggle-thumb-inner"></span>
+                                        <span class="record-filter-tristate-toggle-thumb-scan"></span>
+                                        <span class="record-filter-tristate-toggle-thumb-particles">
+                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                        </span>
+                                    </span>
                                     <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Active ? "active" : null)"
                                            data-testid="empire-status-active"
                                            @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Active)">

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -134,6 +134,7 @@
                                     <input type="text"
                                            inputmode="numeric"
                                            placeholder="0"
+                                           data-testid="empire-controlled-worlds-min-input"
                                            @bind="controlledWorldCountMinText"
                                            @bind:event="oninput"
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
@@ -143,9 +144,36 @@
                                     <input type="text"
                                            inputmode="numeric"
                                            placeholder="Any"
+                                           data-testid="empire-controlled-worlds-max-input"
                                            @bind="controlledWorldCountMaxText"
                                            @bind:event="oninput"
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                            </div>
+                            <div class="record-filter-slider-group">
+                                <label class="record-filter-slider-field">
+                                    <span>Min slider</span>
+                                    <input type="range"
+                                           min="@GetControlledWorldSliderMinimum()"
+                                           max="@GetControlledWorldSliderMaximum()"
+                                           step="1"
+                                           value="@GetControlledWorldMinSliderValue()"
+                                           data-testid="empire-controlled-worlds-min-slider"
+                                           aria-label="Minimum controlled worlds slider"
+                                           @oninput="HandleControlledWorldMinSliderChanged" />
+                                    <small>@GetControlledWorldSliderValueLabel(minimum: true)</small>
+                                </label>
+                                <label class="record-filter-slider-field">
+                                    <span>Max slider</span>
+                                    <input type="range"
+                                           min="@GetControlledWorldSliderMinimum()"
+                                           max="@GetControlledWorldSliderMaximum()"
+                                           step="1"
+                                           value="@GetControlledWorldMaxSliderValue()"
+                                           data-testid="empire-controlled-worlds-max-slider"
+                                           aria-label="Maximum controlled worlds slider"
+                                           @oninput="HandleControlledWorldMaxSliderChanged" />
+                                    <small>@GetControlledWorldSliderValueLabel(minimum: false)</small>
                                 </label>
                             </div>
                         </div>
@@ -156,6 +184,7 @@
                                     <span>Min</span>
                                     <input type="text"
                                            placeholder="e.g. 500M"
+                                           data-testid="empire-population-min-input"
                                            title="@GetPopulationFilterInputTitle(nativePopulationMinText)"
                                            @bind="nativePopulationMinText"
                                            @bind:event="oninput"
@@ -165,10 +194,37 @@
                                     <span>Max</span>
                                     <input type="text"
                                            placeholder="e.g. 12B"
+                                           data-testid="empire-population-max-input"
                                            title="@GetPopulationFilterInputTitle(nativePopulationMaxText)"
                                            @bind="nativePopulationMaxText"
                                            @bind:event="oninput"
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                            </div>
+                            <div class="record-filter-slider-group">
+                                <label class="record-filter-slider-field">
+                                    <span>Min slider</span>
+                                    <input type="range"
+                                           min="@GetPopulationSliderMinimum()"
+                                           max="@GetPopulationSliderMaximum()"
+                                           step="1"
+                                           value="@GetPopulationMinSliderValue()"
+                                           data-testid="empire-population-min-slider"
+                                           aria-label="Minimum population slider"
+                                           @oninput="HandlePopulationMinSliderChanged" />
+                                    <small>@GetPopulationSliderValueLabel(minimum: true)</small>
+                                </label>
+                                <label class="record-filter-slider-field">
+                                    <span>Max slider</span>
+                                    <input type="range"
+                                           min="@GetPopulationSliderMinimum()"
+                                           max="@GetPopulationSliderMaximum()"
+                                           step="1"
+                                           value="@GetPopulationMaxSliderValue()"
+                                           data-testid="empire-population-max-slider"
+                                           aria-label="Maximum population slider"
+                                           @oninput="HandlePopulationMaxSliderChanged" />
+                                    <small>@GetPopulationSliderValueLabel(minimum: false)</small>
                                 </label>
                             </div>
                         </div>
@@ -192,6 +248,7 @@
                                     <input type="text"
                                            inputmode="numeric"
                                            placeholder="Any"
+                                           data-testid="empire-tech-level-min-input"
                                            @bind="techLevelMinText"
                                            @bind:event="oninput"
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
@@ -201,9 +258,36 @@
                                     <input type="text"
                                            inputmode="numeric"
                                            placeholder="Any"
+                                           data-testid="empire-tech-level-max-input"
                                            @bind="techLevelMaxText"
                                            @bind:event="oninput"
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
+                                </label>
+                            </div>
+                            <div class="record-filter-slider-group">
+                                <label class="record-filter-slider-field">
+                                    <span>Min slider</span>
+                                    <input type="range"
+                                           min="@GetTechLevelSliderMinimum()"
+                                           max="@GetTechLevelSliderMaximum()"
+                                           step="1"
+                                           value="@GetTechLevelMinSliderValue()"
+                                           data-testid="empire-tech-level-min-slider"
+                                           aria-label="Minimum tech level slider"
+                                           @oninput="HandleTechLevelMinSliderChanged" />
+                                    <small>@GetTechLevelSliderValueLabel(minimum: true)</small>
+                                </label>
+                                <label class="record-filter-slider-field">
+                                    <span>Max slider</span>
+                                    <input type="range"
+                                           min="@GetTechLevelSliderMinimum()"
+                                           max="@GetTechLevelSliderMaximum()"
+                                           step="1"
+                                           value="@GetTechLevelMaxSliderValue()"
+                                           data-testid="empire-tech-level-max-slider"
+                                           aria-label="Maximum tech level slider"
+                                           @oninput="HandleTechLevelMaxSliderChanged" />
+                                    <small>@GetTechLevelSliderValueLabel(minimum: false)</small>
                                 </label>
                             </div>
                         </div>

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -150,10 +150,13 @@
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
                                 </label>
                             </div>
-                            <div class="record-filter-slider-group">
-                                <label class="record-filter-slider-field">
-                                    <span>Min slider</span>
+                            <div class="record-filter-dual-slider">
+                                <div class="record-filter-dual-slider-readout">@GetControlledWorldSliderSummary()</div>
+                                <div class="record-filter-dual-slider-shell" style="@GetControlledWorldSliderStyle()">
+                                    <span class="record-filter-dual-slider-track" aria-hidden="true"></span>
+                                    <span class="record-filter-dual-slider-range" aria-hidden="true"></span>
                                     <input type="range"
+                                           class="record-filter-dual-slider-input min"
                                            min="@GetControlledWorldSliderMinimum()"
                                            max="@GetControlledWorldSliderMaximum()"
                                            step="1"
@@ -161,11 +164,8 @@
                                            data-testid="empire-controlled-worlds-min-slider"
                                            aria-label="Minimum controlled worlds slider"
                                            @oninput="HandleControlledWorldMinSliderChanged" />
-                                    <small>@GetControlledWorldSliderValueLabel(minimum: true)</small>
-                                </label>
-                                <label class="record-filter-slider-field">
-                                    <span>Max slider</span>
                                     <input type="range"
+                                           class="record-filter-dual-slider-input max"
                                            min="@GetControlledWorldSliderMinimum()"
                                            max="@GetControlledWorldSliderMaximum()"
                                            step="1"
@@ -173,8 +173,7 @@
                                            data-testid="empire-controlled-worlds-max-slider"
                                            aria-label="Maximum controlled worlds slider"
                                            @oninput="HandleControlledWorldMaxSliderChanged" />
-                                    <small>@GetControlledWorldSliderValueLabel(minimum: false)</small>
-                                </label>
+                                </div>
                             </div>
                         </div>
                         <div class="record-filter-fieldset">
@@ -201,10 +200,13 @@
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
                                 </label>
                             </div>
-                            <div class="record-filter-slider-group">
-                                <label class="record-filter-slider-field">
-                                    <span>Min slider</span>
+                            <div class="record-filter-dual-slider">
+                                <div class="record-filter-dual-slider-readout">@GetPopulationSliderSummary()</div>
+                                <div class="record-filter-dual-slider-shell" style="@GetPopulationSliderStyle()">
+                                    <span class="record-filter-dual-slider-track" aria-hidden="true"></span>
+                                    <span class="record-filter-dual-slider-range" aria-hidden="true"></span>
                                     <input type="range"
+                                           class="record-filter-dual-slider-input min"
                                            min="@GetPopulationSliderMinimum()"
                                            max="@GetPopulationSliderMaximum()"
                                            step="1"
@@ -212,11 +214,8 @@
                                            data-testid="empire-population-min-slider"
                                            aria-label="Minimum population slider"
                                            @oninput="HandlePopulationMinSliderChanged" />
-                                    <small>@GetPopulationSliderValueLabel(minimum: true)</small>
-                                </label>
-                                <label class="record-filter-slider-field">
-                                    <span>Max slider</span>
                                     <input type="range"
+                                           class="record-filter-dual-slider-input max"
                                            min="@GetPopulationSliderMinimum()"
                                            max="@GetPopulationSliderMaximum()"
                                            step="1"
@@ -224,8 +223,7 @@
                                            data-testid="empire-population-max-slider"
                                            aria-label="Maximum population slider"
                                            @oninput="HandlePopulationMaxSliderChanged" />
-                                    <small>@GetPopulationSliderValueLabel(minimum: false)</small>
-                                </label>
+                                </div>
                             </div>
                         </div>
                         <div class="record-filter-fieldset">
@@ -264,10 +262,13 @@
                                            @bind:after="HandleEmpireFiltersChangedAsync" />
                                 </label>
                             </div>
-                            <div class="record-filter-slider-group">
-                                <label class="record-filter-slider-field">
-                                    <span>Min slider</span>
+                            <div class="record-filter-dual-slider">
+                                <div class="record-filter-dual-slider-readout">@GetTechLevelSliderSummary()</div>
+                                <div class="record-filter-dual-slider-shell" style="@GetTechLevelSliderStyle()">
+                                    <span class="record-filter-dual-slider-track" aria-hidden="true"></span>
+                                    <span class="record-filter-dual-slider-range" aria-hidden="true"></span>
                                     <input type="range"
+                                           class="record-filter-dual-slider-input min"
                                            min="@GetTechLevelSliderMinimum()"
                                            max="@GetTechLevelSliderMaximum()"
                                            step="1"
@@ -275,11 +276,8 @@
                                            data-testid="empire-tech-level-min-slider"
                                            aria-label="Minimum tech level slider"
                                            @oninput="HandleTechLevelMinSliderChanged" />
-                                    <small>@GetTechLevelSliderValueLabel(minimum: true)</small>
-                                </label>
-                                <label class="record-filter-slider-field">
-                                    <span>Max slider</span>
                                     <input type="range"
+                                           class="record-filter-dual-slider-input max"
                                            min="@GetTechLevelSliderMinimum()"
                                            max="@GetTechLevelSliderMaximum()"
                                            step="1"
@@ -287,8 +285,7 @@
                                            data-testid="empire-tech-level-max-slider"
                                            aria-label="Maximum tech level slider"
                                            @oninput="HandleTechLevelMaxSliderChanged" />
-                                    <small>@GetTechLevelSliderValueLabel(minimum: false)</small>
-                                </label>
+                                </div>
                             </div>
                         </div>
                         <div class="record-filter-actions">

--- a/StarWin.Web/Components/Pages/Empires.razor
+++ b/StarWin.Web/Components/Pages/Empires.razor
@@ -67,77 +67,64 @@
                                 }
                             </datalist>
                         </label>
-                        <div class="record-filter-inline-group">
-                            <div class="record-filter-fieldset">
-                                <span class="record-filter-heading">Status</span>
-                                <div class="record-filter-tristate-toggle @GetEmpireStatusToggleStateClass()"
-                                     style="--toggle-index:@GetEmpireStatusToggleIndex();"
-                                     role="radiogroup"
-                                     aria-label="Empire status filter"
-                                     data-testid="empire-status-filter">
-                                    <span class="record-filter-tristate-toggle-track" aria-hidden="true">
-                                        <span class="record-filter-tristate-toggle-track-lines">
-                                            <span class="record-filter-tristate-toggle-track-line"></span>
-                                        </span>
-                                        <span class="record-filter-tristate-toggle-reflection"></span>
-                                        <span class="record-filter-tristate-toggle-holo-glow"></span>
+                        <div class="record-filter-fieldset">
+                            <span class="record-filter-heading">Status</span>
+                            <div class="record-filter-tristate-toggle @GetEmpireStatusToggleStateClass()"
+                                 style="--toggle-index:@GetEmpireStatusToggleIndex();"
+                                 role="radiogroup"
+                                 aria-label="Empire status filter"
+                                 data-testid="empire-status-filter">
+                                <span class="record-filter-tristate-toggle-track" aria-hidden="true">
+                                    <span class="record-filter-tristate-toggle-track-lines">
+                                        <span class="record-filter-tristate-toggle-track-line"></span>
                                     </span>
-                                    <span class="record-filter-tristate-toggle-thumb" aria-hidden="true">
-                                        <span class="record-filter-tristate-toggle-energy-rings">
-                                            <span class="record-filter-tristate-toggle-energy-ring"></span>
-                                            <span class="record-filter-tristate-toggle-energy-ring"></span>
-                                            <span class="record-filter-tristate-toggle-energy-ring"></span>
-                                        </span>
-                                        <span class="record-filter-tristate-toggle-thumb-core"></span>
-                                        <span class="record-filter-tristate-toggle-thumb-inner"></span>
-                                        <span class="record-filter-tristate-toggle-thumb-scan"></span>
-                                        <span class="record-filter-tristate-toggle-thumb-particles">
-                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
-                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
-                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
-                                            <span class="record-filter-tristate-toggle-thumb-particle"></span>
-                                        </span>
+                                    <span class="record-filter-tristate-toggle-reflection"></span>
+                                    <span class="record-filter-tristate-toggle-holo-glow"></span>
+                                </span>
+                                <span class="record-filter-tristate-toggle-thumb" aria-hidden="true">
+                                    <span class="record-filter-tristate-toggle-energy-rings">
+                                        <span class="record-filter-tristate-toggle-energy-ring"></span>
+                                        <span class="record-filter-tristate-toggle-energy-ring"></span>
+                                        <span class="record-filter-tristate-toggle-energy-ring"></span>
                                     </span>
-                                    <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Active ? "active" : null)"
-                                           data-testid="empire-status-active"
-                                           @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Active)">
-                                        <input type="radio"
-                                               name="empire-status-filter"
-                                               checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Active)"
-                                               aria-label="Active empires" />
-                                        <span>Active</span>
-                                    </label>
-                                    <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Both ? "active" : null)"
-                                           data-testid="empire-status-both"
-                                           @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Both)">
-                                        <input type="radio"
-                                               name="empire-status-filter"
-                                               checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Both)"
-                                               aria-label="Active and fallen empires" />
-                                        <span>Both</span>
-                                    </label>
-                                    <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen ? "active" : null)"
-                                           data-testid="empire-status-fallen"
-                                           @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Fallen)">
-                                        <input type="radio"
-                                               name="empire-status-filter"
-                                               checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen)"
-                                               aria-label="Fallen empires" />
-                                        <span>Fallen</span>
-                                    </label>
-                                </div>
+                                    <span class="record-filter-tristate-toggle-thumb-core"></span>
+                                    <span class="record-filter-tristate-toggle-thumb-inner"></span>
+                                    <span class="record-filter-tristate-toggle-thumb-scan"></span>
+                                    <span class="record-filter-tristate-toggle-thumb-particles">
+                                        <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                        <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                        <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                        <span class="record-filter-tristate-toggle-thumb-particle"></span>
+                                    </span>
+                                </span>
+                                <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Active ? "active" : null)"
+                                       data-testid="empire-status-active"
+                                       @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Active)">
+                                    <input type="radio"
+                                           name="empire-status-filter"
+                                           checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Active)"
+                                           aria-label="Active empires" />
+                                    <span>Active</span>
+                                </label>
+                                <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Both ? "active" : null)"
+                                       data-testid="empire-status-both"
+                                       @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Both)">
+                                    <input type="radio"
+                                           name="empire-status-filter"
+                                           checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Both)"
+                                           aria-label="Active and fallen empires" />
+                                    <span>Both</span>
+                                </label>
+                                <label class="record-filter-tristate-toggle-option @(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen ? "active" : null)"
+                                       data-testid="empire-status-fallen"
+                                       @onclick="() => SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter.Fallen)">
+                                    <input type="radio"
+                                           name="empire-status-filter"
+                                           checked="@(empireStatusFilter == ExplorerEmpireStatusFilter.Fallen)"
+                                           aria-label="Fallen empires" />
+                                    <span>Fallen</span>
+                                </label>
                             </div>
-                            <label class="record-filter-select-label">
-                                Sort
-                                <select @bind="empireSortOption"
-                                        @bind:after="HandleEmpireSortChangedAsync"
-                                        data-testid="empire-sort-select">
-                                    <option value="@ExplorerEmpireSortOption.Alphabetical">Alphabetical</option>
-                                    <option value="@ExplorerEmpireSortOption.Population">Population</option>
-                                    <option value="@ExplorerEmpireSortOption.ControlledWorlds">Controlled worlds</option>
-                                    <option value="@ExplorerEmpireSortOption.EconomicPower">Economic power</option>
-                                </select>
-                            </label>
                         </div>
                         <div class="record-filter-fieldset">
                             <span class="record-filter-heading">Controlled worlds</span>
@@ -225,7 +212,20 @@
                         </div>
                     </div>
                 </details>
-                <div class="timeline-count">Showing @LoadedEmpireSummaries.Count empire@(LoadedEmpireSummaries.Count == 1 ? string.Empty : "s")@(empireHasMoreRecords ? "+" : string.Empty)</div>
+                <div class="record-list-toolbar">
+                    <div class="timeline-count">Showing @LoadedEmpireSummaries.Count empire@(LoadedEmpireSummaries.Count == 1 ? string.Empty : "s")@(empireHasMoreRecords ? "+" : string.Empty)</div>
+                    <label class="record-list-sort-label">
+                        <span>Sort</span>
+                        <select @bind="empireSortOption"
+                                @bind:after="HandleEmpireSortChangedAsync"
+                                data-testid="empire-sort-select">
+                            <option value="@ExplorerEmpireSortOption.Alphabetical">Alphabetical</option>
+                            <option value="@ExplorerEmpireSortOption.Population">Population</option>
+                            <option value="@ExplorerEmpireSortOption.ControlledWorlds">Controlled worlds</option>
+                            <option value="@ExplorerEmpireSortOption.EconomicPower">Economic power</option>
+                        </select>
+                    </label>
+                </div>
                 @if ((empireListLoading || empireFilterPending) && LoadedEmpireSummaries.Count == 0)
                 {
                     <article class="timeline-event-card">

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -271,6 +271,26 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         return Task.CompletedTask;
     }
 
+    protected int GetEmpireStatusToggleIndex()
+    {
+        return empireStatusFilter switch
+        {
+            ExplorerEmpireStatusFilter.Active => 0,
+            ExplorerEmpireStatusFilter.Fallen => 2,
+            _ => 1
+        };
+    }
+
+    protected string GetEmpireStatusToggleStateClass()
+    {
+        return empireStatusFilter switch
+        {
+            ExplorerEmpireStatusFilter.Active => "state-active",
+            ExplorerEmpireStatusFilter.Fallen => "state-fallen",
+            _ => "state-both"
+        };
+    }
+
     protected Task SetEmpireTechLevelSystemAsync(ExplorerEmpireTechLevelSystem techLevelSystem)
     {
         if (empireTechLevelSystem == techLevelSystem)

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
@@ -44,12 +45,20 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     protected IReadOnlyList<StarWinSearchResult> searchResults = [];
     protected string empireQuery = string.Empty;
     protected string empireRaceText = string.Empty;
+    protected string controlledWorldCountMinText = string.Empty;
+    protected string controlledWorldCountMaxText = string.Empty;
+    protected string nativePopulationMinText = string.Empty;
+    protected string nativePopulationMaxText = string.Empty;
+    protected string techLevelMinText = string.Empty;
+    protected string techLevelMaxText = string.Empty;
     protected string empireMemberRaceSearch = string.Empty;
     protected string empireColonySearch = string.Empty;
     protected string empireRelationshipSearch = string.Empty;
     protected string empireRelationshipType = string.Empty;
     protected int empireRaceId = ComboAllFilterId;
-    protected bool showOnlyFallenEmpires;
+    protected ExplorerEmpireStatusFilter empireStatusFilter = ExplorerEmpireStatusFilter.Both;
+    protected ExplorerEmpireTechLevelSystem empireTechLevelSystem = ExplorerEmpireTechLevelSystem.Gurps;
+    protected ExplorerEmpireSortOption empireSortOption = ExplorerEmpireSortOption.Alphabetical;
     protected bool empireHasMoreRecords;
     protected bool empireListLoading;
     protected bool empireDetailLoading;
@@ -250,9 +259,32 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         return Task.CompletedTask;
     }
 
-    protected Task ToggleFallenEmpireFilterAsync()
+    protected Task SetEmpireStatusFilterAsync(ExplorerEmpireStatusFilter statusFilter)
     {
-        showOnlyFallenEmpires = !showOnlyFallenEmpires;
+        if (empireStatusFilter == statusFilter)
+        {
+            return Task.CompletedTask;
+        }
+
+        empireStatusFilter = statusFilter;
+        RequestEmpireFilterReload(useDebounce: false);
+        return Task.CompletedTask;
+    }
+
+    protected Task SetEmpireTechLevelSystemAsync(ExplorerEmpireTechLevelSystem techLevelSystem)
+    {
+        if (empireTechLevelSystem == techLevelSystem)
+        {
+            return Task.CompletedTask;
+        }
+
+        empireTechLevelSystem = techLevelSystem;
+        RequestEmpireFilterReload(useDebounce: false);
+        return Task.CompletedTask;
+    }
+
+    protected Task HandleEmpireSortChangedAsync()
+    {
         RequestEmpireFilterReload(useDebounce: false);
         return Task.CompletedTask;
     }
@@ -261,8 +293,15 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     {
         empireQuery = string.Empty;
         empireRaceText = string.Empty;
+        controlledWorldCountMinText = string.Empty;
+        controlledWorldCountMaxText = string.Empty;
+        nativePopulationMinText = string.Empty;
+        nativePopulationMaxText = string.Empty;
+        techLevelMinText = string.Empty;
+        techLevelMaxText = string.Empty;
         empireRaceId = ComboAllFilterId;
-        showOnlyFallenEmpires = false;
+        empireStatusFilter = ExplorerEmpireStatusFilter.Both;
+        empireTechLevelSystem = ExplorerEmpireTechLevelSystem.Gurps;
         ResetEmpireWindow();
     }
 
@@ -413,7 +452,11 @@ public partial class Empires : ComponentBase, IAsyncDisposable
             loadedEmpireSectorId = selectedSectorId;
             empireHasMoreRecords = false;
             empireObserverConfigured = false;
-            ClearSelectedEmpireDetail();
+            if (sectorChanged)
+            {
+                ClearSelectedEmpireDetail();
+            }
+
             if (sectorChanged || empireFilterOptions.Races.Count == 0)
             {
                 empireFilterOptions = await ExplorerQueryService.LoadEmpireFilterOptionsAsync(selectedSectorId, cancellationToken);
@@ -555,13 +598,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         try
         {
             var page = await ExplorerQueryService.LoadEmpireListPageAsync(
-                new ExplorerEmpireListPageRequest(
-                    selectedSectorId,
-                    loadedEmpireSummaries.Count,
-                    ExplorerListBatchSize,
-                    string.IsNullOrWhiteSpace(empireQuery) ? null : empireQuery.Trim(),
-                    empireRaceId == ComboAllFilterId ? null : empireRaceId,
-                    showOnlyFallenEmpires),
+                BuildEmpireListPageRequest(loadedEmpireSummaries.Count, ExplorerListBatchSize),
                 cancellationToken);
 
             if (IsStaleEmpireFilterRequest(requestVersion))
@@ -611,11 +648,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         }
 
         loadedEmpireSummaries.Add(requestedItem);
-        loadedEmpireSummaries.Sort((left, right) =>
-        {
-            var nameComparison = string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase);
-            return nameComparison != 0 ? nameComparison : left.EmpireId.CompareTo(right.EmpireId);
-        });
+        loadedEmpireSummaries.Sort(CompareEmpireSummaries);
     }
 
     private async Task EnsureSelectedEmpireDetailAsync(CancellationToken cancellationToken = default, int? requestVersion = default)
@@ -695,9 +728,16 @@ public partial class Empires : ComponentBase, IAsyncDisposable
 
     private bool HasActiveEmpireFilters()
     {
-        return !string.IsNullOrWhiteSpace(empireQuery)
-            || empireRaceId != ComboAllFilterId
-            || showOnlyFallenEmpires;
+        var request = BuildEmpireListPageRequest(0, 1);
+        return !string.IsNullOrWhiteSpace(request.Query)
+            || request.RaceId.HasValue
+            || request.StatusFilter != ExplorerEmpireStatusFilter.Both
+            || request.MinControlledWorldCount.HasValue
+            || request.MaxControlledWorldCount.HasValue
+            || request.MinNativePopulationMillions.HasValue
+            || request.MaxNativePopulationMillions.HasValue
+            || request.MinTechLevel.HasValue
+            || request.MaxTechLevel.HasValue;
     }
 
     private bool IsStaleEmpireFilterRequest(int? requestVersion)
@@ -807,6 +847,60 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         return $"GURPS TL {empire.GurpsTechLevel}; {DescribeWorldTracking(empire.ControlledWorldCount, empire.TrackedWorldCount)}";
     }
 
+    protected IReadOnlyList<string> GetActiveEmpireFilterChips()
+    {
+        var request = BuildEmpireListPageRequest(0, 1);
+        var chips = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+        {
+            chips.Add($"Text: {request.Query}");
+        }
+
+        if (request.RaceId is int raceId)
+        {
+            var raceName = empireFilterOptions.Races.FirstOrDefault(option => option.Id == raceId)?.Name;
+            chips.Add(string.IsNullOrWhiteSpace(raceName)
+                ? $"Race: {empireRaceText.Trim()}"
+                : $"Race: {raceName}");
+        }
+
+        if (request.StatusFilter != ExplorerEmpireStatusFilter.Both)
+        {
+            chips.Add(request.StatusFilter == ExplorerEmpireStatusFilter.Active
+                ? "Status: Active"
+                : "Status: Fallen");
+        }
+
+        if (request.MinControlledWorldCount.HasValue || request.MaxControlledWorldCount.HasValue)
+        {
+            chips.Add($"Controlled worlds: {FormatRange(request.MinControlledWorldCount, request.MaxControlledWorldCount)}");
+        }
+
+        if (request.MinNativePopulationMillions.HasValue || request.MaxNativePopulationMillions.HasValue)
+        {
+            chips.Add($"Population: {FormatPopulationRange(request.MinNativePopulationMillions, request.MaxNativePopulationMillions)}");
+        }
+
+        if (request.MinTechLevel.HasValue || request.MaxTechLevel.HasValue)
+        {
+            var systemLabel = request.TechLevelSystem == ExplorerEmpireTechLevelSystem.Gurps ? "GURPS TL" : "StarWin TL";
+            chips.Add($"{systemLabel}: {FormatRange(request.MinTechLevel, request.MaxTechLevel)}");
+        }
+
+        return chips;
+    }
+
+    protected static string GetPopulationFilterInputTitle(string value)
+    {
+        if (ParsePopulationAbsolute(value) is not decimal absolutePopulation)
+        {
+            return "Enter a full population or use M, B, or T abbreviations.";
+        }
+
+        return $"{absolutePopulation:N0}";
+    }
+
     protected static string GetEmpireColonyRowClass(ExplorerEmpireColonyListing listing)
     {
         return listing.IsControlled
@@ -848,6 +942,172 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         return relationship.Age > 0
             ? $"{relationship.Relation}; contact age {relationship.Age}"
             : relationship.Relation;
+    }
+
+    private ExplorerEmpireListPageRequest BuildEmpireListPageRequest(int offset, int limit)
+    {
+        var (minControlledWorldCount, maxControlledWorldCount) = NormalizeRange(
+            ParseNullableInt(controlledWorldCountMinText),
+            ParseNullableInt(controlledWorldCountMaxText));
+        var (minTechLevel, maxTechLevel) = NormalizeRange(
+            ParseNullableInt(techLevelMinText),
+            ParseNullableInt(techLevelMaxText));
+        var (minNativePopulationAbsolute, maxNativePopulationAbsolute) = NormalizeRange(
+            ParsePopulationAbsolute(nativePopulationMinText),
+            ParsePopulationAbsolute(nativePopulationMaxText));
+
+        return new ExplorerEmpireListPageRequest(
+            selectedSectorId,
+            offset,
+            limit,
+            string.IsNullOrWhiteSpace(empireQuery) ? null : empireQuery.Trim(),
+            empireRaceId == ComboAllFilterId ? null : empireRaceId,
+            empireStatusFilter,
+            minControlledWorldCount,
+            maxControlledWorldCount,
+            ToPopulationMillions(minNativePopulationAbsolute, roundUp: true),
+            ToPopulationMillions(maxNativePopulationAbsolute, roundUp: false),
+            empireTechLevelSystem,
+            minTechLevel,
+            maxTechLevel,
+            empireSortOption);
+    }
+
+    private int CompareEmpireSummaries(ExplorerEmpireListItem left, ExplorerEmpireListItem right)
+    {
+        return empireSortOption switch
+        {
+            ExplorerEmpireSortOption.Population => CompareDescending(left.NativePopulationMillions, right.NativePopulationMillions, left, right),
+            ExplorerEmpireSortOption.ControlledWorlds => CompareDescending(left.ControlledWorldCount, right.ControlledWorldCount, left, right),
+            ExplorerEmpireSortOption.EconomicPower => CompareDescending(left.EconomicPowerMcr, right.EconomicPowerMcr, left, right),
+            _ => CompareByName(left, right)
+        };
+    }
+
+    private static int CompareDescending<TValue>(TValue leftValue, TValue rightValue, ExplorerEmpireListItem left, ExplorerEmpireListItem right)
+        where TValue : IComparable<TValue>
+    {
+        var valueComparison = rightValue.CompareTo(leftValue);
+        return valueComparison != 0
+            ? valueComparison
+            : CompareByName(left, right);
+    }
+
+    private static int CompareByName(ExplorerEmpireListItem left, ExplorerEmpireListItem right)
+    {
+        var nameComparison = string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase);
+        return nameComparison != 0 ? nameComparison : left.EmpireId.CompareTo(right.EmpireId);
+    }
+
+    private static int? ParseNullableInt(string value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
+            ? parsedValue
+            : null;
+    }
+
+    private static decimal? ParsePopulationAbsolute(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmedValue = value.Trim().Replace(",", string.Empty, StringComparison.Ordinal);
+        var multiplier = 1m;
+        if (trimmedValue.Length > 0)
+        {
+            var suffix = char.ToUpperInvariant(trimmedValue[^1]);
+            if (suffix is 'M' or 'B' or 'T')
+            {
+                multiplier = suffix switch
+                {
+                    'M' => 1_000_000m,
+                    'B' => 1_000_000_000m,
+                    'T' => 1_000_000_000_000m,
+                    _ => 1m
+                };
+                trimmedValue = trimmedValue[..^1];
+            }
+        }
+
+        return decimal.TryParse(trimmedValue, NumberStyles.Number, CultureInfo.InvariantCulture, out var numericPortion)
+            && numericPortion >= 0m
+            ? numericPortion * multiplier
+            : null;
+    }
+
+    private static long? ToPopulationMillions(decimal? absolutePopulation, bool roundUp)
+    {
+        if (absolutePopulation is not decimal resolvedPopulation)
+        {
+            return null;
+        }
+
+        var populationMillions = resolvedPopulation / 1_000_000m;
+        var roundedMillions = roundUp
+            ? Math.Ceiling(populationMillions)
+            : Math.Floor(populationMillions);
+        return roundedMillions < 0m
+            ? 0
+            : (long)roundedMillions;
+    }
+
+    private static (T? MinValue, T? MaxValue) NormalizeRange<T>(T? minValue, T? maxValue)
+        where T : struct, IComparable<T>
+    {
+        if (minValue.HasValue && maxValue.HasValue && minValue.Value.CompareTo(maxValue.Value) > 0)
+        {
+            return (maxValue, minValue);
+        }
+
+        return (minValue, maxValue);
+    }
+
+    private static string FormatRange<T>(T? minValue, T? maxValue)
+        where T : struct
+    {
+        return (minValue, maxValue) switch
+        {
+            ({ } minimum, { } maximum) when EqualityComparer<T>.Default.Equals(minimum, maximum) => $"{minimum}",
+            ({ } minimum, { } maximum) => $"{minimum}-{maximum}",
+            ({ } minimum, null) => $"{minimum}+",
+            (null, { } maximum) => $"up to {maximum}",
+            _ => string.Empty
+        };
+    }
+
+    private static string FormatPopulationRange(long? minPopulationMillions, long? maxPopulationMillions)
+    {
+        return (minPopulationMillions, maxPopulationMillions) switch
+        {
+            ({ } minimum, { } maximum) when minimum == maximum => FormatPopulationFilterMillions(minimum),
+            ({ } minimum, { } maximum) => $"{FormatPopulationFilterMillions(minimum)}-{FormatPopulationFilterMillions(maximum)}",
+            ({ } minimum, null) => $"{FormatPopulationFilterMillions(minimum)}+",
+            (null, { } maximum) => $"up to {FormatPopulationFilterMillions(maximum)}",
+            _ => string.Empty
+        };
+    }
+
+    private static string FormatPopulationFilterMillions(long populationMillions)
+    {
+        var absolutePopulation = populationMillions * 1_000_000m;
+        if (absolutePopulation >= 1_000_000_000_000m)
+        {
+            return $"{absolutePopulation / 1_000_000_000_000m:0.#}T";
+        }
+
+        if (absolutePopulation >= 1_000_000_000m)
+        {
+            return $"{absolutePopulation / 1_000_000_000m:0.#}B";
+        }
+
+        if (absolutePopulation >= 1_000_000m)
+        {
+            return $"{absolutePopulation / 1_000_000m:0.#}M";
+        }
+
+        return $"{absolutePopulation:0}";
     }
 
     protected static IReadOnlyList<ExplorerEmpireRaceMembershipDetail> FilterMemberRaces(

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -299,6 +299,7 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         }
 
         empireTechLevelSystem = techLevelSystem;
+        ApplyTechLevelSliderValues(GetTechLevelSliderSelection().MinValue, GetTechLevelSliderSelection().MaxValue);
         RequestEmpireFilterReload(useDebounce: false);
         return Task.CompletedTask;
     }
@@ -306,6 +307,125 @@ public partial class Empires : ComponentBase, IAsyncDisposable
     protected Task HandleEmpireSortChangedAsync()
     {
         RequestEmpireFilterReload(useDebounce: false);
+        return Task.CompletedTask;
+    }
+
+    protected int GetControlledWorldSliderMinimum() => 0;
+
+    protected int GetControlledWorldSliderMaximum() => GetControlledWorldSliderUpperBound();
+
+    protected int GetControlledWorldMinSliderValue() => GetControlledWorldSliderSelection().MinValue;
+
+    protected int GetControlledWorldMaxSliderValue() => GetControlledWorldSliderSelection().MaxValue;
+
+    protected string GetControlledWorldSliderValueLabel(bool minimum)
+    {
+        var explicitValue = minimum
+            ? ParseNullableInt(controlledWorldCountMinText)
+            : ParseNullableInt(controlledWorldCountMaxText);
+        if (!explicitValue.HasValue)
+        {
+            return "Any";
+        }
+
+        return (minimum ? GetControlledWorldMinSliderValue() : GetControlledWorldMaxSliderValue())
+            .ToString(CultureInfo.InvariantCulture);
+    }
+
+    protected Task HandleControlledWorldMinSliderChanged(ChangeEventArgs args)
+    {
+        var nextMinValue = ParseSliderInt(args.Value, GetControlledWorldSliderMinimum());
+        var (_, currentMaxValue) = GetControlledWorldSliderSelection();
+        ApplyControlledWorldSliderValues(nextMinValue, Math.Max(nextMinValue, currentMaxValue));
+        RequestEmpireFilterReload(useDebounce: true);
+        return Task.CompletedTask;
+    }
+
+    protected Task HandleControlledWorldMaxSliderChanged(ChangeEventArgs args)
+    {
+        var nextMaxValue = ParseSliderInt(args.Value, GetControlledWorldSliderMaximum());
+        var (currentMinValue, _) = GetControlledWorldSliderSelection();
+        ApplyControlledWorldSliderValues(Math.Min(currentMinValue, nextMaxValue), nextMaxValue);
+        RequestEmpireFilterReload(useDebounce: true);
+        return Task.CompletedTask;
+    }
+
+    protected long GetPopulationSliderMinimum() => 0;
+
+    protected long GetPopulationSliderMaximum() => GetPopulationSliderUpperBound();
+
+    protected long GetPopulationMinSliderValue() => GetPopulationSliderSelection().MinValue;
+
+    protected long GetPopulationMaxSliderValue() => GetPopulationSliderSelection().MaxValue;
+
+    protected string GetPopulationSliderValueLabel(bool minimum)
+    {
+        var explicitValue = minimum
+            ? ParsePopulationAbsolute(nativePopulationMinText)
+            : ParsePopulationAbsolute(nativePopulationMaxText);
+        if (!explicitValue.HasValue)
+        {
+            return "Any";
+        }
+
+        return FormatPopulationFilterMillions(minimum ? GetPopulationMinSliderValue() : GetPopulationMaxSliderValue());
+    }
+
+    protected Task HandlePopulationMinSliderChanged(ChangeEventArgs args)
+    {
+        var nextMinValue = ParseSliderLong(args.Value, GetPopulationSliderMinimum());
+        var (_, currentMaxValue) = GetPopulationSliderSelection();
+        ApplyPopulationSliderValues(nextMinValue, Math.Max(nextMinValue, currentMaxValue));
+        RequestEmpireFilterReload(useDebounce: true);
+        return Task.CompletedTask;
+    }
+
+    protected Task HandlePopulationMaxSliderChanged(ChangeEventArgs args)
+    {
+        var nextMaxValue = ParseSliderLong(args.Value, GetPopulationSliderMaximum());
+        var (currentMinValue, _) = GetPopulationSliderSelection();
+        ApplyPopulationSliderValues(Math.Min(currentMinValue, nextMaxValue), nextMaxValue);
+        RequestEmpireFilterReload(useDebounce: true);
+        return Task.CompletedTask;
+    }
+
+    protected int GetTechLevelSliderMinimum() => 0;
+
+    protected int GetTechLevelSliderMaximum() => GetTechLevelSliderUpperBound();
+
+    protected int GetTechLevelMinSliderValue() => GetTechLevelSliderSelection().MinValue;
+
+    protected int GetTechLevelMaxSliderValue() => GetTechLevelSliderSelection().MaxValue;
+
+    protected string GetTechLevelSliderValueLabel(bool minimum)
+    {
+        var explicitValue = minimum
+            ? ParseNullableInt(techLevelMinText)
+            : ParseNullableInt(techLevelMaxText);
+        if (!explicitValue.HasValue)
+        {
+            return "Any";
+        }
+
+        return (minimum ? GetTechLevelMinSliderValue() : GetTechLevelMaxSliderValue())
+            .ToString(CultureInfo.InvariantCulture);
+    }
+
+    protected Task HandleTechLevelMinSliderChanged(ChangeEventArgs args)
+    {
+        var nextMinValue = ParseSliderInt(args.Value, GetTechLevelSliderMinimum());
+        var (_, currentMaxValue) = GetTechLevelSliderSelection();
+        ApplyTechLevelSliderValues(nextMinValue, Math.Max(nextMinValue, currentMaxValue));
+        RequestEmpireFilterReload(useDebounce: true);
+        return Task.CompletedTask;
+    }
+
+    protected Task HandleTechLevelMaxSliderChanged(ChangeEventArgs args)
+    {
+        var nextMaxValue = ParseSliderInt(args.Value, GetTechLevelSliderMaximum());
+        var (currentMinValue, _) = GetTechLevelSliderSelection();
+        ApplyTechLevelSliderValues(Math.Min(currentMinValue, nextMaxValue), nextMaxValue);
+        RequestEmpireFilterReload(useDebounce: true);
         return Task.CompletedTask;
     }
 
@@ -1004,6 +1124,111 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         };
     }
 
+    private int GetControlledWorldSliderUpperBound()
+    {
+        var currentSelectionMaximum = Math.Max(
+            ParseNullableInt(controlledWorldCountMinText) ?? 0,
+            ParseNullableInt(controlledWorldCountMaxText) ?? 0);
+        return Math.Max(Math.Max(1, empireFilterOptions.MaxControlledWorldCount), currentSelectionMaximum);
+    }
+
+    private (int MinValue, int MaxValue) GetControlledWorldSliderSelection()
+    {
+        var maximumBound = GetControlledWorldSliderUpperBound();
+        var (minValue, maxValue) = NormalizeRange(
+            ParseNullableInt(controlledWorldCountMinText),
+            ParseNullableInt(controlledWorldCountMaxText));
+        return (
+            Math.Clamp(minValue ?? GetControlledWorldSliderMinimum(), GetControlledWorldSliderMinimum(), maximumBound),
+            Math.Clamp(maxValue ?? maximumBound, GetControlledWorldSliderMinimum(), maximumBound));
+    }
+
+    private void ApplyControlledWorldSliderValues(int minValue, int maxValue)
+    {
+        var minimumBound = GetControlledWorldSliderMinimum();
+        var maximumBound = GetControlledWorldSliderUpperBound();
+        var clampedMinValue = Math.Clamp(minValue, minimumBound, maximumBound);
+        var clampedMaxValue = Math.Clamp(Math.Max(maxValue, clampedMinValue), minimumBound, maximumBound);
+
+        controlledWorldCountMinText = clampedMinValue <= minimumBound
+            ? string.Empty
+            : clampedMinValue.ToString(CultureInfo.InvariantCulture);
+        controlledWorldCountMaxText = clampedMaxValue >= maximumBound
+            ? string.Empty
+            : clampedMaxValue.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private long GetPopulationSliderUpperBound()
+    {
+        var currentSelectionMaximum = Math.Max(
+            ToPopulationMillions(ParsePopulationAbsolute(nativePopulationMinText), roundUp: true) ?? 0,
+            ToPopulationMillions(ParsePopulationAbsolute(nativePopulationMaxText), roundUp: false) ?? 0);
+        return Math.Max(Math.Max(1L, empireFilterOptions.MaxNativePopulationMillions), currentSelectionMaximum);
+    }
+
+    private (long MinValue, long MaxValue) GetPopulationSliderSelection()
+    {
+        var maximumBound = GetPopulationSliderUpperBound();
+        var (minValue, maxValue) = NormalizeRange(
+            ToPopulationMillions(ParsePopulationAbsolute(nativePopulationMinText), roundUp: true),
+            ToPopulationMillions(ParsePopulationAbsolute(nativePopulationMaxText), roundUp: false));
+        return (
+            Math.Clamp(minValue ?? GetPopulationSliderMinimum(), GetPopulationSliderMinimum(), maximumBound),
+            Math.Clamp(maxValue ?? maximumBound, GetPopulationSliderMinimum(), maximumBound));
+    }
+
+    private void ApplyPopulationSliderValues(long minValue, long maxValue)
+    {
+        var minimumBound = GetPopulationSliderMinimum();
+        var maximumBound = GetPopulationSliderUpperBound();
+        var clampedMinValue = Math.Clamp(minValue, minimumBound, maximumBound);
+        var clampedMaxValue = Math.Clamp(Math.Max(maxValue, clampedMinValue), minimumBound, maximumBound);
+
+        nativePopulationMinText = clampedMinValue <= minimumBound
+            ? string.Empty
+            : FormatPopulationFilterMillions(clampedMinValue);
+        nativePopulationMaxText = clampedMaxValue >= maximumBound
+            ? string.Empty
+            : FormatPopulationFilterMillions(clampedMaxValue);
+    }
+
+    private int GetTechLevelSliderUpperBound()
+    {
+        var configuredMaximum = empireTechLevelSystem == ExplorerEmpireTechLevelSystem.Gurps
+            ? empireFilterOptions.MaxGurpsTechLevel
+            : empireFilterOptions.MaxStarWinTechLevel;
+        var currentSelectionMaximum = Math.Max(
+            ParseNullableInt(techLevelMinText) ?? 0,
+            ParseNullableInt(techLevelMaxText) ?? 0);
+        return Math.Max(Math.Max(1, configuredMaximum), currentSelectionMaximum);
+    }
+
+    private (int MinValue, int MaxValue) GetTechLevelSliderSelection()
+    {
+        var maximumBound = GetTechLevelSliderUpperBound();
+        var (minValue, maxValue) = NormalizeRange(
+            ParseNullableInt(techLevelMinText),
+            ParseNullableInt(techLevelMaxText));
+        return (
+            Math.Clamp(minValue ?? GetTechLevelSliderMinimum(), GetTechLevelSliderMinimum(), maximumBound),
+            Math.Clamp(maxValue ?? maximumBound, GetTechLevelSliderMinimum(), maximumBound));
+    }
+
+    private void ApplyTechLevelSliderValues(int minValue, int maxValue)
+    {
+        var minimumBound = GetTechLevelSliderMinimum();
+        var maximumBound = GetTechLevelSliderUpperBound();
+        var clampedMinValue = Math.Clamp(minValue, minimumBound, maximumBound);
+        var clampedMaxValue = Math.Clamp(Math.Max(maxValue, clampedMinValue), minimumBound, maximumBound);
+
+        techLevelMinText = clampedMinValue <= minimumBound
+            ? string.Empty
+            : clampedMinValue.ToString(CultureInfo.InvariantCulture);
+        techLevelMaxText = clampedMaxValue >= maximumBound
+            ? string.Empty
+            : clampedMaxValue.ToString(CultureInfo.InvariantCulture);
+    }
+
     private static int CompareDescending<TValue>(TValue leftValue, TValue rightValue, ExplorerEmpireListItem left, ExplorerEmpireListItem right)
         where TValue : IComparable<TValue>
     {
@@ -1024,6 +1249,22 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
             ? parsedValue
             : null;
+    }
+
+    private static int ParseSliderInt(object? value, int fallbackValue)
+    {
+        return value is not null
+            && int.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
+            ? parsedValue
+            : fallbackValue;
+    }
+
+    private static long ParseSliderLong(object? value, long fallbackValue)
+    {
+        return value is not null
+            && long.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue)
+            ? parsedValue
+            : fallbackValue;
     }
 
     private static decimal? ParsePopulationAbsolute(string? value)

--- a/StarWin.Web/Components/Pages/Empires.razor.cs
+++ b/StarWin.Web/Components/Pages/Empires.razor.cs
@@ -318,19 +318,19 @@ public partial class Empires : ComponentBase, IAsyncDisposable
 
     protected int GetControlledWorldMaxSliderValue() => GetControlledWorldSliderSelection().MaxValue;
 
-    protected string GetControlledWorldSliderValueLabel(bool minimum)
+    protected string GetControlledWorldSliderSummary()
     {
-        var explicitValue = minimum
-            ? ParseNullableInt(controlledWorldCountMinText)
-            : ParseNullableInt(controlledWorldCountMaxText);
-        if (!explicitValue.HasValue)
-        {
-            return "Any";
-        }
-
-        return (minimum ? GetControlledWorldMinSliderValue() : GetControlledWorldMaxSliderValue())
-            .ToString(CultureInfo.InvariantCulture);
+        var summary = FormatRange(
+            ParseNullableInt(controlledWorldCountMinText),
+            ParseNullableInt(controlledWorldCountMaxText));
+        return string.IsNullOrWhiteSpace(summary) ? "Any" : summary;
     }
+
+    protected string GetControlledWorldSliderStyle() => BuildDualSliderStyle(
+        GetControlledWorldSliderMinimum(),
+        GetControlledWorldSliderMaximum(),
+        GetControlledWorldMinSliderValue(),
+        GetControlledWorldMaxSliderValue());
 
     protected Task HandleControlledWorldMinSliderChanged(ChangeEventArgs args)
     {
@@ -358,18 +358,19 @@ public partial class Empires : ComponentBase, IAsyncDisposable
 
     protected long GetPopulationMaxSliderValue() => GetPopulationSliderSelection().MaxValue;
 
-    protected string GetPopulationSliderValueLabel(bool minimum)
+    protected string GetPopulationSliderSummary()
     {
-        var explicitValue = minimum
-            ? ParsePopulationAbsolute(nativePopulationMinText)
-            : ParsePopulationAbsolute(nativePopulationMaxText);
-        if (!explicitValue.HasValue)
-        {
-            return "Any";
-        }
-
-        return FormatPopulationFilterMillions(minimum ? GetPopulationMinSliderValue() : GetPopulationMaxSliderValue());
+        var summary = FormatPopulationRange(
+            ToPopulationMillions(ParsePopulationAbsolute(nativePopulationMinText), roundUp: true),
+            ToPopulationMillions(ParsePopulationAbsolute(nativePopulationMaxText), roundUp: false));
+        return string.IsNullOrWhiteSpace(summary) ? "Any" : summary;
     }
+
+    protected string GetPopulationSliderStyle() => BuildDualSliderStyle(
+        GetPopulationSliderMinimum(),
+        GetPopulationSliderMaximum(),
+        GetPopulationMinSliderValue(),
+        GetPopulationMaxSliderValue());
 
     protected Task HandlePopulationMinSliderChanged(ChangeEventArgs args)
     {
@@ -397,19 +398,19 @@ public partial class Empires : ComponentBase, IAsyncDisposable
 
     protected int GetTechLevelMaxSliderValue() => GetTechLevelSliderSelection().MaxValue;
 
-    protected string GetTechLevelSliderValueLabel(bool minimum)
+    protected string GetTechLevelSliderSummary()
     {
-        var explicitValue = minimum
-            ? ParseNullableInt(techLevelMinText)
-            : ParseNullableInt(techLevelMaxText);
-        if (!explicitValue.HasValue)
-        {
-            return "Any";
-        }
-
-        return (minimum ? GetTechLevelMinSliderValue() : GetTechLevelMaxSliderValue())
-            .ToString(CultureInfo.InvariantCulture);
+        var summary = FormatRange(
+            ParseNullableInt(techLevelMinText),
+            ParseNullableInt(techLevelMaxText));
+        return string.IsNullOrWhiteSpace(summary) ? "Any" : summary;
     }
+
+    protected string GetTechLevelSliderStyle() => BuildDualSliderStyle(
+        GetTechLevelSliderMinimum(),
+        GetTechLevelSliderMaximum(),
+        GetTechLevelMinSliderValue(),
+        GetTechLevelMaxSliderValue());
 
     protected Task HandleTechLevelMinSliderChanged(ChangeEventArgs args)
     {
@@ -1227,6 +1228,25 @@ public partial class Empires : ComponentBase, IAsyncDisposable
         techLevelMaxText = clampedMaxValue >= maximumBound
             ? string.Empty
             : clampedMaxValue.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string BuildDualSliderStyle(long minimumBound, long maximumBound, long minimumValue, long maximumValue)
+    {
+        if (maximumBound <= minimumBound)
+        {
+            return "--slider-min-percent: 0%; --slider-max-percent: 100%;";
+        }
+
+        var range = maximumBound - minimumBound;
+        var minimumPercent = Math.Clamp((minimumValue - minimumBound) * 100m / range, 0m, 100m);
+        var maximumPercent = Math.Clamp((maximumValue - minimumBound) * 100m / range, 0m, 100m);
+        return FormattableString.Invariant(
+            $"--slider-min-percent: {minimumPercent:0.###}%; --slider-max-percent: {maximumPercent:0.###}%;");
+    }
+
+    private static string BuildDualSliderStyle(int minimumBound, int maximumBound, int minimumValue, int maximumValue)
+    {
+        return BuildDualSliderStyle((long)minimumBound, maximumBound, minimumValue, maximumValue);
     }
 
     private static int CompareDescending<TValue>(TValue leftValue, TValue rightValue, ExplorerEmpireListItem left, ExplorerEmpireListItem right)

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor
@@ -245,6 +245,30 @@
                         </section>
                     </div>
                 </section>
+
+                <section class="configuration-card-group">
+                    <div class="configuration-group-header">
+                        <div>
+                            <span class="panel-kicker">Empire Cache</span>
+                            <h3>Sector empire stats</h3>
+                        </div>
+                        <p>Rebuild the sector-scoped empire cache when colony control changes and the explorer needs fast, up-to-date world counts again.</p>
+                    </div>
+                    <div class="configuration-card-grid">
+                        <section class="configuration-card configuration-card-metrics">
+                            <div class="configuration-card-header">
+                                <span class="panel-kicker">Cache</span>
+                                <h4>Empire stats readiness</h4>
+                            </div>
+                            <dl class="field-grid compact-field-grid">
+                                <div><dt>Status</dt><dd>@GetSectorEmpireStatsStatus()</dd></div>
+                                <div><dt>Tracked empires</dt><dd>@(selectedConfigurationState?.SectorEmpireStatsEmpireCount ?? 0)</dd></div>
+                                <div><dt>Last rebuilt</dt><dd>@DisplayDateTime(selectedConfigurationState?.SectorEmpireStatsCalculatedAtUtc)</dd></div>
+                                <div><dt>Summary</dt><dd>@GetSectorEmpireStatsSummary()</dd></div>
+                            </dl>
+                        </section>
+                    </div>
+                </section>
             </div>
             <div class="parent-actions">
                 <button type="button" @onclick="SaveSectorConfigurationAsync">Save configuration</button>
@@ -252,6 +276,9 @@
                     @(SavedRouteCount == 0 ? "Save Current Routes" : "Update Current Routes")
                 </button>
                 <button type="button" @onclick="() => ConvertIndependentColoniesAsync(sector.Id)" disabled="@routeSaveLoadingVisible">Convert independent colonies</button>
+                <button type="button" @onclick="RefreshSectorEmpireStatsAsync" disabled="@sectorEmpireStatsRefreshLoading">
+                    @(sectorEmpireStatsRefreshLoading ? "Refreshing empire stats..." : "Recalculate sector empire stats")
+                </button>
                 <button type="button" @onclick="() => LoadSectorConfigurationForm(selectedConfigurationState)">Reset form</button>
             </div>
             @if (!string.IsNullOrWhiteSpace(sectorConfigurationStatus))

--- a/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
+++ b/StarWin.Web/Components/Pages/SectorConfiguration.razor.cs
@@ -20,6 +20,7 @@ public partial class SectorConfiguration : ComponentBase
     [Inject] protected IStarWinExplorerContextService ExplorerContextService { get; set; } = default!;
     [Inject] protected IStarWinExplorerQueryService ExplorerQueryService { get; set; } = default!;
     [Inject] protected IStarWinSectorConfigurationService SectorConfigurationService { get; set; } = default!;
+    [Inject] protected IStarWinSectorEmpireStatsService SectorEmpireStatsService { get; set; } = default!;
     [Inject] protected IStarWinSectorRouteService SectorRouteService { get; set; } = default!;
     [Inject] protected IStarWinIndependentColonyService IndependentColonyService { get; set; } = default!;
     [Inject] protected NavigationManager NavigationManager { get; set; } = default!;
@@ -66,6 +67,7 @@ public partial class SectorConfiguration : ComponentBase
     protected decimal tl10OffLaneSpeedMultiplier = 32m;
     protected decimal tl10HyperlaneSpeedModifier = 3m;
     protected string sectorConfigurationStatus = string.Empty;
+    protected bool sectorEmpireStatsRefreshLoading;
     protected bool routeSaveLoadingVisible;
     protected string routeSaveLoadingStatus = string.Empty;
     protected string routeSaveLoadingDetail = string.Empty;
@@ -79,6 +81,7 @@ public partial class SectorConfiguration : ComponentBase
     protected IReadOnlyList<StarWinSector> ExplorerSectors => explorerContext.Sectors;
     protected int SavedRouteCount => selectedConfigurationState?.SavedRouteCount ?? 0;
     protected SectorHyperlaneNetworkReport SavedRouteReport => selectedConfigurationState?.SavedRouteReport ?? SectorHyperlaneNetworkReport.Empty;
+    protected bool SectorEmpireStatsNeedRefresh => selectedConfigurationState?.SectorEmpireStatsInvalidatedAtUtc is not null;
 
     protected override async Task OnInitializedAsync()
     {
@@ -241,6 +244,38 @@ public partial class SectorConfiguration : ComponentBase
             : "Not recorded";
     }
 
+    protected string GetSectorEmpireStatsStatus()
+    {
+        if (selectedConfigurationState?.SectorEmpireStatsCalculatedAtUtc is not DateTime)
+        {
+            return "Not calculated";
+        }
+
+        return SectorEmpireStatsNeedRefresh
+            ? "Needs refresh"
+            : "Ready";
+    }
+
+    protected string GetSectorEmpireStatsSummary()
+    {
+        if (selectedConfigurationState is null)
+        {
+            return "No sector selected.";
+        }
+
+        if (selectedConfigurationState.SectorEmpireStatsCalculatedAtUtc is not DateTime calculatedAtUtc)
+        {
+            return "Build the sector empire stats cache before relying on sector-scoped world filters.";
+        }
+
+        if (selectedConfigurationState.SectorEmpireStatsInvalidatedAtUtc is DateTime invalidatedAtUtc)
+        {
+            return $"The cache was last rebuilt {DisplayDateTime(calculatedAtUtc)} and was marked stale {DisplayDateTime(invalidatedAtUtc)}.";
+        }
+
+        return $"The cache currently tracks {selectedConfigurationState.SectorEmpireStatsEmpireCount:N0} empire row{(selectedConfigurationState.SectorEmpireStatsEmpireCount == 1 ? string.Empty : "s")} for this sector.";
+    }
+
     private void LoadSectorConfigurationForm(ExplorerSectorConfigurationState? state)
     {
         if (state is null)
@@ -380,6 +415,33 @@ public partial class SectorConfiguration : ComponentBase
             routeSaveProcessedItems = null;
             routeSaveTotalItems = null;
             StateHasChanged();
+        }
+    }
+
+    private async Task RefreshSectorEmpireStatsAsync()
+    {
+        if (sectorEmpireStatsRefreshLoading)
+        {
+            return;
+        }
+
+        var sector = GetSelectedSector();
+        sectorEmpireStatsRefreshLoading = true;
+        sectorConfigurationStatus = $"Refreshing sector empire stats for {sector.Name}...";
+
+        try
+        {
+            var result = await SectorEmpireStatsService.RebuildSectorStatsAsync(sector.Id);
+            await LoadSelectedConfigurationStateAsync(selectedSectorId, selectedSystemId);
+            sectorConfigurationStatus = $"Refreshed {result.EmpireCount:N0} sector empire stat row{(result.EmpireCount == 1 ? string.Empty : "s")} for {sector.Name}.";
+        }
+        catch (InvalidOperationException ex)
+        {
+            sectorConfigurationStatus = ex.Message;
+        }
+        finally
+        {
+            sectorEmpireStatsRefreshLoading = false;
         }
     }
 

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1290,6 +1290,13 @@ dd {
     cursor: pointer;
 }
 
+.record-filter-summary-copy {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
 .record-filter-summary::-webkit-details-marker {
     display: none;
 }
@@ -1314,6 +1321,34 @@ dd {
     content: "+";
 }
 
+.record-filter-panel[open] .record-filter-chip-list {
+    display: none;
+}
+
+.record-filter-chip-list {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.record-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    border: 1px solid rgba(125, 211, 252, 0.26);
+    border-radius: 999px;
+    background: rgba(14, 165, 233, 0.12);
+    color: #dbeafe;
+    padding: 2px 8px;
+    font-size: 0.72rem;
+    font-weight: 800;
+}
+
+.record-filter-grid {
+    display: grid;
+    gap: 10px;
+}
+
 .record-filter-panel label {
     display: grid;
     gap: 6px;
@@ -1322,10 +1357,77 @@ dd {
     font-weight: 900;
 }
 
+.record-filter-inline-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px;
+    align-items: end;
+}
+
+.record-filter-fieldset {
+    display: grid;
+    gap: 8px;
+    border: 1px solid rgba(125, 211, 252, 0.16);
+    border-radius: 8px;
+    background: rgba(8, 15, 32, 0.68);
+    padding: 10px;
+}
+
+.record-filter-fieldset-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.record-filter-heading {
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.record-filter-segmented-control {
+    margin-bottom: 0;
+}
+
+.record-filter-segmented-control button {
+    min-height: 34px;
+    padding: 6px 10px;
+}
+
+.record-filter-range-inputs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.record-filter-range-inputs label {
+    gap: 4px;
+}
+
+.record-filter-range-inputs label span {
+    color: #cbd5e1;
+    font-size: 0.7rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.record-filter-select-label {
+    align-self: stretch;
+}
+
 .record-filter-actions,
 .record-filter-toggle-row {
     display: flex;
     align-items: stretch;
+}
+
+.record-filter-actions {
+    justify-content: flex-end;
 }
 
 .record-filter-actions .timeline-clear-button {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -304,9 +304,9 @@ dd {
 
 .control-strip {
     display: grid;
-    grid-template-columns: minmax(0, 1.9fr) minmax(320px, 1.15fr);
+    grid-template-columns: minmax(0, 1fr);
     gap: 14px 18px;
-    align-items: end;
+    align-items: stretch;
     border: 1px solid var(--line);
     border-radius: 8px;
     background: var(--surface);
@@ -316,18 +316,19 @@ dd {
 
 .control-strip-fields {
     display: grid;
-    grid-template-columns: minmax(160px, 220px) minmax(220px, 360px) minmax(260px, 420px);
+    grid-template-columns: minmax(160px, 180px) minmax(220px, 260px) minmax(240px, 1fr);
     gap: 14px;
     align-items: end;
     min-width: 0;
 }
 
 .control-strip-tabs {
+    order: -1;
     min-width: 0;
 }
 
 .control-strip-tabs .section-tabs {
-    justify-content: flex-end;
+    justify-content: flex-start;
 }
 
 .control-strip label,
@@ -377,26 +378,18 @@ dd {
     box-shadow: 0 0 18px rgba(56, 189, 248, 0.18);
 }
 
-@media (max-width: 1280px) {
+@media (min-width: 1900px) {
     .control-strip {
-        grid-template-columns: 1fr;
-        align-items: stretch;
-    }
-
-    .control-strip-fields {
-        grid-template-columns: minmax(180px, 240px) minmax(220px, 1fr);
-    }
-
-    .control-strip-fields .archive-search {
-        grid-column: 1 / -1;
+        grid-template-columns: minmax(0, 760px) minmax(0, 1fr);
+        align-items: end;
     }
 
     .control-strip-tabs {
-        order: -1;
+        order: 0;
     }
 
     .control-strip-tabs .section-tabs {
-        justify-content: flex-start;
+        justify-content: flex-end;
     }
 }
 

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1400,7 +1400,7 @@ dd {
 
 .record-filter-tristate-toggle {
     --toggle-index: 1;
-    --toggle-glow-x: 24%;
+    --toggle-glow-x: 50%;
     --toggle-track-glow: rgba(24, 174, 255, 0.18);
     --toggle-track-border: rgba(41, 183, 255, 0.4);
     --toggle-track-inner-glow: rgba(14, 165, 233, 0.14);
@@ -1449,6 +1449,36 @@ dd {
     transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 
+.record-filter-tristate-toggle.state-active {
+    --toggle-glow-x: 24%;
+    --toggle-track-glow: rgba(34, 197, 94, 0.2);
+    --toggle-track-border: rgba(74, 222, 128, 0.4);
+    --toggle-track-inner-glow: rgba(34, 197, 94, 0.14);
+    --toggle-track-outline: rgba(6, 78, 59, 0.65);
+    --toggle-track-ambient-glow: rgba(34, 197, 94, 0.18);
+    --toggle-scan-soft: rgba(74, 222, 128, 0.08);
+    --toggle-scan-strong: rgba(74, 222, 128, 0.36);
+    --toggle-thumb-border: rgba(110, 231, 183, 0.58);
+    --toggle-thumb-outline: rgba(5, 150, 105, 0.44);
+    --toggle-thumb-glow: rgba(74, 222, 128, 0.42);
+    --toggle-thumb-highlight: rgba(196, 255, 232, 0.9);
+    --toggle-thumb-mid: rgba(112, 255, 196, 0.38);
+    --toggle-thumb-deep: rgba(11, 167, 101, 0.92);
+    --toggle-thumb-base: rgba(3, 59, 40, 0.98);
+    --toggle-thumb-shell-top: rgba(6, 47, 35, 0.98);
+    --toggle-thumb-shell-bottom: rgba(3, 25, 18, 0.98);
+    --toggle-thumb-core: rgba(118, 255, 208, 0.72);
+    --toggle-thumb-core-shadow: rgba(16, 255, 169, 0.36);
+    --toggle-thumb-inner-stop: rgba(168, 255, 223, 0.56);
+    --toggle-thumb-inner-shadow: rgba(83, 255, 193, 0.54);
+    --toggle-thumb-scan-accent: rgba(83, 255, 193, 0.38);
+    --toggle-particle: rgba(110, 255, 206, 0.84);
+    --toggle-particle-shadow: rgba(83, 255, 193, 0.78);
+    --toggle-holo-glow: rgba(16, 255, 169, 0.18);
+    --toggle-label-glow: rgba(83, 255, 193, 0.44);
+    --toggle-status-dot: rgba(103, 255, 194, 0.95);
+}
+
 .record-filter-tristate-toggle:hover {
     border-color: rgba(125, 211, 252, 0.3);
     box-shadow:
@@ -1458,32 +1488,32 @@ dd {
 
 .record-filter-tristate-toggle.state-both {
     --toggle-glow-x: 50%;
-    --toggle-track-glow: rgba(245, 158, 11, 0.18);
-    --toggle-track-border: rgba(251, 191, 36, 0.44);
-    --toggle-track-inner-glow: rgba(245, 158, 11, 0.16);
-    --toggle-track-outline: rgba(74, 36, 4, 0.7);
-    --toggle-track-ambient-glow: rgba(245, 158, 11, 0.22);
-    --toggle-scan-soft: rgba(251, 191, 36, 0.08);
-    --toggle-scan-strong: rgba(251, 191, 36, 0.34);
-    --toggle-thumb-border: rgba(252, 211, 77, 0.58);
-    --toggle-thumb-outline: rgba(180, 83, 9, 0.42);
-    --toggle-thumb-glow: rgba(250, 204, 21, 0.34);
-    --toggle-thumb-highlight: rgba(255, 245, 166, 0.92);
-    --toggle-thumb-mid: rgba(251, 191, 36, 0.42);
-    --toggle-thumb-deep: rgba(217, 119, 6, 0.92);
-    --toggle-thumb-base: rgba(120, 53, 15, 0.98);
-    --toggle-thumb-shell-top: rgba(67, 30, 8, 0.98);
-    --toggle-thumb-shell-bottom: rgba(37, 17, 6, 0.98);
-    --toggle-thumb-core: rgba(253, 230, 138, 0.72);
-    --toggle-thumb-core-shadow: rgba(250, 204, 21, 0.34);
-    --toggle-thumb-inner-stop: rgba(255, 237, 160, 0.56);
-    --toggle-thumb-inner-shadow: rgba(251, 191, 36, 0.52);
-    --toggle-thumb-scan-accent: rgba(251, 191, 36, 0.36);
-    --toggle-particle: rgba(253, 224, 71, 0.82);
-    --toggle-particle-shadow: rgba(251, 191, 36, 0.74);
-    --toggle-holo-glow: rgba(250, 204, 21, 0.18);
-    --toggle-label-glow: rgba(251, 191, 36, 0.44);
-    --toggle-status-dot: rgba(250, 204, 21, 0.95);
+    --toggle-track-glow: rgba(24, 174, 255, 0.18);
+    --toggle-track-border: rgba(41, 183, 255, 0.4);
+    --toggle-track-inner-glow: rgba(14, 165, 233, 0.14);
+    --toggle-track-outline: rgba(5, 21, 43, 0.65);
+    --toggle-track-ambient-glow: rgba(14, 165, 233, 0.18);
+    --toggle-scan-soft: rgba(69, 188, 255, 0.08);
+    --toggle-scan-strong: rgba(69, 188, 255, 0.36);
+    --toggle-thumb-border: rgba(81, 200, 255, 0.58);
+    --toggle-thumb-outline: rgba(9, 85, 155, 0.44);
+    --toggle-thumb-glow: rgba(38, 180, 255, 0.42);
+    --toggle-thumb-highlight: rgba(166, 231, 255, 0.88);
+    --toggle-thumb-mid: rgba(118, 203, 255, 0.35);
+    --toggle-thumb-deep: rgba(25, 121, 198, 0.94);
+    --toggle-thumb-base: rgba(5, 38, 84, 0.98);
+    --toggle-thumb-shell-top: rgba(7, 26, 54, 0.98);
+    --toggle-thumb-shell-bottom: rgba(5, 17, 35, 0.98);
+    --toggle-thumb-core: rgba(102, 216, 255, 0.7);
+    --toggle-thumb-core-shadow: rgba(56, 189, 248, 0.35);
+    --toggle-thumb-inner-stop: rgba(148, 217, 255, 0.52);
+    --toggle-thumb-inner-shadow: rgba(125, 211, 252, 0.52);
+    --toggle-thumb-scan-accent: rgba(56, 189, 248, 0.34);
+    --toggle-particle: rgba(125, 211, 252, 0.82);
+    --toggle-particle-shadow: rgba(125, 211, 252, 0.7);
+    --toggle-holo-glow: rgba(56, 189, 248, 0.16);
+    --toggle-label-glow: rgba(56, 189, 248, 0.42);
+    --toggle-status-dot: rgba(78, 196, 255, 0.94);
 }
 
 .record-filter-tristate-toggle.state-fallen {
@@ -1748,6 +1778,8 @@ dd {
 .record-filter-tristate-toggle-option span {
     position: relative;
     z-index: 1;
+    text-shadow: 0 1px 1px rgba(2, 6, 23, 0.8);
+    transition: text-shadow 180ms ease, background 180ms ease, box-shadow 180ms ease, padding 180ms ease;
 }
 
 .record-filter-tristate-toggle-option::after {
@@ -1774,7 +1806,22 @@ dd {
 
 .record-filter-tristate-toggle-option.active {
     color: var(--toggle-label-active);
-    text-shadow: 0 0 12px var(--toggle-label-glow);
+    text-shadow:
+        0 1px 2px rgba(2, 6, 23, 0.96),
+        0 0 12px var(--toggle-label-glow);
+}
+
+.record-filter-tristate-toggle-option.active span {
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, rgba(2, 6, 23, 0.22), rgba(2, 6, 23, 0.08));
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.14),
+        0 0 0 1px rgba(255, 255, 255, 0.06);
+    text-shadow:
+        0 1px 2px rgba(2, 6, 23, 0.98),
+        0 0 12px var(--toggle-label-glow);
+    -webkit-text-stroke: 0.2px rgba(2, 6, 23, 0.55);
 }
 
 .record-filter-tristate-toggle-option.active::after {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1400,38 +1400,181 @@ dd {
 
 .record-filter-tristate-toggle {
     --toggle-index: 1;
+    --toggle-glow-x: 24%;
+    --toggle-track-glow: rgba(24, 174, 255, 0.18);
+    --toggle-track-border: rgba(41, 183, 255, 0.4);
+    --toggle-track-inner-glow: rgba(14, 165, 233, 0.14);
+    --toggle-track-outline: rgba(5, 21, 43, 0.65);
+    --toggle-track-ambient-glow: rgba(14, 165, 233, 0.18);
+    --toggle-scan-soft: rgba(69, 188, 255, 0.08);
+    --toggle-scan-strong: rgba(69, 188, 255, 0.36);
+    --toggle-thumb-border: rgba(81, 200, 255, 0.58);
+    --toggle-thumb-outline: rgba(9, 85, 155, 0.44);
+    --toggle-thumb-glow: rgba(38, 180, 255, 0.42);
+    --toggle-thumb-highlight: rgba(166, 231, 255, 0.88);
+    --toggle-thumb-mid: rgba(118, 203, 255, 0.35);
+    --toggle-thumb-deep: rgba(25, 121, 198, 0.94);
+    --toggle-thumb-base: rgba(5, 38, 84, 0.98);
+    --toggle-thumb-shell-top: rgba(7, 26, 54, 0.98);
+    --toggle-thumb-shell-bottom: rgba(5, 17, 35, 0.98);
+    --toggle-thumb-core: rgba(102, 216, 255, 0.7);
+    --toggle-thumb-core-shadow: rgba(56, 189, 248, 0.35);
+    --toggle-thumb-inner-stop: rgba(148, 217, 255, 0.52);
+    --toggle-thumb-inner-shadow: rgba(125, 211, 252, 0.52);
+    --toggle-thumb-scan-accent: rgba(56, 189, 248, 0.34);
+    --toggle-particle: rgba(125, 211, 252, 0.82);
+    --toggle-particle-shadow: rgba(125, 211, 252, 0.7);
+    --toggle-holo-glow: rgba(56, 189, 248, 0.16);
+    --toggle-label-active: #eef6ff;
+    --toggle-label-inactive: rgba(191, 219, 254, 0.78);
+    --toggle-label-glow: rgba(56, 189, 248, 0.42);
+    --toggle-status-dot: rgba(78, 196, 255, 0.94);
     position: relative;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     align-items: center;
-    width: min(100%, 16rem);
-    padding: 4px;
+    width: min(100%, 17rem);
+    min-height: 52px;
+    padding: 0;
     border-radius: 999px;
     overflow: hidden;
     background:
-        linear-gradient(180deg, rgba(7, 17, 33, 0.96), rgba(8, 26, 49, 0.98) 58%, rgba(7, 17, 32, 0.96)),
-        radial-gradient(circle at 50% 50%, rgba(56, 189, 248, 0.1), transparent 60%);
-    border: 1px solid rgba(41, 183, 255, 0.34);
+        linear-gradient(180deg, rgba(8, 16, 31, 0.98), rgba(4, 9, 20, 0.94)),
+        radial-gradient(circle at top right, rgba(34, 211, 238, 0.12), transparent 48%);
+    border: 1px solid rgba(125, 211, 252, 0.18);
     box-shadow:
-        inset 0 2px 10px rgba(2, 6, 23, 0.55),
-        inset 0 0 18px rgba(14, 165, 233, 0.12),
-        0 0 0 1px rgba(5, 21, 43, 0.45);
+        inset 0 1px 0 rgba(255, 255, 255, 0.04),
+        0 16px 30px rgba(2, 6, 23, 0.18);
+    isolation: isolate;
+    transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 
-.record-filter-tristate-toggle::before {
-    content: "";
+.record-filter-tristate-toggle:hover {
+    border-color: rgba(125, 211, 252, 0.3);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.06),
+        0 18px 34px rgba(2, 6, 23, 0.24);
+}
+
+.record-filter-tristate-toggle.state-both {
+    --toggle-glow-x: 50%;
+    --toggle-track-glow: rgba(245, 158, 11, 0.18);
+    --toggle-track-border: rgba(251, 191, 36, 0.44);
+    --toggle-track-inner-glow: rgba(245, 158, 11, 0.16);
+    --toggle-track-outline: rgba(74, 36, 4, 0.7);
+    --toggle-track-ambient-glow: rgba(245, 158, 11, 0.22);
+    --toggle-scan-soft: rgba(251, 191, 36, 0.08);
+    --toggle-scan-strong: rgba(251, 191, 36, 0.34);
+    --toggle-thumb-border: rgba(252, 211, 77, 0.58);
+    --toggle-thumb-outline: rgba(180, 83, 9, 0.42);
+    --toggle-thumb-glow: rgba(250, 204, 21, 0.34);
+    --toggle-thumb-highlight: rgba(255, 245, 166, 0.92);
+    --toggle-thumb-mid: rgba(251, 191, 36, 0.42);
+    --toggle-thumb-deep: rgba(217, 119, 6, 0.92);
+    --toggle-thumb-base: rgba(120, 53, 15, 0.98);
+    --toggle-thumb-shell-top: rgba(67, 30, 8, 0.98);
+    --toggle-thumb-shell-bottom: rgba(37, 17, 6, 0.98);
+    --toggle-thumb-core: rgba(253, 230, 138, 0.72);
+    --toggle-thumb-core-shadow: rgba(250, 204, 21, 0.34);
+    --toggle-thumb-inner-stop: rgba(255, 237, 160, 0.56);
+    --toggle-thumb-inner-shadow: rgba(251, 191, 36, 0.52);
+    --toggle-thumb-scan-accent: rgba(251, 191, 36, 0.36);
+    --toggle-particle: rgba(253, 224, 71, 0.82);
+    --toggle-particle-shadow: rgba(251, 191, 36, 0.74);
+    --toggle-holo-glow: rgba(250, 204, 21, 0.18);
+    --toggle-label-glow: rgba(251, 191, 36, 0.44);
+    --toggle-status-dot: rgba(250, 204, 21, 0.95);
+}
+
+.record-filter-tristate-toggle.state-fallen {
+    --toggle-glow-x: 76%;
+    --toggle-track-glow: rgba(248, 113, 113, 0.18);
+    --toggle-track-border: rgba(248, 113, 113, 0.42);
+    --toggle-track-inner-glow: rgba(239, 68, 68, 0.16);
+    --toggle-track-outline: rgba(69, 10, 10, 0.72);
+    --toggle-track-ambient-glow: rgba(239, 68, 68, 0.2);
+    --toggle-scan-soft: rgba(248, 113, 113, 0.08);
+    --toggle-scan-strong: rgba(248, 113, 113, 0.34);
+    --toggle-thumb-border: rgba(252, 165, 165, 0.54);
+    --toggle-thumb-outline: rgba(153, 27, 27, 0.42);
+    --toggle-thumb-glow: rgba(248, 113, 113, 0.34);
+    --toggle-thumb-highlight: rgba(254, 202, 202, 0.9);
+    --toggle-thumb-mid: rgba(248, 113, 113, 0.4);
+    --toggle-thumb-deep: rgba(185, 28, 28, 0.92);
+    --toggle-thumb-base: rgba(69, 10, 10, 0.98);
+    --toggle-thumb-shell-top: rgba(63, 12, 17, 0.98);
+    --toggle-thumb-shell-bottom: rgba(31, 6, 8, 0.98);
+    --toggle-thumb-core: rgba(252, 165, 165, 0.68);
+    --toggle-thumb-core-shadow: rgba(248, 113, 113, 0.34);
+    --toggle-thumb-inner-stop: rgba(254, 205, 211, 0.54);
+    --toggle-thumb-inner-shadow: rgba(252, 165, 165, 0.48);
+    --toggle-thumb-scan-accent: rgba(248, 113, 113, 0.34);
+    --toggle-particle: rgba(254, 202, 202, 0.78);
+    --toggle-particle-shadow: rgba(248, 113, 113, 0.68);
+    --toggle-holo-glow: rgba(248, 113, 113, 0.18);
+    --toggle-label-glow: rgba(248, 113, 113, 0.4);
+    --toggle-status-dot: rgba(252, 165, 165, 0.92);
+}
+
+.record-filter-tristate-toggle-track {
     position: absolute;
-    left: 12px;
-    right: 12px;
-    top: 50%;
-    height: 1px;
-    transform: translateY(-50%);
-    background: linear-gradient(
-        90deg,
-        rgba(56, 189, 248, 0.14) 0%,
-        rgba(148, 163, 184, 0.18) 50%,
-        rgba(248, 113, 113, 0.14) 100%);
+    inset: 4px;
+    border-radius: 999px;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at var(--toggle-glow-x) 50%, var(--toggle-track-glow), transparent 34%),
+        linear-gradient(180deg, #071121, #081a31 58%, #071120);
+    border: 1px solid var(--toggle-track-border);
+    box-shadow:
+        inset 0 3px 10px rgba(2, 6, 23, 0.6),
+        inset 0 0 22px var(--toggle-track-inner-glow),
+        0 0 0 1px var(--toggle-track-outline),
+        0 0 22px var(--toggle-track-ambient-glow);
+    transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease, filter 180ms ease;
+    z-index: 0;
     pointer-events: none;
+}
+
+.record-filter-tristate-toggle-track-lines {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+
+.record-filter-tristate-toggle-track-line {
+    position: absolute;
+    left: 20px;
+    right: 20px;
+    top: 50%;
+    height: 2px;
+    transform: translateY(-50%);
+    border-radius: 999px;
+    background:
+        repeating-linear-gradient(
+            90deg,
+            var(--toggle-scan-soft) 0 6px,
+            var(--toggle-scan-strong) 6px 11px,
+            transparent 11px 18px);
+    opacity: 0.9;
+    animation: record-filter-toggle-scan 2.2s linear infinite;
+    transition: opacity 180ms ease, background 180ms ease, left 180ms ease, right 180ms ease;
+}
+
+.record-filter-tristate-toggle-reflection {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 40%);
+}
+
+.record-filter-tristate-toggle-holo-glow {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: radial-gradient(ellipse at center, var(--toggle-holo-glow) 0%, rgba(2, 6, 23, 0) 72%);
+    filter: blur(10px);
+    opacity: 0.5;
+    transition: background 180ms ease, opacity 180ms ease;
 }
 
 .record-filter-tristate-toggle-thumb {
@@ -1439,48 +1582,187 @@ dd {
     top: 4px;
     left: 4px;
     width: calc((100% - 8px) / 3);
-    bottom: 4px;
+    height: calc(100% - 8px);
     border-radius: 999px;
     transform: translateX(calc(var(--toggle-index) * 100%));
-    background: linear-gradient(180deg, rgba(71, 178, 255, 0.88), rgba(17, 108, 203, 0.9));
+    border: 1px solid var(--toggle-thumb-border);
+    background:
+        radial-gradient(circle at 46% 42%, var(--toggle-thumb-highlight), var(--toggle-thumb-mid) 34%, var(--toggle-thumb-deep) 76%, var(--toggle-thumb-base) 100%),
+        linear-gradient(180deg, var(--toggle-thumb-shell-top), var(--toggle-thumb-shell-bottom));
     box-shadow:
-        0 0 18px rgba(56, 189, 248, 0.22),
-        inset 0 1px 0 rgba(255, 255, 255, 0.26);
-    transition: transform 180ms ease, background 180ms ease, box-shadow 180ms ease;
+        0 0 0 2px var(--toggle-thumb-outline),
+        0 0 18px var(--toggle-thumb-glow),
+        0 8px 18px rgba(2, 6, 23, 0.42),
+        inset 0 1px 1px rgba(255, 255, 255, 0.3);
+    transition: transform 180ms ease, background 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+    z-index: 1;
     pointer-events: none;
 }
 
-.record-filter-tristate-toggle.state-both .record-filter-tristate-toggle-thumb {
-    background: linear-gradient(180deg, rgba(250, 204, 21, 0.9), rgba(217, 119, 6, 0.9));
-    box-shadow:
-        0 0 18px rgba(250, 204, 21, 0.24),
-        inset 0 1px 0 rgba(255, 255, 255, 0.2);
+.record-filter-tristate-toggle-energy-rings {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 38px;
+    height: 38px;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
 }
 
-.record-filter-tristate-toggle.state-fallen .record-filter-tristate-toggle-thumb {
-    background: linear-gradient(180deg, rgba(248, 113, 113, 0.9), rgba(185, 28, 28, 0.9));
-    box-shadow:
-        0 0 18px rgba(248, 113, 113, 0.24),
-        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+.record-filter-tristate-toggle-energy-ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    border: 2px solid transparent;
+    opacity: 0.9;
+}
+
+.record-filter-tristate-toggle-energy-ring:nth-child(1) {
+    width: 36px;
+    height: 36px;
+    border-top-color: color-mix(in srgb, var(--toggle-status-dot) 58%, transparent);
+    border-right-color: color-mix(in srgb, var(--toggle-status-dot) 26%, transparent);
+    animation: record-filter-toggle-spin 3s linear infinite;
+}
+
+.record-filter-tristate-toggle-energy-ring:nth-child(2) {
+    width: 28px;
+    height: 28px;
+    border-bottom-color: color-mix(in srgb, var(--toggle-status-dot) 52%, transparent);
+    border-left-color: color-mix(in srgb, var(--toggle-status-dot) 22%, transparent);
+    animation: record-filter-toggle-spin 2s linear infinite reverse;
+}
+
+.record-filter-tristate-toggle-energy-ring:nth-child(3) {
+    width: 20px;
+    height: 20px;
+    border-left-color: color-mix(in srgb, var(--toggle-status-dot) 44%, transparent);
+    border-top-color: color-mix(in srgb, var(--toggle-status-dot) 18%, transparent);
+    animation: record-filter-toggle-spin 1.4s linear infinite;
+}
+
+.record-filter-tristate-toggle-thumb-core {
+    position: absolute;
+    inset: 8px;
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--toggle-thumb-core) 0%, transparent 62%);
+    box-shadow: 0 0 18px var(--toggle-thumb-core-shadow);
+    opacity: 0.9;
+    transition: background 180ms ease, box-shadow 180ms ease;
+}
+
+.record-filter-tristate-toggle-thumb-inner {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.84) 0%, var(--toggle-thumb-inner-stop) 100%);
+    border-radius: 50%;
+    box-shadow: 0 0 12px var(--toggle-thumb-inner-shadow);
+    opacity: 0.82;
+    animation: record-filter-toggle-pulse 2s infinite alternate;
+}
+
+.record-filter-tristate-toggle-thumb-scan {
+    position: absolute;
+    width: 100%;
+    height: 5px;
+    top: -7px;
+    left: 0;
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        var(--toggle-thumb-scan-accent) 18%,
+        rgba(255, 255, 255, 0.82) 50%,
+        var(--toggle-thumb-scan-accent) 82%,
+        transparent 100%);
+    filter: blur(0.6px);
+    animation: record-filter-toggle-thumb-scan 2s linear infinite;
+    opacity: 0.78;
+}
+
+.record-filter-tristate-toggle-thumb-particles {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+
+.record-filter-tristate-toggle-thumb-particle {
+    position: absolute;
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background: var(--toggle-particle);
+    box-shadow: 0 0 5px var(--toggle-particle-shadow);
+    opacity: 0;
+    animation: record-filter-toggle-particle-float 3s infinite ease-out;
+}
+
+.record-filter-tristate-toggle-thumb-particle:nth-child(1) {
+    top: 66%;
+    left: 28%;
+    animation-delay: 0.2s;
+}
+
+.record-filter-tristate-toggle-thumb-particle:nth-child(2) {
+    top: 58%;
+    left: 62%;
+    animation-delay: 0.7s;
+}
+
+.record-filter-tristate-toggle-thumb-particle:nth-child(3) {
+    top: 42%;
+    left: 38%;
+    animation-delay: 1.1s;
+}
+
+.record-filter-tristate-toggle-thumb-particle:nth-child(4) {
+    top: 36%;
+    left: 70%;
+    animation-delay: 1.6s;
 }
 
 .record-filter-tristate-toggle-option {
     position: relative;
-    z-index: 1;
+    z-index: 2;
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 2.25rem;
+    min-height: 52px;
     padding: 0 0.55rem;
     border-radius: 999px;
-    font-size: 0.76rem;
-    font-weight: 700;
+    font-size: 0.74rem;
+    font-weight: 900;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: rgba(191, 219, 254, 0.78);
+    color: var(--toggle-label-inactive);
     cursor: pointer;
     user-select: none;
-    transition: color 180ms ease, text-shadow 180ms ease;
+    transition: color 180ms ease, text-shadow 180ms ease, opacity 180ms ease;
+}
+
+.record-filter-tristate-toggle-option span {
+    position: relative;
+    z-index: 1;
+}
+
+.record-filter-tristate-toggle-option::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 9px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    transform: translateX(-50%) scale(0.75);
+    background: var(--toggle-status-dot);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--toggle-status-dot) 48%, transparent);
+    opacity: 0;
+    transition: opacity 180ms ease, transform 180ms ease, box-shadow 180ms ease;
 }
 
 .record-filter-tristate-toggle-option input {
@@ -1491,13 +1773,21 @@ dd {
 }
 
 .record-filter-tristate-toggle-option.active {
-    color: #f8fafc;
-    text-shadow: 0 0 10px rgba(255, 255, 255, 0.18);
+    color: var(--toggle-label-active);
+    text-shadow: 0 0 12px var(--toggle-label-glow);
 }
 
-.record-filter-tristate-toggle-option:focus-within {
-    outline: 2px solid rgba(125, 211, 252, 0.55);
-    outline-offset: 2px;
+.record-filter-tristate-toggle-option.active::after {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+}
+
+.record-filter-tristate-toggle:focus-within .record-filter-tristate-toggle-track {
+    box-shadow:
+        inset 0 3px 10px rgba(2, 6, 23, 0.6),
+        inset 0 0 22px var(--toggle-track-inner-glow),
+        0 0 0 3px rgba(56, 189, 248, 0.2),
+        0 0 26px rgba(34, 211, 238, 0.26);
 }
 
 .record-filter-range-inputs {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1896,7 +1896,7 @@ dd {
     justify-self: auto;
 }
 
-.record-filter-panel input,
+.record-filter-panel input:not([type="range"]),
 .record-filter-panel select,
 .record-list-sort-label select {
     width: 100%;
@@ -1910,11 +1910,109 @@ dd {
     outline: none;
 }
 
-.record-filter-panel input:focus,
+.record-filter-panel input:not([type="range"]):focus,
 .record-filter-panel select:focus,
 .record-list-sort-label select:focus {
     border-color: var(--accent);
     box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
+}
+
+.record-filter-slider-group {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.record-filter-panel .record-filter-slider-field {
+    display: grid;
+    gap: 4px;
+    color: #cbd5e1;
+    font-size: 0.7rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.record-filter-slider-field small {
+    color: #93c5fd;
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    text-transform: none;
+}
+
+.record-filter-slider-field input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    min-height: auto;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+}
+
+.record-filter-slider-field input[type="range"]::-webkit-slider-runnable-track {
+    height: 6px;
+    border-radius: 999px;
+    border: 1px solid rgba(125, 211, 252, 0.28);
+    background:
+        linear-gradient(90deg, rgba(56, 189, 248, 0.24), rgba(14, 165, 233, 0.68)),
+        rgba(2, 6, 23, 0.94);
+    box-shadow: inset 0 1px 2px rgba(2, 6, 23, 0.55);
+}
+
+.record-filter-slider-field input[type="range"]::-moz-range-track {
+    height: 6px;
+    border-radius: 999px;
+    border: 1px solid rgba(125, 211, 252, 0.28);
+    background:
+        linear-gradient(90deg, rgba(56, 189, 248, 0.24), rgba(14, 165, 233, 0.68)),
+        rgba(2, 6, 23, 0.94);
+    box-shadow: inset 0 1px 2px rgba(2, 6, 23, 0.55);
+}
+
+.record-filter-slider-field input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    margin-top: -6px;
+    border: 1px solid rgba(186, 230, 253, 0.82);
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #e0f2fe, #38bdf8 55%, #0f172a 100%);
+    box-shadow:
+        0 0 0 2px rgba(8, 47, 73, 0.56),
+        0 0 16px rgba(56, 189, 248, 0.34);
+    cursor: pointer;
+}
+
+.record-filter-slider-field input[type="range"]::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border: 1px solid rgba(186, 230, 253, 0.82);
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #e0f2fe, #38bdf8 55%, #0f172a 100%);
+    box-shadow:
+        0 0 0 2px rgba(8, 47, 73, 0.56),
+        0 0 16px rgba(56, 189, 248, 0.34);
+    cursor: pointer;
+}
+
+.record-filter-slider-field input[type="range"]:focus-visible {
+    outline: none;
+}
+
+.record-filter-slider-field input[type="range"]:focus-visible::-webkit-slider-runnable-track {
+    box-shadow:
+        0 0 0 3px rgba(56, 189, 248, 0.18),
+        inset 0 1px 2px rgba(2, 6, 23, 0.55);
+}
+
+.record-filter-slider-field input[type="range"]:focus-visible::-moz-range-track {
+    box-shadow:
+        0 0 0 3px rgba(56, 189, 248, 0.18),
+        inset 0 1px 2px rgba(2, 6, 23, 0.55);
 }
 
 .record-filter-toggle {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -379,22 +379,22 @@ dd {
 
 @media (min-width: 1900px) {
     .control-strip {
-        grid-template-columns: minmax(0, 760px) minmax(0, 1fr);
+        grid-template-columns: minmax(0, 1fr) minmax(0, 760px);
         align-items: end;
     }
 
     .control-strip-tabs {
-        grid-column: 2;
-        grid-row: 1;
-    }
-
-    .control-strip-fields {
         grid-column: 1;
         grid-row: 1;
     }
 
+    .control-strip-fields {
+        grid-column: 2;
+        grid-row: 1;
+    }
+
     .control-strip-tabs .section-tabs {
-        justify-content: flex-end;
+        justify-content: flex-start;
     }
 }
 

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1344,6 +1344,14 @@ dd {
     font-weight: 800;
 }
 
+.record-list-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
 .record-filter-grid {
     display: grid;
     gap: 10px;
@@ -1859,6 +1867,21 @@ dd {
     align-self: stretch;
 }
 
+.record-list-sort-label {
+    display: grid;
+    gap: 6px;
+    justify-items: start;
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.record-list-sort-label select {
+    min-width: min(240px, 100%);
+}
+
 .record-filter-actions,
 .record-filter-toggle-row {
     display: flex;
@@ -1874,7 +1897,8 @@ dd {
 }
 
 .record-filter-panel input,
-.record-filter-panel select {
+.record-filter-panel select,
+.record-list-sort-label select {
     width: 100%;
     box-sizing: border-box;
     min-height: 38px;
@@ -1887,7 +1911,8 @@ dd {
 }
 
 .record-filter-panel input:focus,
-.record-filter-panel select:focus {
+.record-filter-panel select:focus,
+.record-list-sort-label select:focus {
     border-color: var(--accent);
     box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
 }

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1917,102 +1917,130 @@ dd {
     box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
 }
 
-.record-filter-slider-group {
+.record-filter-dual-slider {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
+    gap: 12px;
+    border: 1px solid rgba(125, 211, 252, 0.18);
+    border-radius: 12px;
+    background:
+        linear-gradient(180deg, rgba(8, 16, 31, 0.88), rgba(4, 9, 20, 0.82)),
+        radial-gradient(circle at top center, rgba(34, 211, 238, 0.08), transparent 56%);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.03),
+        0 10px 22px rgba(2, 6, 23, 0.14);
+    padding: 12px;
 }
 
-.record-filter-panel .record-filter-slider-field {
-    display: grid;
-    gap: 4px;
-    color: #cbd5e1;
-    font-size: 0.7rem;
-    font-weight: 900;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+.record-filter-dual-slider-readout {
+    justify-self: center;
+    color: #67d6ff;
+    font-size: 1rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    text-align: center;
 }
 
-.record-filter-slider-field small {
-    color: #93c5fd;
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.02em;
-    text-transform: none;
+.record-filter-dual-slider-shell {
+    --slider-min-percent: 0%;
+    --slider-max-percent: 100%;
+    position: relative;
+    height: 34px;
+    padding: 0 6px;
 }
 
-.record-filter-slider-field input[type="range"] {
+.record-filter-dual-slider-track,
+.record-filter-dual-slider-range {
+    position: absolute;
+    top: 50%;
+    height: 6px;
+    transform: translateY(-50%);
+    border-radius: 999px;
+    pointer-events: none;
+}
+
+.record-filter-dual-slider-track {
+    left: 6px;
+    right: 6px;
+    border: 1px solid rgba(125, 211, 252, 0.22);
+    background: rgba(226, 232, 240, 0.16);
+    box-shadow: inset 0 1px 2px rgba(2, 6, 23, 0.52);
+}
+
+.record-filter-dual-slider-range {
+    left: calc(6px + var(--slider-min-percent));
+    right: calc(6px + (100% - var(--slider-max-percent)));
+    background: linear-gradient(90deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.98));
+    box-shadow: 0 0 14px rgba(56, 189, 248, 0.26);
+}
+
+.record-filter-dual-slider-input {
     -webkit-appearance: none;
     appearance: none;
+    position: absolute;
+    inset: 0;
     width: 100%;
     min-height: auto;
     border: none;
     background: transparent;
     box-shadow: none;
+    margin: 0;
     padding: 0;
+    pointer-events: none;
 }
 
-.record-filter-slider-field input[type="range"]::-webkit-slider-runnable-track {
+.record-filter-dual-slider-input::-webkit-slider-runnable-track {
     height: 6px;
-    border-radius: 999px;
-    border: 1px solid rgba(125, 211, 252, 0.28);
-    background:
-        linear-gradient(90deg, rgba(56, 189, 248, 0.24), rgba(14, 165, 233, 0.68)),
-        rgba(2, 6, 23, 0.94);
-    box-shadow: inset 0 1px 2px rgba(2, 6, 23, 0.55);
+    background: transparent;
+    border: none;
 }
 
-.record-filter-slider-field input[type="range"]::-moz-range-track {
+.record-filter-dual-slider-input::-moz-range-track {
     height: 6px;
-    border-radius: 999px;
-    border: 1px solid rgba(125, 211, 252, 0.28);
-    background:
-        linear-gradient(90deg, rgba(56, 189, 248, 0.24), rgba(14, 165, 233, 0.68)),
-        rgba(2, 6, 23, 0.94);
-    box-shadow: inset 0 1px 2px rgba(2, 6, 23, 0.55);
+    background: transparent;
+    border: none;
 }
 
-.record-filter-slider-field input[type="range"]::-webkit-slider-thumb {
+.record-filter-dual-slider-input::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
     margin-top: -6px;
-    border: 1px solid rgba(186, 230, 253, 0.82);
+    border: 2px solid rgba(125, 211, 252, 0.82);
     border-radius: 50%;
-    background: radial-gradient(circle at 35% 30%, #e0f2fe, #38bdf8 55%, #0f172a 100%);
+    background: radial-gradient(circle at 35% 30%, #f8fdff, #a5f3fc 22%, #38bdf8 56%, #0f172a 100%);
     box-shadow:
-        0 0 0 2px rgba(8, 47, 73, 0.56),
-        0 0 16px rgba(56, 189, 248, 0.34);
+        0 0 0 2px rgba(8, 47, 73, 0.34),
+        0 0 16px rgba(56, 189, 248, 0.3);
     cursor: pointer;
+    pointer-events: auto;
 }
 
-.record-filter-slider-field input[type="range"]::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
-    border: 1px solid rgba(186, 230, 253, 0.82);
+.record-filter-dual-slider-input::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border: 2px solid rgba(125, 211, 252, 0.82);
     border-radius: 50%;
-    background: radial-gradient(circle at 35% 30%, #e0f2fe, #38bdf8 55%, #0f172a 100%);
+    background: radial-gradient(circle at 35% 30%, #f8fdff, #a5f3fc 22%, #38bdf8 56%, #0f172a 100%);
     box-shadow:
-        0 0 0 2px rgba(8, 47, 73, 0.56),
-        0 0 16px rgba(56, 189, 248, 0.34);
+        0 0 0 2px rgba(8, 47, 73, 0.34),
+        0 0 16px rgba(56, 189, 248, 0.3);
     cursor: pointer;
+    pointer-events: auto;
 }
 
-.record-filter-slider-field input[type="range"]:focus-visible {
-    outline: none;
+.record-filter-dual-slider-input.min {
+    z-index: 2;
 }
 
-.record-filter-slider-field input[type="range"]:focus-visible::-webkit-slider-runnable-track {
+.record-filter-dual-slider-input.max {
+    z-index: 3;
+}
+
+.record-filter-dual-slider-shell:focus-within .record-filter-dual-slider-track {
     box-shadow:
         0 0 0 3px rgba(56, 189, 248, 0.18),
-        inset 0 1px 2px rgba(2, 6, 23, 0.55);
-}
-
-.record-filter-slider-field input[type="range"]:focus-visible::-moz-range-track {
-    box-shadow:
-        0 0 0 3px rgba(56, 189, 248, 0.18),
-        inset 0 1px 2px rgba(2, 6, 23, 0.55);
+        inset 0 1px 2px rgba(2, 6, 23, 0.52);
 }
 
 .record-filter-toggle {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -304,14 +304,30 @@ dd {
 
 .control-strip {
     display: grid;
-    grid-template-columns: minmax(180px, 240px) minmax(260px, 420px) minmax(260px, 460px) 1fr;
-    gap: 14px;
+    grid-template-columns: minmax(0, 1.9fr) minmax(320px, 1.15fr);
+    gap: 14px 18px;
     align-items: end;
     border: 1px solid var(--line);
     border-radius: 8px;
     background: var(--surface);
     padding: 14px;
     box-shadow: var(--shadow);
+}
+
+.control-strip-fields {
+    display: grid;
+    grid-template-columns: minmax(160px, 220px) minmax(220px, 360px) minmax(260px, 420px);
+    gap: 14px;
+    align-items: end;
+    min-width: 0;
+}
+
+.control-strip-tabs {
+    min-width: 0;
+}
+
+.control-strip-tabs .section-tabs {
+    justify-content: flex-end;
 }
 
 .control-strip label,
@@ -359,6 +375,39 @@ dd {
     background: linear-gradient(135deg, rgba(14, 165, 233, 0.34), rgba(124, 58, 237, 0.24));
     color: #f8fbff;
     box-shadow: 0 0 18px rgba(56, 189, 248, 0.18);
+}
+
+@media (max-width: 1280px) {
+    .control-strip {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+    }
+
+    .control-strip-fields {
+        grid-template-columns: minmax(180px, 240px) minmax(220px, 1fr);
+    }
+
+    .control-strip-fields .archive-search {
+        grid-column: 1 / -1;
+    }
+
+    .control-strip-tabs {
+        order: -1;
+    }
+
+    .control-strip-tabs .section-tabs {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 900px) {
+    .control-strip-fields {
+        grid-template-columns: 1fr;
+    }
+
+    .control-strip-fields .archive-search {
+        grid-column: auto;
+    }
 }
 
 .loading-modal-backdrop {
@@ -4375,7 +4424,6 @@ dd {
 @media (max-width: 1100px) {
     .explorer-hero,
     .about-grid,
-    .control-strip,
     .overview-layout,
     .timeline-layout,
     .hyperlane-layout,

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -323,7 +323,6 @@ dd {
 }
 
 .control-strip-tabs {
-    order: -1;
     min-width: 0;
 }
 
@@ -385,7 +384,13 @@ dd {
     }
 
     .control-strip-tabs {
-        order: 0;
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .control-strip-fields {
+        grid-column: 1;
+        grid-row: 1;
     }
 
     .control-strip-tabs .section-tabs {

--- a/StarWin.Web/wwwroot/app.css
+++ b/StarWin.Web/wwwroot/app.css
@@ -1398,6 +1398,108 @@ dd {
     padding: 6px 10px;
 }
 
+.record-filter-tristate-toggle {
+    --toggle-index: 1;
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: center;
+    width: min(100%, 16rem);
+    padding: 4px;
+    border-radius: 999px;
+    overflow: hidden;
+    background:
+        linear-gradient(180deg, rgba(7, 17, 33, 0.96), rgba(8, 26, 49, 0.98) 58%, rgba(7, 17, 32, 0.96)),
+        radial-gradient(circle at 50% 50%, rgba(56, 189, 248, 0.1), transparent 60%);
+    border: 1px solid rgba(41, 183, 255, 0.34);
+    box-shadow:
+        inset 0 2px 10px rgba(2, 6, 23, 0.55),
+        inset 0 0 18px rgba(14, 165, 233, 0.12),
+        0 0 0 1px rgba(5, 21, 43, 0.45);
+}
+
+.record-filter-tristate-toggle::before {
+    content: "";
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    top: 50%;
+    height: 1px;
+    transform: translateY(-50%);
+    background: linear-gradient(
+        90deg,
+        rgba(56, 189, 248, 0.14) 0%,
+        rgba(148, 163, 184, 0.18) 50%,
+        rgba(248, 113, 113, 0.14) 100%);
+    pointer-events: none;
+}
+
+.record-filter-tristate-toggle-thumb {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: calc((100% - 8px) / 3);
+    bottom: 4px;
+    border-radius: 999px;
+    transform: translateX(calc(var(--toggle-index) * 100%));
+    background: linear-gradient(180deg, rgba(71, 178, 255, 0.88), rgba(17, 108, 203, 0.9));
+    box-shadow:
+        0 0 18px rgba(56, 189, 248, 0.22),
+        inset 0 1px 0 rgba(255, 255, 255, 0.26);
+    transition: transform 180ms ease, background 180ms ease, box-shadow 180ms ease;
+    pointer-events: none;
+}
+
+.record-filter-tristate-toggle.state-both .record-filter-tristate-toggle-thumb {
+    background: linear-gradient(180deg, rgba(250, 204, 21, 0.9), rgba(217, 119, 6, 0.9));
+    box-shadow:
+        0 0 18px rgba(250, 204, 21, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.record-filter-tristate-toggle.state-fallen .record-filter-tristate-toggle-thumb {
+    background: linear-gradient(180deg, rgba(248, 113, 113, 0.9), rgba(185, 28, 28, 0.9));
+    box-shadow:
+        0 0 18px rgba(248, 113, 113, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.record-filter-tristate-toggle-option {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.25rem;
+    padding: 0 0.55rem;
+    border-radius: 999px;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(191, 219, 254, 0.78);
+    cursor: pointer;
+    user-select: none;
+    transition: color 180ms ease, text-shadow 180ms ease;
+}
+
+.record-filter-tristate-toggle-option input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.record-filter-tristate-toggle-option.active {
+    color: #f8fafc;
+    text-shadow: 0 0 10px rgba(255, 255, 255, 0.18);
+}
+
+.record-filter-tristate-toggle-option:focus-within {
+    outline: 2px solid rgba(125, 211, 252, 0.55);
+    outline-offset: 2px;
+}
+
 .record-filter-range-inputs {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/StarWin.Web/wwwroot/js/sectorMap3d.js
+++ b/StarWin.Web/wwwroot/js/sectorMap3d.js
@@ -1039,31 +1039,22 @@ function panCameraTarget(state, horizontalDelta, verticalDelta) {
         return;
     }
 
-    const forward = new state.THREE.Vector3().subVectors(state.target, state.camera.position).normalize();
-    const right = new state.THREE.Vector3().crossVectors(forward, state.camera.up).normalize();
-    const up = new state.THREE.Vector3().crossVectors(right, forward).normalize();
+    const { right, up } = getCameraAxes(state);
 
     state.target.addScaledVector(right, horizontalDelta);
     state.target.addScaledVector(up, verticalDelta);
 }
 
 function updateCamera(state) {
-    const offset = state.baseCameraOffset.clone().setLength(state.radius).applyQuaternion(state.orbitRotation);
-    const up = new state.THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
+    const { offset, up } = getCameraAxes(state);
     state.camera.position.copy(state.target).add(offset);
     state.camera.up.copy(up);
     state.camera.lookAt(state.target);
-    if (state.roll) {
-        state.camera.rotateZ(state.roll);
-    }
 }
 
 function rotateCameraOffset(state, yawDelta, pitchDelta) {
     const THREE = state.THREE;
-    const offset = state.baseCameraOffset.clone().applyQuaternion(state.orbitRotation).normalize();
-    const cameraUp = new THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
-    const forward = offset.clone().multiplyScalar(-1).normalize();
-    const right = new THREE.Vector3().crossVectors(forward, cameraUp).normalize();
+    const { up: cameraUp, right } = getCameraAxes(state);
 
     if (Math.abs(yawDelta) > 0) {
         state.orbitRotation.premultiply(new THREE.Quaternion().setFromAxisAngle(cameraUp, yawDelta));
@@ -1072,6 +1063,21 @@ function rotateCameraOffset(state, yawDelta, pitchDelta) {
     if (Math.abs(pitchDelta) > 0) {
         state.orbitRotation.premultiply(new THREE.Quaternion().setFromAxisAngle(right, pitchDelta));
     }
+}
+
+function getCameraAxes(state) {
+    const THREE = state.THREE;
+    const offset = state.baseCameraOffset.clone().setLength(state.radius).applyQuaternion(state.orbitRotation);
+    const forward = offset.clone().normalize().multiplyScalar(-1);
+    let up = new THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
+
+    if (state.roll) {
+        up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));
+    }
+
+    const right = new THREE.Vector3().crossVectors(forward, up).normalize();
+    up = new THREE.Vector3().crossVectors(right, forward).normalize();
+    return { offset, forward, up, right };
 }
 
 function resize(state) {

--- a/StarWin.Web/wwwroot/js/sectorMap3d.js
+++ b/StarWin.Web/wwwroot/js/sectorMap3d.js
@@ -8,6 +8,9 @@ const slowFrameRatio = 0.32;
 const minimumAdaptiveSystemLimit = 150;
 const compactSystemScale = 0.38;
 const systemCoordinateScale = 8;
+const minimumCameraRadius = 26;
+const maximumCameraRadius = 220;
+const keyboardFrameMilliseconds = 1000 / 60;
 
 async function loadThree() {
     if (!threePromise) {
@@ -131,7 +134,9 @@ function createMap(host, THREE) {
         orbitRotation: new THREE.Quaternion(),
         radius: 116,
         roll: 0,
-        drag: null
+        drag: null,
+        activeKeys: new Set(),
+        lastAnimationTimestamp: 0
     };
 
     canvas.addEventListener("pointerdown", event => {
@@ -154,6 +159,8 @@ function createMap(host, THREE) {
     canvas.addEventListener("pointerup", event => handlePointerUp(state, event));
     canvas.addEventListener("wheel", event => handleWheel(state, event), { passive: false });
     canvas.addEventListener("keydown", event => handleKeyDown(state, event));
+    canvas.addEventListener("keyup", event => handleKeyUp(state, event));
+    canvas.addEventListener("blur", () => clearActiveKeys(state));
     canvas.addEventListener("contextmenu", event => event.preventDefault());
     updateCamera(state);
     animate(state);
@@ -911,7 +918,7 @@ function disposeLabelSprite(label) {
 function handleWheel(state, event) {
     event.preventDefault();
     const direction = event.deltaY > 0 ? 1 : -1;
-    state.radius = Math.max(26, Math.min(220, state.radius * (1 + direction * 0.12)));
+    state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius * (1 + direction * 0.12)));
     updateCamera(state);
 }
 
@@ -920,40 +927,124 @@ function handleKeyDown(state, event) {
         return;
     }
 
-    const key = event.key.toLowerCase();
-    const rotationStep = event.shiftKey ? 0.16 : 0.08;
-    let handled = true;
-
-    switch (key) {
-        case "a":
-            rotateCameraOffset(state, -rotationStep, 0);
-            break;
-        case "d":
-            rotateCameraOffset(state, rotationStep, 0);
-            break;
-        case "w":
-            rotateCameraOffset(state, 0, -rotationStep);
-            break;
-        case "s":
-            rotateCameraOffset(state, 0, rotationStep);
-            break;
-        case "q":
-            state.roll += rotationStep;
-            break;
-        case "e":
-            state.roll -= rotationStep;
-            break;
-        default:
-            handled = false;
-            break;
-    }
-
-    if (!handled) {
+    const key = normalizeKeyboardNavigationKey(event.key);
+    if (!isKeyboardNavigationKey(key)) {
         return;
     }
 
+    state.activeKeys.add(key);
     event.preventDefault();
-    updateCamera(state);
+}
+
+function handleKeyUp(state, event) {
+    const key = normalizeKeyboardNavigationKey(event.key);
+    if (!isKeyboardNavigationKey(key)) {
+        return;
+    }
+
+    state.activeKeys.delete(key);
+    event.preventDefault();
+}
+
+function clearActiveKeys(state) {
+    state.activeKeys.clear();
+}
+
+function normalizeKeyboardNavigationKey(key) {
+    const normalizedKey = key.toLowerCase();
+    switch (normalizedKey) {
+        case "=":
+        case "+":
+        case "add":
+            return "+";
+        case "_":
+        case "-":
+        case "subtract":
+            return "-";
+        default:
+            return normalizedKey;
+    }
+}
+
+function isKeyboardNavigationKey(key) {
+    return [
+        "a",
+        "d",
+        "w",
+        "s",
+        "q",
+        "e",
+        "+",
+        "-",
+        "arrowup",
+        "arrowdown",
+        "arrowleft",
+        "arrowright",
+        "shift"
+    ].includes(key);
+}
+
+function applyKeyboardNavigation(state, frameScale) {
+    if (!state.activeKeys.size) {
+        return false;
+    }
+
+    const speedMultiplier = state.activeKeys.has("shift") ? 2 : 1;
+    const rotationStep = 0.032 * speedMultiplier * frameScale;
+    const panStep = state.radius * 0.012 * speedMultiplier * frameScale;
+    const zoomStep = state.radius * 0.022 * speedMultiplier * frameScale;
+    const yawDirection = getAxisDirection(state.activeKeys, ["a"], ["d"]);
+    const pitchDirection = getAxisDirection(state.activeKeys, ["w"], ["s"]);
+    const rollDirection = getAxisDirection(state.activeKeys, ["e"], ["q"]);
+    const zoomDirection = getAxisDirection(state.activeKeys, ["-"], ["+"]);
+    const panHorizontalDirection = getAxisDirection(state.activeKeys, ["arrowleft"], ["arrowright"]);
+    const panVerticalDirection = getAxisDirection(state.activeKeys, ["arrowdown"], ["arrowup"]);
+
+    if (yawDirection === 0
+        && pitchDirection === 0
+        && rollDirection === 0
+        && zoomDirection === 0
+        && panHorizontalDirection === 0
+        && panVerticalDirection === 0) {
+        return false;
+    }
+
+    rotateCameraOffset(state, yawDirection * rotationStep, pitchDirection * rotationStep);
+    state.roll += rollDirection * rotationStep;
+    adjustCameraRadius(state, -zoomDirection * zoomStep);
+    panCameraTarget(state, panHorizontalDirection * panStep, panVerticalDirection * panStep);
+    return true;
+}
+
+function getAxisDirection(activeKeys, negativeKeys, positiveKeys) {
+    const negativeActive = negativeKeys.some(key => activeKeys.has(key));
+    const positiveActive = positiveKeys.some(key => activeKeys.has(key));
+    if (negativeActive === positiveActive) {
+        return 0;
+    }
+
+    return positiveActive ? 1 : -1;
+}
+
+function adjustCameraRadius(state, radiusDelta) {
+    if (radiusDelta === 0) {
+        return;
+    }
+
+    state.radius = Math.max(minimumCameraRadius, Math.min(maximumCameraRadius, state.radius + radiusDelta));
+}
+
+function panCameraTarget(state, horizontalDelta, verticalDelta) {
+    if (horizontalDelta === 0 && verticalDelta === 0) {
+        return;
+    }
+
+    const forward = new state.THREE.Vector3().subVectors(state.target, state.camera.position).normalize();
+    const right = new state.THREE.Vector3().crossVectors(forward, state.camera.up).normalize();
+    const up = new state.THREE.Vector3().crossVectors(right, forward).normalize();
+
+    state.target.addScaledVector(right, horizontalDelta);
+    state.target.addScaledVector(up, verticalDelta);
 }
 
 function updateCamera(state) {
@@ -997,6 +1088,15 @@ function resize(state) {
 
 function animate(state, timestamp = performance.now()) {
     state.animationFrame = requestAnimationFrame(nextTimestamp => animate(state, nextTimestamp));
+    const frameScale = state.lastAnimationTimestamp === 0
+        ? 1
+        : Math.min(2, Math.max(0.5, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds));
+    state.lastAnimationTimestamp = timestamp;
+
+    if (applyKeyboardNavigation(state, frameScale)) {
+        updateCamera(state);
+    }
+
     trackMapPerformance(state, timestamp);
     faceImageMarkers(state);
     state.renderer.render(state.scene, state.camera);

--- a/StarWin.Web/wwwroot/js/sectorMap3d.js
+++ b/StarWin.Web/wwwroot/js/sectorMap3d.js
@@ -1072,7 +1072,7 @@ function getCameraAxes(state) {
     let up = new THREE.Vector3(0, 1, 0).applyQuaternion(state.orbitRotation).normalize();
 
     if (state.roll) {
-        up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(forward, state.roll));
+        up.applyQuaternion(new THREE.Quaternion().setFromAxisAngle(offset.clone().normalize(), state.roll));
     }
 
     const right = new THREE.Vector3().crossVectors(forward, up).normalize();
@@ -1096,7 +1096,7 @@ function animate(state, timestamp = performance.now()) {
     state.animationFrame = requestAnimationFrame(nextTimestamp => animate(state, nextTimestamp));
     const frameScale = state.lastAnimationTimestamp === 0
         ? 1
-        : Math.min(2, Math.max(0.5, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds));
+        : Math.min(2, Math.max(0, (timestamp - state.lastAnimationTimestamp) / keyboardFrameMilliseconds));
     state.lastAnimationTimestamp = timestamp;
 
     if (applyKeyboardNavigation(state, frameScale)) {

--- a/StarforgedAtlas.PortableLauncher/StarforgedAtlas.PortableLauncher.csproj
+++ b/StarforgedAtlas.PortableLauncher/StarforgedAtlas.PortableLauncher.csproj
@@ -10,6 +10,11 @@
     <AssemblyTitle>Starforged Atlas Portable Launcher</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>..\StarWin.Desktop\Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
+    <AssemblyVersion>2026.7.7.0</AssemblyVersion>
+    <FileVersion>2026.7.7.0</FileVersion>
+    <Version>2026.7.7.0</Version>
+    <InformationalVersion>2026-07-07.0-developer-preview</InformationalVersion>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>

--- a/StarforgedAtlas.PortableLauncher/StarforgedAtlas.PortableLauncher.csproj
+++ b/StarforgedAtlas.PortableLauncher/StarforgedAtlas.PortableLauncher.csproj
@@ -10,11 +10,6 @@
     <AssemblyTitle>Starforged Atlas Portable Launcher</AssemblyTitle>
     <Product>Starforged Atlas</Product>
     <ApplicationIcon>..\StarWin.Desktop\Assets\StarforgedAtlasLogo.ico</ApplicationIcon>
-    <AssemblyVersion>2026.4.30.0</AssemblyVersion>
-    <FileVersion>2026.4.30.0</FileVersion>
-    <Version>2026.4.30.0</Version>
-    <InformationalVersion>2026-04-30.0-developer-preview</InformationalVersion>
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <UseWindowsForms>true</UseWindowsForms>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
## Release
- 2026-07-07.0 Developer Preview

## Summary
- promote the current `dev` branch to `master`
- include the desktop and portable launcher version stamp `2026-07-07.0-developer-preview`
- ship the Empires search, filtering, and cached stats work from issue `#67`
- include the Explorer tab-order and responsive control-strip updates from issues `#70` and `#71`
- include the null-validation regression tests from issues `#113` and `#115`
- include the 3D sector map keyboard rotation and zoom improvements from issue `#75`

## Issues included
- #67
- #70
- #71
- #75
- #113
- #115

## Verification
- `dotnet test "Slipstream Map.sln" -nologo -m:1`
