### PR TITLE
Add GurpsTechnologyLevelMapper parse test

### DIFF
--- a/StarWin.Domain.Tests/Services/GurpsTechnologyLevelMapperTests.cs
+++ b/StarWin.Domain.Tests/Services/GurpsTechnologyLevelMapperTests.cs
@@ -1,0 +1,16 @@
+using StarWin.Domain.Services;
+
+namespace StarWin.Domain.Tests.Services;
+
+public sealed class GurpsTechnologyLevelMapperTests
+{
+    [Fact]
+    public void TryParseDisplay_WithSuperscienceValueAndWhitespace_ReturnsExpected()
+    {
+        var result = GurpsTechnologyLevelMapper.TryParseDisplay(" 14^ ", out var baseTechLevel, out var isSuperscience);
+
+        Assert.True(result);
+        Assert.Equal(14, baseTechLevel);
+        Assert.True(isSuperscience);
+    }
+}


### PR DESCRIPTION
## Coverage gap
`GurpsTechnologyLevelMapper.TryParseDisplay` had no dedicated coverage for superscience parsing and whitespace handling.

## Behavior validated
- Added one focused test that verifies trimmed superscience text values parse successfully.
- Validates returned base technology level and superscience flag.

## Test command
- `dotnet test StarWin.Domain.Tests/StarWin.Domain.Tests.csproj --filter FullyQualifiedName~GurpsTechnologyLevelMapperTests`

## Issue link
Refs #119